### PR TITLE
Add "script_name" to Python configuration

### DIFF
--- a/src/nxt_application.h
+++ b/src/nxt_application.h
@@ -52,6 +52,7 @@ typedef struct {
     nxt_str_t                  module;
     char                       *callable;
     nxt_str_t                  protocol;
+    nxt_str_t                  script_name;
     uint32_t                   threads;
     uint32_t                   thread_stack_size;
     nxt_conf_value_t           *targets;

--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -127,6 +127,8 @@ static nxt_int_t nxt_conf_vldt_python_path_element(nxt_conf_validation_t *vldt,
     nxt_conf_value_t *value);
 static nxt_int_t nxt_conf_vldt_python_protocol(nxt_conf_validation_t *vldt,
     nxt_conf_value_t *value, void *data);
+static nxt_int_t nxt_conf_vldt_python_script_name(nxt_conf_validation_t * vldt,
+    nxt_conf_value_t *value, void *data);
 static nxt_int_t nxt_conf_vldt_threads(nxt_conf_validation_t *vldt,
     nxt_conf_value_t *value, void *data);
 static nxt_int_t nxt_conf_vldt_thread_stack_size(nxt_conf_validation_t *vldt,
@@ -720,6 +722,10 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_python_common_members[] = {
         .name       = nxt_string("protocol"),
         .type       = NXT_CONF_VLDT_STRING,
         .validator  = nxt_conf_vldt_python_protocol,
+    }, {
+        .name       = nxt_string("script_name"),
+        .type       = NXT_CONF_VLDT_STRING,
+        .validator  = nxt_conf_vldt_python_script_name,
     }, {
         .name       = nxt_string("threads"),
         .type       = NXT_CONF_VLDT_INTEGER,
@@ -1778,6 +1784,23 @@ nxt_conf_vldt_python_protocol(nxt_conf_validation_t *vldt,
 
     return nxt_conf_vldt_error(vldt, "The \"protocol\" can either be "
                                      "\"wsgi\" or \"asgi\".");
+}
+
+
+static nxt_int_t
+nxt_conf_vldt_python_script_name(nxt_conf_validation_t *vldt,
+    nxt_conf_value_t * value, void *data)
+{
+    nxt_str_t script_name;
+
+    nxt_conf_get_string(value, &script_name);
+
+    if (script_name.length == 0 || script_name.start[0] == '/') {
+        return NXT_OK;
+    }
+
+    return nxt_conf_vldt_error(vldt, "The \"script_name\" must be a string "
+                                     "beginning with \"/\".");
 }
 
 

--- a/src/nxt_main_process.c
+++ b/src/nxt_main_process.c
@@ -209,6 +209,12 @@ static nxt_conf_map_t  nxt_python_app_conf[] = {
     },
 
     {
+        nxt_string("script_name"),
+        NXT_CONF_MAP_STR,
+        offsetof(nxt_common_app_conf_t, u.python.script_name),
+    },
+
+    {
         nxt_string("threads"),
         NXT_CONF_MAP_INT32,
         offsetof(nxt_common_app_conf_t, u.python.threads),

--- a/src/python/nxt_python.c
+++ b/src/python/nxt_python.c
@@ -263,7 +263,7 @@ nxt_python_start(nxt_task_t *task, nxt_process_data_t *data)
         goto fail;
     }
 
-    rc = nxt_py_proto.ctx_data_alloc(&python_init.ctx_data, 1);
+    rc = nxt_py_proto.ctx_data_alloc(&python_init.ctx_data, 1, c->script_name);
     if (nxt_slow_path(rc != NXT_UNIT_OK)) {
         goto fail;
     }
@@ -503,7 +503,7 @@ nxt_python_init_threads(nxt_python_app_conf_t *c)
     for (i = 0; i < c->threads - 1; i++) {
         ti = &nxt_py_threads[i];
 
-        res = nxt_py_proto.ctx_data_alloc(&ti->ctx_data, 0);
+        res = nxt_py_proto.ctx_data_alloc(&ti->ctx_data, 0, c->script_name);
         if (nxt_slow_path(res != NXT_UNIT_OK)) {
             return NXT_UNIT_ERROR;
         }

--- a/src/python/nxt_python.h
+++ b/src/python/nxt_python.h
@@ -60,7 +60,7 @@ typedef struct {
 
 
 typedef struct {
-    int   (*ctx_data_alloc)(void **pdata, int main);
+    int   (*ctx_data_alloc)(void **pdata, int main, nxt_str_t script_name);
     void  (*ctx_data_free)(void *data);
     int   (*startup)(void *data);
     int   (*run)(nxt_unit_ctx_t *ctx);

--- a/src/python/nxt_python_asgi.h
+++ b/src/python/nxt_python_asgi.h
@@ -25,6 +25,7 @@ typedef struct {
 
 typedef struct {
     nxt_queue_t      drain_queue;
+    PyObject         *root_path;
     PyObject         *loop_run_until_complete;
     PyObject         *loop_create_future;
     PyObject         *loop_create_task;

--- a/src/python/nxt_python_asgi_str.c
+++ b/src/python/nxt_python_asgi_str.c
@@ -99,7 +99,7 @@ static nxt_python_string_t nxt_py_asgi_strings[] = {
     { nxt_string("query_string"), &nxt_py_query_string_str },
     { nxt_string("raw_path"), &nxt_py_raw_path_str },
     { nxt_string("result"), &nxt_py_result_str },
-    { nxt_string("root_path"), &nxt_py_root_path_str }, // not used
+    { nxt_string("root_path"), &nxt_py_root_path_str },
     { nxt_string("scheme"), &nxt_py_scheme_str },
     { nxt_string("server"), &nxt_py_server_str },
     { nxt_string("set_exception"), &nxt_py_set_exception_str },

--- a/test/python/script_name/asgi.py
+++ b/test/python/script_name/asgi.py
@@ -1,0 +1,16 @@
+async def application(scope, receive, send):
+    assert scope['type'] == 'http'
+
+    await send(
+        {
+            'type': 'http.response.start',
+            'status': 200,
+            'headers': [
+                (b'content-length', b'0'),
+                (b'script-name', scope.get('root_path', 'NULL').encode()),
+                (b'request-uri', scope['path'].encode()),
+            ]
+        }
+    )
+
+    await send({'type': 'http.response.body', 'body': b''})

--- a/test/python/script_name/wsgi.py
+++ b/test/python/script_name/wsgi.py
@@ -1,0 +1,10 @@
+def application(environ, start_response):
+    start_response(
+        '200',
+        [
+            ('Content-Length', '0'),
+            ('Script-Name', environ.get('SCRIPT_NAME', 'No Script Name')),
+            ('Path-Info', environ['PATH_INFO'])
+        ]
+    )
+    return []

--- a/test/test_asgi_application.py
+++ b/test/test_asgi_application.py
@@ -67,6 +67,17 @@ custom-header: BLAH
             resp['headers']['query-string'] == 'var1=val1&var2=val2'
         ), 'query-string header'
 
+    def test_asgi_application_script_name(self):
+        self.load('script_name', script_name='/api/rest')
+
+        resp = self.get(url='/api/rest/get')
+        assert (
+            resp['headers']['script-name'] == '/api/rest'
+        ), 'script-name header'
+        assert (
+            resp['headers']['request-uri'] == '/api/rest/get'
+        ), 'path-info header'
+
     def test_asgi_application_query_string_space(self):
         self.load('query_string')
 

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -308,6 +308,48 @@ class TestConfiguration(TestControl):
 
         assert 'success' in self.conf(conf)
 
+    def test_json_application_script_name(self):
+        conf = {
+            "applications": {
+                "sub-app": {
+                    "type": "python",
+                    "processes": {"spare": 0},
+                    "path": "/app",
+                    "module": "wsgi",
+                    "script_name": "/app",
+                }
+            },
+            "listeners": {"*:7080": {"pass": "routes"}},
+            "routes": [
+                {
+                    "match": {"uri": "/app/*"},
+                    "action": {"pass": "applications/sub-app"},
+                }
+            ]
+        }
+
+        assert 'success' in self.conf(conf)
+
+    def test_json_application_invalid_script_name(self):
+        conf = {
+            "applications": {
+                "sub-app": {
+                    "type": "python",
+                    "processes": {"spare": 0},
+                    "path": "/app",
+                    "module": "wsgi",
+                    "script_name": "app",
+                }
+            },
+            "listeners": {"*:7080": {"pass": "applications/sub-app"}},
+        }
+
+        resp = self.conf(conf)
+        assert 'error' in resp
+        assert resp['detail'] == (
+            'The "script_name" must be a string beginning with "/".'
+        )
+
     def test_json_application_many2(self):
         conf = {
             "applications": {

--- a/test/test_python_application.py
+++ b/test/test_python_application.py
@@ -94,6 +94,41 @@ custom-header: BLAH
             resp['headers']['Query-String'] == ' var1= val1 & var2=val2'
         ), 'Query-String space 4'
 
+    def test_python_application_script_name_strip(self):
+        self.load('script_name', script_name='/test')
+
+        resp = self.get(url='/test/')
+
+        assert resp['status'] == 200, 'script name strip status'
+        assert (
+            resp['headers']['Script-Name'] == '/test'
+        ), 'script name strip script name'
+        assert resp['headers']['Path-Info'] == '/', 'script name strip path info'
+
+    def test_python_application_script_name_empty_path(self):
+        self.load('script_name', script_name='/test')
+
+        resp = self.get(url='/test')
+
+        assert resp['status'] == 200, 'script name strip status'
+        assert (
+            resp['headers']['Script-Name'] == '/test'
+        ), 'script name strip script name'
+        assert resp['headers']['Path-Info'] == '/', 'script name strip path info'
+
+    def test_python_applications_script_name_no_match(self):
+        self.load('script_name', script_name='/api/rest')
+
+        resp = self.get(url='/api/get')
+
+        assert resp['status'] == 200, 'script name strip status'
+        assert (
+            resp['headers']['Script-Name'] == '/api/rest'
+        ), 'script name strip script name'
+        assert (
+            resp['headers']['Path-Info'] == '/api/get'
+        ), 'script name strip path info'
+
     def test_python_application_query_string_empty(self):
         self.load('query_string')
 

--- a/test/unit/applications/lang/python.py
+++ b/test/unit/applications/lang/python.py
@@ -50,6 +50,7 @@ class TestApplicationPython(TestApplicationProto):
             'protocol',
             'targets',
             'threads',
+            'script_name',
         ):
             if attr in kwargs:
                 app[attr] = kwargs.pop(attr)


### PR DESCRIPTION
Fixes #590

Allow configurations for Python applications to accept an optional `script_name` parameter. If set, the value must be a string beginning with `/`. If not set, Unit will behave as before.

The `script_name` is used in the following ways:

* In ASGI applications, the key-value pair `"root_path": "<script_name>"` is added to the `scope` dict
* In WSGI applications, the key-value pair `"SCRIPT_NAME": "<script_name>"` is added to the `environ` dict, and if the WSGI callable is called for a request whose path begins with `script_name`, the `PATH_INFO` in `environ` is set to all characters after those in `script_name`, or `/` is the request path is identical to `script_name`