### PR TITLE
chmod and chown for unix socket as listener

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -2,6 +2,7 @@
    NGINX Unit.
 
    Copyright 2017-2022 NGINX, Inc.
+   Copyright 2022-2022 Evgenii Sokolov
    Copyright 2017-2022 Valentin V. Bartenev
    Copyright 2017-2022 Max Romanov
    Copyright 2017-2022 Andrei Zeliankou

--- a/auto/help
+++ b/auto/help
@@ -1,5 +1,6 @@
 
 # Copyright (C) Igor Sysoev
+# Copyright (C) Evgenii Sokolov
 # Copyright (C) NGINX, Inc.
 
 
@@ -28,6 +29,9 @@ cat << END
 
   --control=ADDRESS    set address of control API socket
                        default: "$NXT_CONTROL"
+
+  --unix-sock-mod=MODE set mode to unix socket as a listener
+                       default: "$NXT_UNIX_DOMAIN_MODE"
 
   --user=USER          set non-privileged processes to run as specified user
                        default: "$NXT_USER"

--- a/auto/options
+++ b/auto/options
@@ -1,6 +1,7 @@
 
 # Copyright (C) Igor Sysoev
 # Copyright (C) Valentin V. Bartenev
+# Copyright (C) Evgenii Sokolov
 # Copyright (C) NGINX, Inc.
 
 
@@ -68,6 +69,8 @@ do
         --log=*)                         NXT_LOG="$value"                    ;;
 
         --control=*)                     NXT_CONTROL="$value"                ;;
+
+        --unix-sock-mod=*)               NXT_UNIX_DOMAIN_MODE="$value"       ;;
 
         --user=*)                        NXT_USER="$value"                   ;;
         --group=*)                       NXT_GROUP="$value"                  ;;
