### PR TITLE
Workaround clang bug in __has_declspec_attribute()

### DIFF
--- a/auto/modules/ruby
+++ b/auto/modules/ruby
@@ -56,6 +56,7 @@ nxt_found=no
 
 if /bin/sh -c "$NXT_RUBY -v" >> $NXT_AUTOCONF_ERR 2>&1; then
 
+    NXT_RUBY_CFLAGS=
     NXT_RUBY_RUBYHDRDIR=`$NXT_RUBY -rrbconfig -e 'print RbConfig::CONFIG["rubyhdrdir"]'`
     NXT_RUBY_ARCHHDRDIR=`$NXT_RUBY -rrbconfig -e 'print RbConfig::CONFIG["rubyarchhdrdir"]'`
     NXT_RUBY_SITEDIR=`$NXT_RUBY -rrbconfig -e 'print RbConfig::CONFIG["sitedir"]'`
@@ -71,6 +72,31 @@ if /bin/sh -c "$NXT_RUBY -v" >> $NXT_AUTOCONF_ERR 2>&1; then
     NXT_RUBY_LIBSCONF=`$NXT_RUBY -rrbconfig -e 'print RbConfig::CONFIG["LIBS"]'`
     NXT_RUBY_LIBPATH=`$NXT_RUBY -rrbconfig -e 'print RbConfig::CONFIG["libdir"]'`
     NXT_RUBY_LIBS="-l$NXT_RUBY_LIBNAME $NXT_RUBY_LIBSCONF"
+
+    if [ $NXT_CC_NAME = clang ]; then
+        # Workaround Clang bug
+        nxt_feature="-fdeclspec"
+        nxt_feature_name=
+        nxt_feature_run=
+        nxt_feature_incs="-fdeclspec"
+        nxt_feature_libs=
+        nxt_feature_test="#include <stdlib.h>
+
+                          __declspec(noreturn) static void f(void);
+
+                          static void f(void) {
+                              exit(0);
+                          }
+
+                          int main(void) {
+                              f();
+                          }"
+        . auto/feature
+
+        if [ $nxt_found = yes ]; then
+            NXT_RUBY_CFLAGS="$NXT_RUBY_CFLAGS -fdeclspec"
+        fi
+    fi
 
     nxt_feature="Ruby library"
     nxt_feature_name=""
@@ -205,7 +231,7 @@ for nxt_src in $NXT_RUBY_MODULE_SRCS; do
 
 $NXT_BUILD_DIR/$nxt_obj:	$nxt_src $NXT_VERSION_H
 	mkdir -p $NXT_BUILD_DIR/src/ruby
-	\$(CC) -c \$(CFLAGS) -DNXT_RUBY_MOUNTS_H=\"$NXT_RUBY_MOUNTS_HEADER\" \\
+	\$(CC) -c \$(CFLAGS) $NXT_RUBY_CFLAGS -DNXT_RUBY_MOUNTS_H=\"$NXT_RUBY_MOUNTS_HEADER\" \\
            \$(NXT_INCS) $NXT_RUBY_INCPATH \\
 	$nxt_dep_flags \\
 	-o $NXT_BUILD_DIR/$nxt_obj $nxt_src


### PR DESCRIPTION
Add -fdeclspec to NXT_RUBY_CFLAGS for Clang, if it's available.

Clang incorrectly reports 1 for __has_declspec_attribute(x) in
some cases, such as MacOS or Cygwin.  That causes ruby code to
break.  ruby added -fdeclspec to their CFLAGS in 2019 to
workaround this bug, since it enables __declspec() and therefore,
the compiler behavior matches what it reports.

Since we don't know what are all the architectures that trigger
the clang bug, let's add the flag for all of them (especially
since it should be harmless).

Add this workaround only at the time of configuring the ruby
module.  This way we don't clutter the global NXT_CFLAGS with an
unnecessary flag.

Link: unit bug <https://github.com/nginx/unit/issues/653>
Link: ruby bug <https://bugs.ruby-lang.org/issues/18616>
Link: LLVM bug <https://github.com/llvm/llvm-project/issues/49958>
Commit: LLVM: Add -fdeclspec `<d170c4b57a91adc74ca89c6d4af616a00323b12c>`
Commit: ruby: Use -fdeclspec `<0958e19ffb047781fe1506760c7cbd8d7fe74e57>`