### PR TITLE
Change log level to debug for socket shutdown issue #109

### DIFF
--- a/src/nxt_socket.c
+++ b/src/nxt_socket.c
@@ -281,7 +281,7 @@ nxt_socket_shutdown(nxt_task_t *task, nxt_socket_t s, nxt_uint_t how)
     switch (err) {
 
     case NXT_ENOTCONN:
-        level = NXT_LOG_INFO;
+        level = NXT_LOG_DEBUG;
         break;
 
     case NXT_ECONNRESET:


### PR DESCRIPTION
Log level set to debug when shutting down a socket that has already been closed by client connexion end.