### PR TITLE
Fix build with OpenSSL 3

### DIFF
--- a/src/nxt_openssl.c
+++ b/src/nxt_openssl.c
@@ -1777,7 +1777,11 @@ nxt_openssl_copy_error(u_char *p, u_char *end)
     clear = 0;
 
     for ( ;; ) {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+        err = ERR_get_error_all(NULL, NULL, NULL, &data, &flags);
+#else
         err = ERR_get_error_line_data(NULL, NULL, &data, &flags);
+#endif
         if (err == 0) {
             break;
         }


### PR DESCRIPTION
See #597 

1st commit drop usage of deprecated ERR_get_error_line_data

2nd commit is a workaround waiting for callback refactoring (move from `SSL_CTX_set_tlsext_ticket_key_cb` to `SSL_CTX_set_tlsext_ticket_key_evp_cb`)