### PR TITLE
Corrected path to sched.h

### DIFF
--- a/src/nxt_main_process.c
+++ b/src/nxt_main_process.c
@@ -15,7 +15,7 @@
 #endif
 
 #ifdef NXT_LINUX
-#include <linux/sched.h>
+#include <sched.h>
 #endif
 
 


### PR DESCRIPTION
In build time of nginx unit there was an error
```
src/nxt_main_process.c:18:10: fatal error: linux/sched.h: No such file or directory
18 | #include <linux/sched.h>
     |          ^~~~~~~~~~~~~~~
compilation terminated.
make: *** [build/Makefile:1001: build/src/nxt_main_process.o] Error 1
```
Checked other places where the sched.h file is included
Sample [src/nxt_unix.h](https://github.com/nginx/unit/blob/7c5a710c5543debff0c70cb4839e15e9a1da322b/src/nxt_unix.h#L157)
```
#include <sched.h>
```

After correction of the file *src/nxt_main_process.c* - compilation took place successfully
Environment: Alpine Linux Edge
Build details: https://gitlab.com/genhoi/docker-php-unit/-/jobs/299538907