### PR TITLE
OpenSolaris: Fix sendfile detection and use O_NONBLOCK instead of FIONBIO

### DIFF
--- a/auto/sendfile
+++ b/auto/sendfile
@@ -10,29 +10,28 @@ NXT_HAVE_SOLARIS_SENDFILEV=NO
 NXT_HAVE_AIX_SEND_FILE=NO
 NXT_HAVE_HPUX_SENDFILE=NO
 
+# Solaris 8 sendfilev().
 
-# Linux sendfile().
+NXT_LIBSENDFILE=
 
-nxt_feature="Linux sendfile()"
-nxt_feature_name=NXT_HAVE_LINUX_SENDFILE
+nxt_feature="Solaris sendfilev()"
+nxt_feature_name=NXT_HAVE_SOLARIS_SENDFILEV
+nxt_feature_libs="-lsendfile"
 nxt_feature_test="#include <sys/sendfile.h>
-                  #include <sys/types.h>
-                  #include <sys/socket.h>
 
-                  int main() {
-                      off_t  offset;
+                    int main() {
+                        size_t              sent;
+                        struct sendfilevec  vec;
 
-                      sendfile(-1, -1, &offset, 0);
-                      send(-1, NULL, 0, MSG_MORE);
-
-                      return 0;
-                  }"
+                        sendfilev(-1, &vec, 0, &sent);
+                        return 0;
+                    }"
 . auto/feature
 
 if [ $nxt_found = yes ]; then
-    NXT_HAVE_LINUX_SENDFILE=YES
+    NXT_HAVE_SOLARIS_SENDFILEV=YES
+    NXT_LIBSENDFILE=$nxt_feature_libs
 fi
-
 
 if [ $nxt_found = no ]; then
     # FreeBSD sendfile().
@@ -59,34 +58,6 @@ if [ $nxt_found = no ]; then
         NXT_HAVE_FREEBSD_SENDFILE=YES
     fi
 fi
-
-
-NXT_LIBSENDFILE=
-
-if [ $nxt_found = no ]; then
-
-    # Solaris 8 sendfilev().
-
-    nxt_feature="Solaris sendfilev()"
-    nxt_feature_name=NXT_HAVE_SOLARIS_SENDFILEV
-    nxt_feature_libs="-lsendfile"
-    nxt_feature_test="#include <sys/sendfile.h>
-
-                      int main() {
-                          size_t              sent;
-                          struct sendfilevec  vec;
-
-                          sendfilev(-1, &vec, 0, &sent);
-                          return 0;
-                      }"
-    . auto/feature
-
-    if [ $nxt_found = yes ]; then
-        NXT_HAVE_SOLARIS_SENDFILEV=YES
-        NXT_LIBSENDFILE=$nxt_feature_libs
-    fi
-fi
-
 
 if [ $nxt_found = no ]; then
 
@@ -160,3 +131,24 @@ if [ $nxt_found = no ]; then
         NXT_HAVE_HPUX_SENDFILE=YES
     fi
 fi
+
+# Linux sendfile().
+
+if [ $nxt_found = no ]; then
+
+    nxt_feature="Linux sendfile()"
+    nxt_feature_name=NXT_HAVE_LINUX_SENDFILE
+    nxt_feature_test="#include <sys/sendfile.h>
+
+                    int main() {
+                        off_t  offset;
+
+                        sendfile(-1, -1, &offset, 0);
+                        return 0;
+                    }"
+    . auto/feature
+
+    if [ $nxt_found = yes ]; then
+        NXT_HAVE_LINUX_SENDFILE=YES
+    fi
+fi 

--- a/auto/sendfile
+++ b/auto/sendfile
@@ -132,9 +132,9 @@ if [ $nxt_found = no ]; then
     fi
 fi
 
-# Linux sendfile().
-
 if [ $nxt_found = no ]; then
+
+    # Linux sendfile().
 
     nxt_feature="Linux sendfile()"
     nxt_feature_name=NXT_HAVE_LINUX_SENDFILE

--- a/auto/sendfile
+++ b/auto/sendfile
@@ -16,11 +16,15 @@ NXT_HAVE_HPUX_SENDFILE=NO
 nxt_feature="Linux sendfile()"
 nxt_feature_name=NXT_HAVE_LINUX_SENDFILE
 nxt_feature_test="#include <sys/sendfile.h>
+                  #include <sys/types.h>
+                  #include <sys/socket.h>
 
                   int main() {
                       off_t  offset;
 
                       sendfile(-1, -1, &offset, 0);
+                      send(-1, NULL, 0, MSG_MORE);
+
                       return 0;
                   }"
 . auto/feature

