### PR TITLE
Define include paths of CFLAGS for cgo

### DIFF
--- a/src/go/unit/unit.go
+++ b/src/go/unit/unit.go
@@ -6,6 +6,7 @@
 package unit
 
 /*
+#cgo CFLAGS: -I./../../ -I./../../../build
 #include "nxt_go_lib.h"
 */
 import "C"


### PR DESCRIPTION
This change enables to...

* `go get` and import from "github.com/nginx/unit/src/go/unit" without setting another GOPATH.
* build specific version of `nginx/unit` with a package management tool.

```go
package main

import (
	"fmt"
	"net/http"

	"github.com/nginx/unit/src/go/unit" // replace from "unit"
)

func main() {
	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
		fmt.Fprintf(w, "Hello, Go")
	})
	unit.ListenAndServe(":8080", nil)
}
```