@@ -179,4 +182,9 @@ case "$NXT_CONTROL" in
     unix:/*)  ;;
     unix:*)   NXT_CONTROL="unix:$NXT_PREFIX${NXT_CONTROL##unix:}" ;;
     *)        ;;
+esac
+
+case "$NXT_UNIX_DOMAIN_MODE" in
+     [0-7][0-7][0-7])  ;;
+     *) NXT_UNIX_DOMAIN_MODE=$NXT_UNIX_DOMAIN_MODE ;;
 esac

--- a/auto/summary
+++ b/auto/summary
@@ -1,5 +1,6 @@
 
 # Copyright (C) Igor Sysoev
+# Copyright (C) Evgenii Sokolov
 # Copyright (C) NGINX, Inc.
 
 
@@ -26,6 +27,7 @@ Unit configuration summary:
 
   IPv6 support: .............. $NXT_INET6
   Unix domain sockets support: $NXT_UNIX_DOMAIN
+  Unix domain sockets mode: .. $NXT_UNIX_DOMAIN_MODE
   TLS support: ............... $NXT_OPENSSL
 
   process isolation: ......... $NXT_ISOLATION

--- a/configure
+++ b/configure
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 # Copyright (C) Igor Sysoev
+# Copyright (C) Evgenii Sokolov
 # Copyright (C) NGINX, Inc.
 
 
@@ -42,6 +43,7 @@ NXT_TMP="tmp"
 NXT_PID="unit.pid"
 NXT_LOG="unit.log"
 NXT_CONTROL="unix:control.unit.sock"
+NXT_UNIX_DOMAIN_MODE="666"
 NXT_USER="nobody"
 NXT_GROUP=
 
@@ -92,6 +94,8 @@ cat << END >> $NXT_AUTO_CONFIG_H
 #define NXT_TMP                "$NXT_TMP"
 
 #define NXT_CONTROL_SOCK       "$NXT_CONTROL"
+
+#define NXT_UNIX_DOMAIN_MODE   "$NXT_UNIX_DOMAIN_MODE"
 
 #define NXT_USER               "$NXT_USER"
 #define NXT_GROUP              "$NXT_GROUP"

--- a/pkg/deb/debian.module/copyright.unit-jsc10
+++ b/pkg/deb/debian.module/copyright.unit-jsc10
@@ -2,6 +2,7 @@
    NGINX Unit.
 
    Copyright 2017-2022 NGINX, Inc.
+   Copyright 2022-2022 Evgenii Sokolov
    Copyright 2017-2022 Valentin V. Bartenev
    Copyright 2017-2022 Max Romanov
    Copyright 2017-2022 Andrei Zeliankou

--- a/pkg/deb/debian.module/copyright.unit-jsc11
+++ b/pkg/deb/debian.module/copyright.unit-jsc11
@@ -2,6 +2,7 @@
    NGINX Unit.
 
    Copyright 2017-2022 NGINX, Inc.
+   Copyright 2022-2022 Evgenii Sokolov
    Copyright 2017-2022 Valentin V. Bartenev
    Copyright 2017-2022 Max Romanov
    Copyright 2017-2022 Andrei Zeliankou

--- a/pkg/deb/debian.module/copyright.unit-jsc8
+++ b/pkg/deb/debian.module/copyright.unit-jsc8
@@ -2,6 +2,7 @@
    NGINX Unit.
 
    Copyright 2017-2022 NGINX, Inc.
+   Copyright 2022-2022 Evgenii Sokolov
    Copyright 2017-2022 Valentin V. Bartenev
    Copyright 2017-2022 Max Romanov
    Copyright 2017-2022 Andrei Zeliankou

--- a/pkg/deb/debian/copyright
+++ b/pkg/deb/debian/copyright
@@ -2,6 +2,7 @@
    NGINX Unit.
 
    Copyright 2017-2022 NGINX, Inc.
+   Copyright 2022-2022 Evgenii Sokolov
    Copyright 2017-2022 Valentin V. Bartenev
    Copyright 2017-2022 Max Romanov
    Copyright 2017-2022 Andrei Zeliankou

--- a/pkg/rpm/rpmbuild/SOURCES/COPYRIGHT.unit-jsc10
+++ b/pkg/rpm/rpmbuild/SOURCES/COPYRIGHT.unit-jsc10
@@ -2,6 +2,7 @@
    NGINX Unit.
 
    Copyright 2017-2022 NGINX, Inc.
+   Copyright 2022-2022 Evgenii Sokolov
    Copyright 2017-2022 Valentin V. Bartenev
    Copyright 2017-2022 Max Romanov
    Copyright 2017-2022 Andrei Zeliankou

--- a/pkg/rpm/rpmbuild/SOURCES/COPYRIGHT.unit-jsc11
+++ b/pkg/rpm/rpmbuild/SOURCES/COPYRIGHT.unit-jsc11
@@ -2,6 +2,7 @@
    NGINX Unit.
 
    Copyright 2017-2022 NGINX, Inc.
+   Copyright 2022-2022 Evgenii Sokolov
    Copyright 2017-2022 Valentin V. Bartenev
    Copyright 2017-2022 Max Romanov
    Copyright 2017-2022 Andrei Zeliankou

--- a/pkg/rpm/rpmbuild/SOURCES/COPYRIGHT.unit-jsc8
+++ b/pkg/rpm/rpmbuild/SOURCES/COPYRIGHT.unit-jsc8
@@ -2,6 +2,7 @@
    NGINX Unit.
 
    Copyright 2017-2022 NGINX, Inc.
+   Copyright 2022-2022 Evgenii Sokolov
    Copyright 2017-2022 Valentin V. Bartenev
    Copyright 2017-2022 Max Romanov
    Copyright 2017-2022 Andrei Zeliankou

--- a/src/nxt_runtime.h
+++ b/src/nxt_runtime.h
@@ -71,6 +71,7 @@ struct nxt_runtime_s {
     const char             *conf;
     const char             *conf_tmp;
     const char             *control;
+    const char             *unix_sock_mod;
     const char             *tmp;
 
     nxt_str_t              certs;


### PR DESCRIPTION
### Feature 1 - chmod:
An extension to the build and run configuration options that set the permission mode for a unix socket as a listener.

**Configuration option:**
`NXT_UNIX_DOMAIN_MODE=MODE`

**Launch option:**
`--unix-sock-mod MODE`

**Available formats (for example: MODE 7):**
`NXT_UNIX_DOMAIN_MODE=7` or `--unix-sock-mod 7`
`NXT_UNIX_DOMAIN_MODE=07` or `--unix-sock-mod 07`
`NXT_UNIX_DOMAIN_MODE=007` or `--unix-sock-mod 007`

**Default MODE value:**
`666` - (srw-rw-rw-)

### Feature 2 - chown:
Set the user and group of the owner of the unix socket as a listener.