### PR TITLE
Supporting new "index" option.

### DIFF
--- a/docs/changes.xml
+++ b/docs/changes.xml
@@ -45,6 +45,12 @@ supporting empty strings in the "location" option of the "return" action.
 
 <change type="feature">
 <para>
+ability to specify a custom index file name when serving static files.
+</para>
+</change>
+
+<change type="feature">
+<para>
 variables support in the "location" option of the "return" action.
 </para>
 </change>

--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -650,6 +650,7 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_share_action_members[] = {
     }, {
         .name       = nxt_string("index"),
         .type       = NXT_CONF_VLDT_STRING,
+        .flags      = NXT_CONF_VLDT_VAR,
     }, {
         .name       = nxt_string("types"),
         .type       = NXT_CONF_VLDT_STRING | NXT_CONF_VLDT_ARRAY,

--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -648,6 +648,9 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_share_action_members[] = {
         .type       = NXT_CONF_VLDT_STRING | NXT_CONF_VLDT_ARRAY,
         .validator  = nxt_conf_vldt_share,
     }, {
+        .name       = nxt_string("index"),
+        .type       = NXT_CONF_VLDT_STRING,
+    }, {
         .name       = nxt_string("types"),
         .type       = NXT_CONF_VLDT_STRING | NXT_CONF_VLDT_ARRAY,
         .validator  = nxt_conf_vldt_match_patterns,

--- a/src/nxt_http.h
+++ b/src/nxt_http.h
@@ -218,6 +218,7 @@ typedef struct {
     nxt_conf_value_t                *location;
     nxt_conf_value_t                *proxy;
     nxt_conf_value_t                *share;
+    nxt_conf_value_t                *index;
     nxt_str_t                       chroot;
     nxt_conf_value_t                *follow_symlinks;
     nxt_conf_value_t                *traverse_mounts;

--- a/src/nxt_http_route.c
+++ b/src/nxt_http_route.c
@@ -611,6 +611,11 @@ static nxt_conf_map_t  nxt_http_route_action_conf[] = {
         offsetof(nxt_http_action_conf_t, share)
     },
     {
+        nxt_string("index"),
+        NXT_CONF_MAP_PTR,
+        offsetof(nxt_http_action_conf_t, index)
+    },
+    {
         nxt_string("chroot"),
         NXT_CONF_MAP_STR,
         offsetof(nxt_http_action_conf_t, chroot)

--- a/test/test_static.py
+++ b/test/test_static.py
@@ -102,6 +102,16 @@ class TestStatic(TestApplicationProto):
         set_index('')
         assert self.get()['status'] == 404, 'index empty'
 
+        set_index('${host}.html')
+        assert (
+            self.get(headers={"Host": "index", "Connection": "close"})['body']
+            == '0123456789'
+        ), 'index var'
+        assert (
+            self.get(headers={"Connection": "close"})['status']
+            == 404
+        ), 'index var empty'
+
     def test_static_index_default(self):
         assert self.get(url='/index.html')['body'] == '0123456789', 'index'
         assert self.get(url='/')['body'] == '0123456789', 'index 2'


### PR DESCRIPTION
This contains several patch sets in itself, but it's too complex for github pull requests.
The breakdown is:

<strike>
Arrays:
```
0f184fe (HEAD -> index-arr, gh/index-arr, alx/index-arr) Static: optimized "index" iteration.
e145bb3 Tests: added tests for "index" (array) option.
825982f Static: supporting multiple paths in the "index" option.
304a838 Simplified branching.
```
</strike>


Variables:
```
93371e9 (gh/index-var, alx/index-var, index-var) Tests: added tests for "index" (var) option.
a3532c9 Static: supporting variables in the "index" option.
5642e81 Generalized code.
```

Simple string:
```
2506eba (gh/index-str, alx/index-str, index-str) Tests: added tests for "index" (string) option.
53e4662 Static: supporting new "index" option.
```
Some cleanup and minor fixes before the patch set itself (already merged):
```
bc4990a (gh/ret404, alx/ret404, ret404) Static: returning 404 when "index" is a non-regular file.
1b5ce9c (gh/rename, alx/rename, rename) Renamed nxt_http_static_ctx_t field 'index' to 'share_idx'.

```