### PR TITLE
Dockerfiles entrypoint support

### DIFF
--- a/pkg/docker/Dockerfile.full
+++ b/pkg/docker/Dockerfile.full
@@ -86,4 +86,8 @@ RUN ln -sf /dev/stdout /var/log/unit.log
 
 STOPSIGNAL SIGTERM
 
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN mkdir /docker-entrypoint.d/
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+
 CMD ["unitd", "--no-daemon", "--control", "unix:/var/run/control.unit.sock"]

--- a/pkg/docker/Dockerfile.go1.7-dev
+++ b/pkg/docker/Dockerfile.go1.7-dev
@@ -86,4 +86,8 @@ RUN ln -sf /dev/stdout /var/log/unit.log
 
 STOPSIGNAL SIGTERM
 
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN mkdir /docker-entrypoint.d/
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+
 CMD ["unitd", "--no-daemon", "--control", "unix:/var/run/control.unit.sock"]

--- a/pkg/docker/Dockerfile.go1.8-dev
+++ b/pkg/docker/Dockerfile.go1.8-dev
@@ -86,4 +86,8 @@ RUN ln -sf /dev/stdout /var/log/unit.log
 
 STOPSIGNAL SIGTERM
 
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN mkdir /docker-entrypoint.d/
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+
 CMD ["unitd", "--no-daemon", "--control", "unix:/var/run/control.unit.sock"]

--- a/pkg/docker/Dockerfile.minimal
+++ b/pkg/docker/Dockerfile.minimal
@@ -86,4 +86,8 @@ RUN ln -sf /dev/stdout /var/log/unit.log
 
 STOPSIGNAL SIGTERM
 
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN mkdir /docker-entrypoint.d/
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+
 CMD ["unitd", "--no-daemon", "--control", "unix:/var/run/control.unit.sock"]

--- a/pkg/docker/Dockerfile.perl5.24
+++ b/pkg/docker/Dockerfile.perl5.24
@@ -86,4 +86,8 @@ RUN ln -sf /dev/stdout /var/log/unit.log
 
 STOPSIGNAL SIGTERM
 
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN mkdir /docker-entrypoint.d/
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+
 CMD ["unitd", "--no-daemon", "--control", "unix:/var/run/control.unit.sock"]

--- a/pkg/docker/Dockerfile.php7.0
+++ b/pkg/docker/Dockerfile.php7.0
@@ -86,4 +86,8 @@ RUN ln -sf /dev/stdout /var/log/unit.log
 
 STOPSIGNAL SIGTERM
 
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN mkdir /docker-entrypoint.d/
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+
 CMD ["unitd", "--no-daemon", "--control", "unix:/var/run/control.unit.sock"]

--- a/pkg/docker/Dockerfile.python2.7
+++ b/pkg/docker/Dockerfile.python2.7
@@ -86,4 +86,8 @@ RUN ln -sf /dev/stdout /var/log/unit.log
 
 STOPSIGNAL SIGTERM
 
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN mkdir /docker-entrypoint.d/
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+
 CMD ["unitd", "--no-daemon", "--control", "unix:/var/run/control.unit.sock"]

--- a/pkg/docker/Dockerfile.python3.5
+++ b/pkg/docker/Dockerfile.python3.5
@@ -86,4 +86,8 @@ RUN ln -sf /dev/stdout /var/log/unit.log
 
 STOPSIGNAL SIGTERM
 
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN mkdir /docker-entrypoint.d/
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+
 CMD ["unitd", "--no-daemon", "--control", "unix:/var/run/control.unit.sock"]

--- a/pkg/docker/Dockerfile.ruby2.3
+++ b/pkg/docker/Dockerfile.ruby2.3
@@ -86,4 +86,8 @@ RUN ln -sf /dev/stdout /var/log/unit.log
 
 STOPSIGNAL SIGTERM
 
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN mkdir /docker-entrypoint.d/
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+
 CMD ["unitd", "--no-daemon", "--control", "unix:/var/run/control.unit.sock"]

