### PR TITLE
switch to __BYTE_ORDER__ (and other underscored endianness macros)

### DIFF
--- a/src/nxt_websocket_header.h
+++ b/src/nxt_websocket_header.h
@@ -8,9 +8,8 @@
 
 #include <netinet/in.h>
 
-
 typedef struct {
-#if (BYTE_ORDER == BIG_ENDIAN)
+#if (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
     uint8_t fin:1;
     uint8_t rsv1:1;
     uint8_t rsv2:1;
@@ -21,7 +20,7 @@ typedef struct {
     uint8_t payload_len:7;
 #endif
 
-#if (BYTE_ORDER == LITTLE_ENDIAN)
+#if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
     uint8_t opcode:4;
     uint8_t rsv3:1;
     uint8_t rsv2:1;


### PR DESCRIPTION
The macros `BYTE_ORDER`, `BIG_ENDIAN` and `LITTLE_ENDIAN` are not defined on Solaris.

This patch change them to `__BYTE_ORDER__`, `__ORDER_BIG_ENDIAN__` and `__ORDER_LITTLE_ENDIAN__`. 

These flags are defined on:

  - Linux
  - OSX
  - Solaris
  - FreeBSD

Closes #297 

Signed-off-by: Tiago Natel de Moura <tiago.moura@nginx.com>