### PR TITLE
Add variables in "location"

### DIFF
--- a/docs/changes.xml
+++ b/docs/changes.xml
@@ -33,6 +33,12 @@ NGINX Unit updated to 1.27.0.
 
 <change type="feature">
 <para>
+variables support in the "location" option of the "return" action.
+</para>
+</change>
+
+<change type="feature">
+<para>
 compatibility with GCC 12.
 </para>
 </change>

--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -635,6 +635,7 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_return_action_members[] = {
     }, {
         .name       = nxt_string("location"),
         .type       = NXT_CONF_VLDT_STRING,
+        .flags      = NXT_CONF_VLDT_VAR,
     },
 
     NXT_CONF_VLDT_END

--- a/src/nxt_http_return.c
+++ b/src/nxt_http_return.c
@@ -8,13 +8,26 @@
 
 
 typedef struct {
-    nxt_http_status_t       status;
-    nxt_str_t               location;
+    nxt_http_status_t  status;
+    nxt_var_t          *location;
+    nxt_str_t          encoded;
+    uint8_t            loc_is_const;
 } nxt_http_return_conf_t;
+
+
+typedef struct {
+    nxt_http_action_t  *action;
+    nxt_str_t          location;
+    nxt_str_t          encoded;
+} nxt_http_return_ctx_t;
 
 
 static nxt_http_action_t *nxt_http_return(nxt_task_t *task,
     nxt_http_request_t *r, nxt_http_action_t *action);
+static nxt_int_t nxt_http_return_encode(nxt_mp_t *mp, nxt_str_t *encoded,
+    const nxt_str_t *location);
+static void nxt_http_return_send_ready(nxt_task_t *task, void *obj, void *data);
+static void nxt_http_return_var_error(nxt_task_t *task, void *obj, void *data);
 
 
 static const nxt_http_request_state_t  nxt_http_return_send_state;
