### PR TITLE
Output the correct Ruby version when configuring ruby

### DIFF
--- a/auto/modules/ruby
+++ b/auto/modules/ruby
@@ -91,7 +91,7 @@ if [ $nxt_found = no ]; then
     exit 1;
 fi
 
-NXT_RUBY_VERSION=`$NXT_RUBY -r rbconfig -e 'printf("%s",RbConfig::CONFIG["ruby_version"])'`
+NXT_RUBY_VERSION=`$NXT_RUBY -r rbconfig -e 'printf("%s",RbConfig::CONFIG["RUBY_PROGRAM_VERSION"])'`
 $echo " + Ruby version: ${NXT_RUBY_VERSION}"
 
 if grep ^$NXT_RUBY_MODULE: $NXT_MAKEFILE 2>&1 > /dev/null; then


### PR DESCRIPTION
Previously if one configured 2.3.5 config would output 2.3.0.
This is because the ruby_version key does not account for the patch number.

---

Note that this whole line can be simplified to `ruby -e'print RUBY_VERSION'`. 