### PR TITLE
Debian init script fixes

### DIFF
--- a/pkg/deb/debian/unit.init
+++ b/pkg/deb/debian/unit.init
@@ -16,8 +16,6 @@ DAEMON=/usr/sbin/unitd
 NAME=unit
 DESC=unitd
 
-[ -r /etc/default/${NAME} ] && . /etc/default/${NAME}
-
 #includes lsb functions
 . /lib/lsb/init-functions
 

--- a/pkg/deb/debian/unit.init
+++ b/pkg/deb/debian/unit.init
@@ -13,7 +13,7 @@
 ### END INIT INFO
 PATH=/sbin:/bin:/usr/sbin:/usr/bin
 DAEMON=/usr/sbin/unitd
-NAME=unitd
+NAME=unit
 DESC=unitd
 
 [ -r /etc/default/${NAME} ] && . /etc/default/${NAME}


### PR DESCRIPTION
The first patch fixes the following issues:

     - inability to stop unit daemon
     - default configuration from /etc/default/unit are not propagated to the daemon

The second patch is purely cosmetical change since we include the defaults a few lines later as well.