--- a/auto/sendfile
+++ b/auto/sendfile
@@ -10,6 +10,7 @@ NXT_HAVE_SOLARIS_SENDFILEV=NO
 NXT_HAVE_AIX_SEND_FILE=NO
 NXT_HAVE_HPUX_SENDFILE=NO
 
+
 # Solaris 8 sendfilev().
 
 NXT_LIBSENDFILE=
@@ -19,13 +20,13 @@ nxt_feature_name=NXT_HAVE_SOLARIS_SENDFILEV
 nxt_feature_libs="-lsendfile"
 nxt_feature_test="#include <sys/sendfile.h>
 
-                    int main() {
-                        size_t              sent;
-                        struct sendfilevec  vec;
+                  int main() {
+                      size_t              sent;
+                      struct sendfilevec  vec;
 
-                        sendfilev(-1, &vec, 0, &sent);
-                        return 0;
-                    }"
+                      sendfilev(-1, &vec, 0, &sent);
+                      return 0;
+                  }"
 . auto/feature
 
 if [ $nxt_found = yes ]; then
@@ -33,7 +34,9 @@ if [ $nxt_found = yes ]; then
     NXT_LIBSENDFILE=$nxt_feature_libs
 fi
 
+
 if [ $nxt_found = no ]; then
+
     # FreeBSD sendfile().
 
     nxt_feature="FreeBSD sendfile()"
@@ -58,6 +61,7 @@ if [ $nxt_found = no ]; then
         NXT_HAVE_FREEBSD_SENDFILE=YES
     fi
 fi
+
 
 if [ $nxt_found = no ]; then
 
@@ -132,6 +136,7 @@ if [ $nxt_found = no ]; then
     fi
 fi
 
+
 if [ $nxt_found = no ]; then
 
     # Linux sendfile().
@@ -140,12 +145,12 @@ if [ $nxt_found = no ]; then
     nxt_feature_name=NXT_HAVE_LINUX_SENDFILE
     nxt_feature_test="#include <sys/sendfile.h>
 
-                    int main() {
-                        off_t  offset;
+                      int main() {
+                          off_t  offset;
 
-                        sendfile(-1, -1, &offset, 0);
-                        return 0;
-                    }"
+                          sendfile(-1, -1, &offset, 0);
+                          return 0;
+                      }"
     . auto/feature
 
     if [ $nxt_found = yes ]; then

--- a/src/nxt_file.c
+++ b/src/nxt_file.c
@@ -310,6 +310,10 @@ nxt_file_rename(nxt_file_name_t *old_name, nxt_file_name_t *new_name)
  *
  * Linux 2.4 uses BKL for ioctl() and fcntl(F_SETFL).
  * Linux 2.6 does not use BKL.
+ * 
+ * On Solaris, the FIONBIO ioctl command is not allowed on a signalfd
+ * file descriptor. Ref.: 
+ * https://github.com/illumos/illumos-gate/blob/master/usr/src/uts/common/io/signalfd.c#L623
  */
 
 #if (NXT_HAVE_FIONBIO) && !(NXT_SOLARIS)

--- a/src/nxt_file.c
+++ b/src/nxt_file.c
@@ -312,7 +312,7 @@ nxt_file_rename(nxt_file_name_t *old_name, nxt_file_name_t *new_name)
  * Linux 2.6 does not use BKL.
  */
 
-#if defined(NXT_HAVE_FIONBIO) && !defined(NXT_SOLARIS)
+#if (NXT_HAVE_FIONBIO) && !(NXT_SOLARIS)
 
 nxt_int_t
 nxt_fd_nonblocking(nxt_task_t *task, nxt_fd_t fd)

--- a/src/nxt_file.c
+++ b/src/nxt_file.c
@@ -312,7 +312,7 @@ nxt_file_rename(nxt_file_name_t *old_name, nxt_file_name_t *new_name)
  * Linux 2.6 does not use BKL.
  */
 
-#if (NXT_HAVE_FIONBIO)
+#if defined(NXT_HAVE_FIONBIO) && !defined(NXT_SOLARIS)
 
 nxt_int_t
 nxt_fd_nonblocking(nxt_task_t *task, nxt_fd_t fd)


### PR DESCRIPTION
The configure script was defining `NXT_HAVE_LINUX_SENDFILE` for solaris, but the linux sendfile implementation uses the linux-only `MSG_MORE` flag (on send(2)) instead of `TCP_CORK` sockopt. I didn't test on Solaris 11 but on OpenSolaris.

Second bug is that unit was getting an error when setting the signals file descriptor to nonblocking. The error was: `Inappropriate ioctl for device`
I arranged the ifdefs to use fnctl and O_NONBLOCK on solaris. 

I don't know about the performance impact of second change but maybe it's good to make it compile and run for now. I'm willing to do some tests with Solaris Zones soon.

This change depends on #298 