--- a/pkg/docker/Dockerfile.tmpl
+++ b/pkg/docker/Dockerfile.tmpl
@@ -86,4 +86,8 @@ RUN ln -sf /dev/stdout /var/log/unit.log
 
 STOPSIGNAL SIGTERM
 
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN mkdir /docker-entrypoint.d/
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+
 CMD ["unitd", "--no-daemon", "--control", "unix:/var/run/control.unit.sock"]

--- a/pkg/docker/docker-entrypoint.sh
+++ b/pkg/docker/docker-entrypoint.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -e
+
+curl_put()
+{
+    RET=`/usr/bin/curl -s -w '%{http_code}' -X PUT --data-binary @$1 --unix-socket /var/run/control.unit.sock http://localhost/$2`
+    RET_BODY=${RET::-3}
+    RET_STATUS=$(echo $RET | /usr/bin/tail -c 4)
+    if [ "$RET_STATUS" -ne "200" ]; then
+        echo "$0: Error: HTTP response status code is '$RET_STATUS'"
+        echo "$RET_BODY"
+        return 1
+    else
+        echo "$0: OK: HTTP response status code is '$RET_STATUS'"
+        echo "$RET_BODY"
+    fi
+    return 0
+}
+
+if [ "$1" = "unitd" ]; then
+    if /usr/bin/find "/var/lib/unit/" -mindepth 1 -print -quit 2>/dev/null | /bin/grep -q .; then
+        echo "$0: /var/lib/unit/ is not empty, skipping initial configuration..."
+    else
+        if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -print -quit 2>/dev/null | /bin/grep -q .; then
+            echo "$0: /docker-entrypoint.d/ is not empty, launching Unit daemon to perform initial configuration..."
+            /usr/sbin/unitd --control unix:/var/run/control.unit.sock
+
+            while [ ! -S /var/run/control.unit.sock ]; do echo "$0: Waiting for control socket to be created..."; /bin/sleep 0.1; done
+            # even when the control socket exists, it does not mean unit has finished initialisation
+            # this curl call will get a reply once unit is fully launched
+            /usr/bin/curl -s -X GET --unix-socket /var/run/control.unit.sock http://localhost/
+
+            echo "$0: Looking for certificate bundles in /docker-entrypoint.d/..."
+            for f in $(/usr/bin/find /docker-entrypoint.d/ -type f -name "*.pem"); do
+                echo "$0: Uploading certificates bundle: $f"
+                curl_put $f "certificates/$(basename $f .pem)"
+            done
+
+            echo "$0: Looking for configuration snippets in /docker-entrypoint.d/..."
+            for f in $(/usr/bin/find /docker-entrypoint.d/ -type f -name "*.json"); do
+                echo "$0: Applying configuration $f";
+                curl_put $f "config"
+            done
+
+            echo "$0: Looking for shell scripts in /docker-entrypoint.d/..."
+            for f in $(/usr/bin/find /docker-entrypoint.d/ -type f -name "*.sh"); do
+                echo "$0: Launching $f";
+                "$f"
+            done
+
+            # warn on filetypes we don't know what to do with
+            for f in $(/usr/bin/find /docker-entrypoint.d/ -type f -not -name "*.sh" -not -name "*.json" -not -name "*.pem"); do
+                echo "$0: Ignoring $f";
+            done
+
+            echo "$0: Stopping Unit daemon after initial configuration..."
+            kill -TERM `/bin/cat /var/run/unit.pid`
+
+            while [ -S /var/run/control.unit.sock ]; do echo "$0: Waiting for control socket to be removed..."; /bin/sleep 0.1; done
+
+            echo
+            echo "$0: Unit initial configuration complete; ready for start up..."
+            echo
+        else
+            echo "$0: /docker-entrypoint.d/ is empty, skipping initial configuration..."
+        fi
+    fi
+fi
+
+exec "$@"


### PR DESCRIPTION
With this change, Docker images now accept shell scripts, json files and certificate chain bundles to provide configuration on a container start by placing them into /docker-entrypoint.d/ directory.