@@ -24,8 +37,8 @@ nxt_int_t
 nxt_http_return_init(nxt_mp_t *mp, nxt_http_action_t *action,
     nxt_http_action_conf_t *acf)
 {
-    nxt_str_t               *loc;
-    nxt_uint_t              encode;
+    nxt_str_t               str;
+    nxt_var_t               *var;
     nxt_http_return_conf_t  *conf;
 
     conf = nxt_mp_zget(mp, sizeof(nxt_http_return_conf_t));
@@ -38,30 +51,22 @@ nxt_http_return_init(nxt_mp_t *mp, nxt_http_action_t *action,
 
     conf->status = nxt_conf_get_number(acf->ret);
 
-    if (acf->location.length > 0) {
-        if (nxt_is_complex_uri_encoded(acf->location.start,
-                                       acf->location.length))
-        {
-            loc = nxt_str_dup(mp, &conf->location, &acf->location);
-            if (nxt_slow_path(loc == NULL)) {
-                return NXT_ERROR;
-            }
+    if (acf->location.length == 0) {
+        conf->loc_is_const = 1;
+        return NXT_OK;
+    }
 
-        } else {
-            loc = &conf->location;
+    var = nxt_var_compile(&acf->location, mp, 0);
+    if (nxt_slow_path(var == NULL)) {
+        return NXT_ERROR;
+    }
 
-            encode = nxt_encode_complex_uri(NULL, acf->location.start,
-                                            acf->location.length);
-            loc->length = acf->location.length + encode * 2;
+    conf->location = var;
+    conf->loc_is_const = nxt_var_is_const(var);
 
-            loc->start = nxt_mp_nget(mp, loc->length);
-            if (nxt_slow_path(loc->start == NULL)) {
-                return NXT_ERROR;
-            }
-
-            nxt_encode_complex_uri(loc->start, acf->location.start,
-                                   acf->location.length);
-        }
+    if (conf->loc_is_const) {
+        nxt_var_raw(conf->location, &str);
+        return nxt_http_return_encode(mp, &conf->encoded, &str);
     }
 
     return NXT_OK;
@@ -72,13 +77,21 @@ nxt_http_action_t *
 nxt_http_return(nxt_task_t *task, nxt_http_request_t *r,
     nxt_http_action_t *action)
 {
-    nxt_http_field_t        *field;
+    nxt_int_t               ret;
+    nxt_str_t               loc;
+    nxt_http_return_ctx_t   *ctx;
     nxt_http_return_conf_t  *conf;
 
     conf = action->u.conf;
 
-    nxt_debug(task, "http return: %d (loc: \"%V\")",
-              conf->status, &conf->location);
+    if (conf->location == NULL) {
+        nxt_str_null(&loc);
+
+    } else {
+        nxt_var_raw(conf->location, &loc);
+    }
+
+    nxt_debug(task, "http return: %d (loc: \"%V\")", conf->status, &loc);
 
     if (conf->status >= NXT_HTTP_BAD_REQUEST
         && conf->status <= NXT_HTTP_SERVER_ERROR_MAX)
@@ -87,27 +100,123 @@ nxt_http_return(nxt_task_t *task, nxt_http_request_t *r,
         return NULL;
     }
 
+    ctx = nxt_mp_zget(r->mem_pool, sizeof(nxt_http_return_ctx_t));
+    if (nxt_slow_path(ctx == NULL)) {
+        goto fail;
+    }
+
+    ctx->action = action;
     r->status = conf->status;
     r->resp.content_length_n = 0;
 
-    if (conf->location.length > 0) {
+    if (conf->loc_is_const) {
+        ctx->encoded = conf->encoded;
+
+        nxt_http_return_send_ready(task, r, ctx);
+
+    } else {
+        ret = nxt_var_query_init(&r->var_query, r, r->mem_pool);
+        if (nxt_slow_path(ret != NXT_OK)) {
+            goto fail;
+        }
+
+        nxt_var_query(task, r->var_query, conf->location, &ctx->location);
+
+        nxt_var_query_resolve(task, r->var_query, ctx,
+                              nxt_http_return_send_ready,
+                              nxt_http_return_var_error);
+    }
+
+    return NULL;
+
+fail:
+
+    nxt_http_request_error(task, r, NXT_HTTP_INTERNAL_SERVER_ERROR);
+    return NULL;
+}
+
+
+static nxt_int_t
+nxt_http_return_encode(nxt_mp_t *mp, nxt_str_t *encoded,
+    const nxt_str_t *location)
+{
+    nxt_uint_t  encode;
+
+    if (nxt_is_complex_uri_encoded(location->start, location->length)) {
+        *encoded = *location;
+
+        return NXT_OK;
+    }
+
+    encode = nxt_encode_complex_uri(NULL, location->start, location->length);
+    encoded->length = location->length + encode * 2;
+
+    encoded->start = nxt_mp_nget(mp, encoded->length);
+    if (nxt_slow_path(encoded->start == NULL)) {
+        return NXT_ERROR;
+    }
+
+    nxt_encode_complex_uri(encoded->start, location->start, location->length);
+
+    return NXT_OK;
+}
+
+
+static void
+nxt_http_return_send_ready(nxt_task_t *task, void *obj, void *data)
+{
+    nxt_int_t               ret;
+    nxt_http_field_t        *field;
+    nxt_http_action_t       *action;
+    nxt_http_request_t      *r;
+    nxt_http_return_ctx_t   *ctx;
+    nxt_http_return_conf_t  *conf;
+
+    r = obj;
+    ctx = data;
+    action = ctx->action;
+    conf = action->u.conf;
+
+    if (!conf->loc_is_const) {
+        ret = nxt_http_return_encode(r->mem_pool, &ctx->encoded,
+                                     &ctx->location);
+        if (nxt_slow_path(ret == NXT_ERROR)) {
+            goto fail;
+        }
+    }
+
+    if (ctx->encoded.length > 0) {
         field = nxt_list_zero_add(r->resp.fields);
         if (nxt_slow_path(field == NULL)) {
-            nxt_http_request_error(task, r, NXT_HTTP_INTERNAL_SERVER_ERROR);
-            return NULL;
+            goto fail;
         }
 
         nxt_http_field_name_set(field, "Location");
 
-        field->value = conf->location.start;
-        field->value_length = conf->location.length;
+        field->value = ctx->encoded.start;
+        field->value_length = ctx->encoded.length;
     }
 
     r->state = &nxt_http_return_send_state;
 
     nxt_http_request_header_send(task, r, NULL, NULL);
 
-    return NULL;
+    return;
+
+fail:
+
+    nxt_http_request_error(task, r, NXT_HTTP_INTERNAL_SERVER_ERROR);
+}
+
+
+static void
+nxt_http_return_var_error(nxt_task_t *task, void *obj, void *data)
+{
+    nxt_http_request_t  *r;
+
+    r = obj;
+
+    nxt_http_request_error(task, r, NXT_HTTP_INTERNAL_SERVER_ERROR);
 }
 
 

--- a/test/test_return.py
+++ b/test/test_return.py
@@ -83,7 +83,7 @@ Connection: close
         assert resp['body'] == ''
 
     def test_return_location(self):
-        reserved = ":/?#[]@!$&'()*+,;="
+        reserved = ":/?#[]@!&'()*+,;="
         unreserved = (
             "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
             "0123456789-._~"
@@ -107,15 +107,15 @@ Connection: close
         check_location(reserved)
 
         # After first "?" all other "?" encoded.
-        check_location("/?" + reserved, "/?:/%3F#[]@!$&'()*+,;=")
+        check_location("/?" + reserved, "/?:/%3F#[]@!&'()*+,;=")
         check_location("???", "?%3F%3F")
 
         # After first "#" all other "?" or "#" encoded.
-        check_location("/#" + reserved, "/#:/%3F%23[]@!$&'()*+,;=")
+        check_location("/#" + reserved, "/#:/%3F%23[]@!&'()*+,;=")
         check_location("##?#?", "#%23%3F%23%3F")
 
         # After first "?" next "#" not encoded.
-        check_location("/?#" + reserved, "/?#:/%3F%23[]@!$&'()*+,;=")
+        check_location("/?#" + reserved, "/?#:/%3F%23[]@!&'()*+,;=")
         check_location("??##", "?%3F#%23")
         check_location("/?##?", "/?#%23%3F")
 

--- a/test/test_return.py
+++ b/test/test_return.py
@@ -161,6 +161,23 @@ Connection: close
         ), 'location method not allowed'
         assert self.get()['headers']['Location'] == 'blah'
 
+        assert 'success' in self.conf(
+            '"https://${host}${uri}"', 'routes/0/action/location'
+        ), 'location with variables'
+        assert self.get()['headers']['Location'] == 'https://localhost/'
+
+        assert 'success' in self.conf(
+            '"/#$host"', 'routes/0/action/location'
+        ), 'location with encoding and a variable'
+        assert self.get()['headers']['Location'] == '/#localhost'
+
+        assert (
+            self.get(headers={"Host": "#foo?bar", "Connection": "close"})[
+                'headers'
+            ]['Location']
+            == "/#%23foo%3Fbar"
+        ), 'location with a variable with encoding'
+
     def test_return_invalid(self):
         def check_error(conf):
             assert 'error' in self.conf(conf, 'routes/0/action')
@@ -171,6 +188,8 @@ Connection: close
         check_error({"return": 1000})
         check_error({"return": -1})
         check_error({"return": 200, "share": "/blah"})
+        check_error({"return": 200, "location": "$hos"})
+        check_error({"return": 200, "location": "$hostblah"})
 
         assert 'error' in self.conf(
             '001', 'routes/0/action/return'


### PR DESCRIPTION
```
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

location = ":/?#[]@!$&'()*+,;=", expect = ":/?#[]@!$&'()*+,;="

    def check_location(location, expect=None):
        if expect is None:
            expect = location
    
>       assert 'success' in self.conf(
            {"return": 301, "location": location}, 'routes/0/action'
        ), 'configure location'
E       AssertionError: configure location
E       assert 'success' in {'detail': 'Unknown variable "" in the "location" value.', 'error': 'Invalid configuration.'}
E        +  where {'detail': 'Unknown variable "" in the "location" value.', 'error': 'Invalid configuration.'} = <bound method args_handler.<locals>.args_wrapper of <test_return.TestReturn object at 0x7f8789d01b50>>({'location': ":/?#[]@!$&'()*+,;=", 'return': 301}, 'routes/0/action')
E        +    where <bound method args_handler.<locals>.args_wrapper of <test_return.TestReturn object at 0x7f8789d01b50>> = <test_return.TestReturn object at 0x7f8789d01b50>.conf

test/test_return.py:98: AssertionError
```

`$` is a special symbol there.  We might have collisions if we use variables there, don't we?