### PR TITLE
Fix missing PID file during killing init configuration Unit daemon

### DIFF
--- a/pkg/docker/docker-entrypoint.sh
+++ b/pkg/docker/docker-entrypoint.sh
@@ -24,7 +24,7 @@ if [ "$1" = "unitd" ]; then
     else
         if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -print -quit 2>/dev/null | /bin/grep -q .; then
             echo "$0: /docker-entrypoint.d/ is not empty, launching Unit daemon to perform initial configuration..."
-            /usr/sbin/unitd --control unix:/var/run/control.unit.sock
+            /usr/sbin/unitd --pid /var/run/unit.pid --control unix:/var/run/control.unit.sock
 
             while [ ! -S /var/run/control.unit.sock ]; do echo "$0: Waiting for control socket to be created..."; /bin/sleep 0.1; done
             # even when the control socket exists, it does not mean unit has finished initialisation


### PR DESCRIPTION
In my opinion, it is advisable to explicitly state the path to the PID file, if this script ends it at the end with a defined absolute path (line 58).
It happened to me that Alpine created a PID file in another location and the script crashed during initialization.