### PR TITLE
WIP: Add details to process startup errors

### DIFF
--- a/src/nxt_controller.c
+++ b/src/nxt_controller.c
@@ -1501,7 +1501,12 @@ nxt_controller_conf_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg,
 
         resp.status = 500;
         resp.title = (u_char *) "Failed to apply new configuration.";
-        resp.offset = -1;
+
+        if (msg->buf != NULL && nxt_buf_mem_used_size(&msg->buf->mem) > 0) {
+            resp.detail.start = (u_char *) msg->buf->mem.pos;
+            resp.detail.length = nxt_buf_mem_used_size(&msg->buf->mem) - 1;
+            resp.offset = -1;
+        }
     }
 
     nxt_controller_response(task, req, &resp);

--- a/src/nxt_main_process.c
+++ b/src/nxt_main_process.c
@@ -364,6 +364,7 @@ failed:
 static nxt_port_handlers_t  nxt_main_process_port_handlers = {
     .data           = nxt_port_main_data_handler,
     .process_ready  = nxt_port_process_ready_handler,
+    .process_error  = nxt_port_process_error_handler,
     .start_worker   = nxt_port_main_start_worker_handler,
     .socket         = nxt_main_port_socket_handler,
     .modules        = nxt_main_port_modules_handler,

--- a/src/nxt_port.c
+++ b/src/nxt_port.c
@@ -363,6 +363,7 @@ nxt_port_process_error_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
     }
 
     nxt_process_close_ports(task, process);
+    nxt_process_use(task, process, -1);
 
     /* disables completion */
     msg->buf = NULL;

--- a/src/nxt_port.h
+++ b/src/nxt_port.h
@@ -29,6 +29,7 @@ struct nxt_port_handlers_s {
 
     /* New process ready. */
     nxt_port_handler_t  process_ready;
+    nxt_port_handler_t  process_error;
 
     /* Process exit/crash notification. */
     nxt_port_handler_t  remove_pid;
@@ -74,6 +75,7 @@ typedef enum {
     _NXT_PORT_MSG_MMAP          = nxt_port_handler_idx(mmap),
 
     _NXT_PORT_MSG_PROCESS_READY = nxt_port_handler_idx(process_ready),
+    _NXT_PORT_MSG_PROCESS_ERROR = nxt_port_handler_idx(process_error),
     _NXT_PORT_MSG_REMOVE_PID    = nxt_port_handler_idx(remove_pid),
     _NXT_PORT_MSG_QUIT          = nxt_port_handler_idx(quit),
 
@@ -104,6 +106,8 @@ typedef enum {
                                   | NXT_PORT_MSG_CLOSE_FD | NXT_PORT_MSG_SYNC,
 
     NXT_PORT_MSG_PROCESS_READY  = _NXT_PORT_MSG_PROCESS_READY
+                                  | NXT_PORT_MSG_LAST,
+    NXT_PORT_MSG_PROCESS_ERROR  = _NXT_PORT_MSG_PROCESS_ERROR
                                   | NXT_PORT_MSG_LAST,
     NXT_PORT_MSG_QUIT           = _NXT_PORT_MSG_QUIT | NXT_PORT_MSG_LAST,
     NXT_PORT_MSG_REMOVE_PID     = _NXT_PORT_MSG_REMOVE_PID | NXT_PORT_MSG_LAST,
@@ -278,6 +282,7 @@ void nxt_port_change_log_file(nxt_task_t *task, nxt_runtime_t *rt,
 void nxt_port_quit_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg);
 void nxt_port_new_port_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg);
 void nxt_port_process_ready_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg);
+void nxt_port_process_error_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg);
 void nxt_port_change_log_file_handler(nxt_task_t *task,
     nxt_port_recv_msg_t *msg);
 void nxt_port_mmap_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg);

--- a/src/nxt_process.c
+++ b/src/nxt_process.c
@@ -151,8 +151,7 @@ nxt_process_start(nxt_task_t *task, nxt_process_t *process)
          */
         ret = nxt_user_cred_set(task, init->user_cred);
         if (ret != NXT_OK) {
-            err.start = (u_char *) "failed to change user credentials";
-            err.length = nxt_strlen(err.start);
+            nxt_str_set(&err, "failed to change user credentials");
             goto pre_start_error;
         }
     }

--- a/src/nxt_process.c
+++ b/src/nxt_process.c
@@ -152,7 +152,7 @@ nxt_process_start(nxt_task_t *task, nxt_process_t *process)
         ret = nxt_user_cred_set(task, init->user_cred);
         if (ret != NXT_OK) {
             err.start = (u_char *) "failed to change user credentials";
-            err.length = nxt_strlen(err.start)-1;
+            err.length = nxt_strlen(err.start);
             goto pre_start_error;
         }
     }
@@ -204,7 +204,6 @@ nxt_process_start(nxt_task_t *task, nxt_process_t *process)
     return;
 
 pre_start_error:
-
     buf = nxt_buf_mem_alloc(rt->mem_pool,
                             err.length+1, 0);
 
@@ -213,6 +212,7 @@ pre_start_error:
                                    err.length);
         *buf->mem.free++ = '\0';
     }
+
     ret = nxt_port_socket_write(task, main_port, NXT_PORT_MSG_PROCESS_ERROR,
                                 -1, init->stream, 0, buf);
 


### PR DESCRIPTION
This PR improves the error messages for errors happening after worker starts but before the READY message is sent.

I think this is a must in order to have meaningful error messages for features like `chroot` and `isolation`.

Example:

```
$ curl --unix-socket control.unit.sock -XPUT http://localhost/config/applications/py --data-binary @app-python.json
{
	"error": "Failed to apply new configuration.",
	"detail": "chdir(/app) failed (2: No such file or directory)"
}
```

_Work in progress_