### PR TITLE
Increase readtimeout for configuration endpoint

### DIFF
--- a/docs/changes.xml
+++ b/docs/changes.xml
@@ -31,6 +31,13 @@ NGINX Unit updated to 1.27.0.
          date="" time=""
          packager="Andrei Belov &lt;defan@nginx.com&gt;">
 
+
+<change type="change">
+<para>
+increased the applications startup timeout.
+</para>
+</change>
+	
 <change type="feature">
 <para>
 ability to specify a custom index file name when serving static files.

--- a/src/nxt_controller.c
+++ b/src/nxt_controller.c
@@ -725,7 +725,7 @@ static const nxt_event_conn_state_t  nxt_controller_conn_read_state
 
     .timer_handler = nxt_controller_conn_read_timeout,
     .timer_value = nxt_controller_conn_timeout_value,
-    .timer_data = 60 * 1000,
+    .timer_data = 300 * 1000,
 };
 
 


### PR DESCRIPTION
As reported in issue #676. In case an application or better to say the set off all applications will take longer then `60` seconds to start, Unit will close the connection to the client sent the new configuration (curl for example).

As the timeout value in this case will not effect Unit during runtime, it is a small change without much impact. One word about the downsides of it. If Unit is hosted in a container, and an application failed to start or is waiting on a database or any other 3rd party connection to be established, the container will not be killed till the new timeout of `300` seconds exceeded. But I think this is a valid point and nothing we have to worry about.