### PR TITLE
Added NXT_MAYBE_UNUSED for __attribute__((__unused__)).

### DIFF
--- a/auto/clang
+++ b/auto/clang
@@ -176,3 +176,21 @@ nxt_feature_test="struct s {
                       return 1;
                   }"
 . auto/feature
+
+
+nxt_feature="GCC __attribute__ unused"
+nxt_feature_name=NXT_HAVE_GCC_ATTRIBUTE_UNUSED
+nxt_feature_run=
+nxt_feature_incs=
+nxt_feature_libs=
+nxt_feature_test="static void f(void) __attribute__ ((__unused__));
+
+                  static void f(void)
+                  {
+                      return;
+                  }
+
+                  int main(void) {
+                      return 0;
+                  }"
+. auto/feature

--- a/src/nxt_clang.h
+++ b/src/nxt_clang.h
@@ -132,6 +132,17 @@ nxt_prefetch(a)
 #endif
 
 
+#if (NXT_HAVE_GCC_ATTRIBUTE_UNUSED)
+
+#define NXT_MAYBE_UNUSED         __attribute__((__unused__))
+
+#else
+
+#define NXT_MAYBE_UNUSED
+
+#endif
+
+
 #if (NXT_HAVE_BUILTIN_POPCOUNT)
 
 #define nxt_popcount       __builtin_popcount

--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -77,7 +77,8 @@ static nxt_int_t nxt_conf_vldt_error(nxt_conf_validation_t *vldt,
 static nxt_int_t nxt_conf_vldt_var(nxt_conf_validation_t *vldt, nxt_str_t *name,
     nxt_str_t *value);
 nxt_inline nxt_int_t nxt_conf_vldt_unsupported(nxt_conf_validation_t *vldt,
-    nxt_conf_value_t *value, void *data);
+    nxt_conf_value_t *value, void *data)
+    NXT_MAYBE_UNUSED;
 
 static nxt_int_t nxt_conf_vldt_mtypes(nxt_conf_validation_t *vldt,
     nxt_conf_value_t *value, void *data);


### PR DESCRIPTION
When testing some configurations of compilers and OSes, I noticed
that clang(1) 13 on Debian caused a function to be compiled but
unused, and the compiler triggered a compile error.

To avoid that error, use __attribute__((__unused__)).  Let's call
our wrapper NXT_MAYBE_UNUSED, since it describes itself more
precisely than the GCC attribute name.  It's also the name that
C2x (likely C23) has given to the standard attribute, which is
[[maybe_unused]], so it's also likely to be more readable because
of that name being in ISO C.