### PR TITLE
Fix a memory leak in nxt_epoll_create()

### DIFF
--- a/src/nxt_epoll_engine.c
+++ b/src/nxt_epoll_engine.c
@@ -351,6 +351,7 @@ nxt_epoll_free(nxt_event_engine_t *engine)
     }
 
     nxt_free(engine->u.epoll.events);
+    nxt_free(engine->u.epoll.changes);
 
     nxt_memzero(&engine->u.epoll, sizeof(nxt_epoll_engine_t));
 }


### PR DESCRIPTION
engine->u.epoll.changes is allocated in nxt_epoll_create() and has to be freed.

Signed-off-by: Andrei Vagin <avagin@virtuozzo.com>