### PR TITLE
fix:configure java module in alpine linux not working issue

### DIFF
--- a/auto/modules/java
+++ b/auto/modules/java
@@ -313,7 +313,7 @@ NXT_JAVA_LIBJVM="$NXT_JAVA_LIB_SERVER_PATH/libjvm.so"
 if [ "$NXT_SYSTEM" = "Darwin" ]; then
 NXT_JAVA_LIBC_DIR="/usr/lib"
 else
-NXT_JAVA_LIBC_DIR=`ldd "$NXT_JAVA_LIBJVM" | grep -E "libc.so|libc.musl-x86_64.so.1" | cut -d' ' -f3`
+NXT_JAVA_LIBC_DIR=`ldd "$NXT_JAVA_LIBJVM" | grep -E "libc.so|libc.musl-x86_64.so" | cut -d' ' -f3`
 NXT_JAVA_LIBC_DIR=`dirname $NXT_JAVA_LIBC_DIR`
 fi
 

--- a/auto/modules/java
+++ b/auto/modules/java
@@ -313,7 +313,7 @@ NXT_JAVA_LIBJVM="$NXT_JAVA_LIB_SERVER_PATH/libjvm.so"
 if [ "$NXT_SYSTEM" = "Darwin" ]; then
 NXT_JAVA_LIBC_DIR="/usr/lib"
 else
-NXT_JAVA_LIBC_DIR=`ldd "$NXT_JAVA_LIBJVM" | grep -E "libc.so|libc.musl-x86_64.so" | cut -d' ' -f3`
+NXT_JAVA_LIBC_DIR=`ldd "$NXT_JAVA_LIBJVM" | grep -F libc. | cut -d' ' -f3`
 NXT_JAVA_LIBC_DIR=`dirname $NXT_JAVA_LIBC_DIR`
 fi
 

--- a/auto/modules/java
+++ b/auto/modules/java
@@ -313,7 +313,7 @@ NXT_JAVA_LIBJVM="$NXT_JAVA_LIB_SERVER_PATH/libjvm.so"
 if [ "$NXT_SYSTEM" = "Darwin" ]; then
 NXT_JAVA_LIBC_DIR="/usr/lib"
 else
-NXT_JAVA_LIBC_DIR=`ldd "$NXT_JAVA_LIBJVM" | grep -E "libc.so | libc.musl-x86_64.so.1" | cut -d' ' -f3`
+NXT_JAVA_LIBC_DIR=`ldd "$NXT_JAVA_LIBJVM" | grep -E "libc.so|libc.musl-x86_64.so.1" | cut -d' ' -f3`
 NXT_JAVA_LIBC_DIR=`dirname $NXT_JAVA_LIBC_DIR`
 fi
 

--- a/auto/modules/java
+++ b/auto/modules/java
@@ -313,7 +313,7 @@ NXT_JAVA_LIBJVM="$NXT_JAVA_LIB_SERVER_PATH/libjvm.so"
 if [ "$NXT_SYSTEM" = "Darwin" ]; then
 NXT_JAVA_LIBC_DIR="/usr/lib"
 else
-NXT_JAVA_LIBC_DIR=`ldd "$NXT_JAVA_LIBJVM" | grep libc.so | cut -d' ' -f3`
+NXT_JAVA_LIBC_DIR=`ldd "$NXT_JAVA_LIBJVM" | grep -E "libc.so | libc.musl-x86_64.so.1" | cut -d' ' -f3`
 NXT_JAVA_LIBC_DIR=`dirname $NXT_JAVA_LIBC_DIR`
 fi
 


### PR DESCRIPTION
Alpine linux using musl libc instread of glibc, if we try to build java module on alpine Linux, we will find it not working, The patch is for resolving the issue 