### PR TITLE
Fixed #define style

### DIFF
--- a/src/nxt_array.h
+++ b/src/nxt_array.h
@@ -35,18 +35,15 @@ NXT_EXPORT void nxt_array_remove(nxt_array_t *array, void *elt);
 NXT_EXPORT nxt_array_t *nxt_array_copy(nxt_mp_t *mp, nxt_array_t *dst,
     nxt_array_t *src);
 
-#define                                                                       \
-nxt_array_last(array)                                                         \
+#define nxt_array_last(array)                                                 \
     nxt_pointer_to((array)->elts, (array)->size * ((array)->nelts - 1))
 
 
-#define                                                                       \
-nxt_array_reset(array)                                                        \
+#define nxt_array_reset(array)                                                \
     (array)->nelts = 0;
 
 
-#define                                                                       \
-nxt_array_is_empty(array)                                                     \
+#define nxt_array_is_empty(array)                                             \
     ((array)->nelts == 0)
 
 

--- a/src/nxt_atomic.h
+++ b/src/nxt_atomic.h
@@ -26,28 +26,23 @@ typedef volatile nxt_atomic_uint_t  nxt_atomic_t;
  * __sync_lock_release() is a release barrier.
  */
 
-#define                                                                       \
-nxt_atomic_cmp_set(lock, cmp, set)                                            \
+#define nxt_atomic_cmp_set(lock, cmp, set)                                    \
     __sync_bool_compare_and_swap(lock, cmp, set)
 
 
-#define                                                                       \
-nxt_atomic_xchg(lock, set)                                                    \
+#define nxt_atomic_xchg(lock, set)                                            \
     __sync_lock_test_and_set(lock, set)
 
 
-#define                                                                       \
-nxt_atomic_fetch_add(value, add)                                              \
+#define nxt_atomic_fetch_add(value, add)                                      \
     __sync_fetch_and_add(value, add)
 
 
-#define                                                                       \
-nxt_atomic_try_lock(lock)                                                     \
+#define nxt_atomic_try_lock(lock)                                             \
     nxt_atomic_cmp_set(lock, 0, 1)
 
 
-#define                                                                       \
-nxt_atomic_release(lock)                                                      \
+#define nxt_atomic_release(lock)                                              \
     __sync_lock_release(lock)
 
 
@@ -60,13 +55,11 @@ nxt_atomic_release(lock)                                                      \
 
 
 #if (__i386__ || __i386 || __amd64__ || __amd64)
-#define                                                                       \
-nxt_cpu_pause()                                                               \
+#define nxt_cpu_pause()                                                       \
     __asm__ ("pause")
 
 #else
-#define                                                                       \
-nxt_cpu_pause()
+#define nxt_cpu_pause()
 #endif
 
 
@@ -79,18 +72,15 @@ typedef ulong_t                     nxt_atomic_uint_t;
 typedef volatile nxt_atomic_uint_t  nxt_atomic_t;
 
 
-#define                                                                       \
-nxt_atomic_cmp_set(lock, cmp, set)                                            \
+#define nxt_atomic_cmp_set(lock, cmp, set)                                    \
     (atomic_cas_ulong(lock, cmp, set) == (ulong_t) cmp)
 
 
-#define                                                                       \
-nxt_atomic_xchg(lock, set)                                                    \
+#define nxt_atomic_xchg(lock, set)                                            \
     atomic_add_swap(lock, set)
 
 
-#define                                                                       \
-nxt_atomic_fetch_add(value, add)                                              \
+#define nxt_atomic_fetch_add(value, add)                                      \
     (atomic_add_long_nv(value, add) - add)
 
 
@@ -124,13 +114,11 @@ nxt_atomic_fetch_add(value, add)                                              \
  * barrier.
  */
 
-#define                                                                       \
-nxt_atomic_try_lock(lock)                                                     \
+#define nxt_atomic_try_lock(lock)                                             \
     nxt_atomic_cmp_set(lock, 0, 1)
 
 
-#define                                                                       \
-nxt_atomic_release(lock)                                                      \
+#define nxt_atomic_release(lock)                                              \
     *lock = 0;
 
 
@@ -142,13 +130,11 @@ nxt_atomic_release(lock)                                                      \
  */
 
 #if (__i386__ || __i386 || __amd64__ || __amd64)
-#define                                                                       \
-nxt_cpu_pause()                                                               \
+#define nxt_cpu_pause()                                                       \
     __asm__ ("rep; nop")
 
 #else
-#define                                                                       \
-nxt_cpu_pause()
+#define nxt_cpu_pause()
 #endif
 
 
@@ -192,13 +178,11 @@ nxt_atomic_cmp_set(nxt_atomic_t *lock, nxt_atomic_int_t cmp,
 }
 
 
-#define                                                                       \
-nxt_atomic_xchg(lock, set)                                                    \
+#define nxt_atomic_xchg(lock, set)                                            \
     __fetch_and_swaplp(lock, set)
 
 
-#define                                                                       \
-nxt_atomic_fetch_add(value, add)                                              \
+#define nxt_atomic_fetch_add(value, add)                                      \
     __fetch_and_addlp(value, add)
 
 
@@ -221,13 +205,11 @@ nxt_atomic_cmp_set(nxt_atomic_t *lock, nxt_atomic_int_t cmp,
 }
 
 
-#define                                                                       \
-nxt_atomic_xchg(lock, set)                                                    \
+#define nxt_atomic_xchg(lock, set)                                            \
     __fetch_and_swap(lock, set)
 
 
-#define                                                                       \
-nxt_atomic_fetch_add(value, add)                                              \
+#define nxt_atomic_fetch_add(value, add)                                      \
     __fetch_and_add(value, add)
 
 
@@ -270,13 +252,11 @@ nxt_atomic_try_lock(nxt_atomic_t *lock)
 }
 
 
-#define                                                                       \
-nxt_atomic_release(lock)                                                      \
+#define nxt_atomic_release(lock)                                              \
     do { __lwsync(); *lock = 0; } while (0)
 
 
-#define                                                                       \
-nxt_cpu_pause()
+#define nxt_cpu_pause()
 
 
 #endif /* NXT_HAVE_XLC_ATOMIC */

--- a/src/nxt_buf.h
+++ b/src/nxt_buf.h
@@ -113,127 +113,100 @@ struct nxt_buf_s {
 #define NXT_BUF_SYNC_LAST   4
 
 
-#define                                                                       \
-nxt_buf_is_mem(b)                                                             \
+#define nxt_buf_is_mem(b)                                                     \
     ((b)->mem.pos != NULL)
 
 
-#define                                                                       \
-nxt_buf_is_file(b)                                                            \
+#define nxt_buf_is_file(b)                                                    \
     ((b)->is_file)
 
-#define                                                                       \
-nxt_buf_set_file(b)                                                           \
+#define nxt_buf_set_file(b)                                                   \
     (b)->is_file = 1
 
-#define                                                                       \
-nxt_buf_clear_file(b)                                                         \
+#define nxt_buf_clear_file(b)                                                 \
     (b)->is_file = 0
 
 
-#define                                                                       \
-nxt_buf_is_mmap(b)                                                            \
+#define nxt_buf_is_mmap(b)                                                    \
     ((b)->is_mmap)
 
-#define                                                                       \
-nxt_buf_set_mmap(b)                                                           \
+#define nxt_buf_set_mmap(b)                                                   \
     (b)->is_mmap = 1
 
-#define                                                                       \
-nxt_buf_clear_mmap(b)                                                         \
+#define nxt_buf_clear_mmap(b)                                                 \
     (b)->is_mmap = 0
 
 
-#define                                                                       \
-nxt_buf_is_port_mmap(b)                                                       \
+#define nxt_buf_is_port_mmap(b)                                               \
     ((b)->is_port_mmap)
 
-#define                                                                       \
-nxt_buf_set_port_mmap(b)                                                      \
+#define nxt_buf_set_port_mmap(b)                                              \
     (b)->is_port_mmap = 1
 
-#define                                                                       \
-nxt_buf_clear_port_mmap(b)                                                    \
+#define nxt_buf_clear_port_mmap(b)                                            \
     (b)->is_port_mmap = 0
 
 
-#define                                                                       \
-nxt_buf_is_sync(b)                                                            \
+#define nxt_buf_is_sync(b)                                                    \
     ((b)->is_sync)
 
-#define                                                                       \
-nxt_buf_set_sync(b)                                                           \
+#define nxt_buf_set_sync(b)                                                   \
     (b)->is_sync = 1
 
-#define                                                                       \
-nxt_buf_clear_sync(b)                                                         \
+#define nxt_buf_clear_sync(b)                                                 \
     (b)->is_sync = 0
 
 
-#define                                                                       \
-nxt_buf_is_nobuf(b)                                                           \
+#define nxt_buf_is_nobuf(b)                                                   \
     ((b)->is_nobuf)
 
-#define                                                                       \
-nxt_buf_set_nobuf(b)                                                          \
+#define nxt_buf_set_nobuf(b)                                                  \
     (b)->is_nobuf = 1
 
-#define                                                                       \
-nxt_buf_clear_nobuf(b)                                                        \
+#define nxt_buf_clear_nobuf(b)                                                \
     (b)->is_nobuf = 0
 
 
-#define                                                                       \
-nxt_buf_is_flush(b)                                                           \
+#define nxt_buf_is_flush(b)                                                   \
     ((b)->is_flush)
 
-#define                                                                       \
-nxt_buf_set_flush(b)                                                          \
+#define nxt_buf_set_flush(b)                                                  \
     (b)->is_flush = 1
 
-#define                                                                       \
-nxt_buf_clear_flush(b)                                                        \
+#define nxt_buf_clear_flush(b)                                                \
     (b)->is_flush = 0
 
 
-#define                                                                       \
-nxt_buf_is_last(b)                                                            \
+#define nxt_buf_is_last(b)                                                    \
     ((b)->is_last)
 
-#define                                                                       \
-nxt_buf_set_last(b)                                                           \
+#define nxt_buf_set_last(b)                                                   \
     (b)->is_last = 1
 
-#define                                                                       \
-nxt_buf_clear_last(b)                                                         \
+#define nxt_buf_clear_last(b)                                                 \
     (b)->is_last = 0
 
 
-#define                                                                       \
-nxt_buf_mem_set_size(bm, size)                                                \
+#define nxt_buf_mem_set_size(bm, size)                                        \
     do {                                                                      \
         (bm)->start = 0;                                                      \
         (bm)->end = (void *) size;                                            \
     } while (0)
 
 
-#define                                                                       \
-nxt_buf_mem_size(bm)                                                          \
+#define nxt_buf_mem_size(bm)                                                  \
     ((bm)->end - (bm)->start)
 
 
-#define                                                                       \
-nxt_buf_mem_used_size(bm)                                                     \
+#define nxt_buf_mem_used_size(bm)                                             \
     ((bm)->free - (bm)->pos)
 
 
-#define                                                                       \
-nxt_buf_mem_free_size(bm)                                                     \
+#define nxt_buf_mem_free_size(bm)                                             \
     ((bm)->end - (bm)->free)
 
 
-#define                                                                       \
-nxt_buf_used_size(b)                                                          \
+#define nxt_buf_used_size(b)                                                  \
     (nxt_buf_is_file(b) ? (b)->file_end - (b)->file_pos:                      \
                           nxt_buf_mem_used_size(&(b)->mem))
 
@@ -264,8 +237,7 @@ nxt_buf_chk_make_plain(nxt_mp_t *mp, nxt_buf_t *src, size_t size)
     return src;
 }
 
-#define                                                                       \
-nxt_buf_free(mp, b)                                                           \
+#define nxt_buf_free(mp, b)                                                   \
     nxt_mp_free((mp), (b))
 
 

--- a/src/nxt_buf_pool.h
+++ b/src/nxt_buf_pool.h
@@ -42,8 +42,7 @@ NXT_EXPORT void nxt_buf_pool_destroy(nxt_buf_pool_t *bp);
 
 /* There is ready free buffer. */
 
-#define                                                                       \
-nxt_buf_pool_ready(bp)                                                        \
+#define nxt_buf_pool_ready(bp)                                                \
     ((bp)->free != NULL                                                       \
      || ((bp)->current != NULL                                                \
          && (bp)->current->mem.free < (bp)->current->mem.end))
@@ -51,29 +50,25 @@ nxt_buf_pool_ready(bp)                                                        \
 
 /* A free buffer is allowed to be allocated. */
 
-#define                                                                       \
-nxt_buf_pool_obtainable(bp)                                                   \
+#define nxt_buf_pool_obtainable(bp)                                           \
     ((bp)->num < (bp)->max)
 
 
 /* There is ready free buffer or it is allowed to be allocated. */
 
-#define                                                                       \
-nxt_buf_pool_available(bp)                                                    \
+#define nxt_buf_pool_available(bp)                                            \
     (nxt_buf_pool_obtainable(bp) || nxt_buf_pool_ready(bp))
 
 
 /* Reserve allocation of "n" free buffers as they were allocated. */
 
-#define                                                                       \
-nxt_buf_pool_reserve(bp, n)                                                   \
+#define nxt_buf_pool_reserve(bp, n)                                           \
     (bp)->num += (n)
 
 
 /* Release a reservation. */
 
-#define                                                                       \
-nxt_buf_pool_release(bp, n)                                                   \
+#define nxt_buf_pool_release(bp, n)                                           \
     (bp)->num -= (n)
 
 

--- a/src/nxt_cache.c
+++ b/src/nxt_cache.c
@@ -8,8 +8,7 @@
 
 
 /* A cache time resolution is 10ms. */
-#define                                                                       \
-nxt_cache_time(thr)                                                           \
+#define nxt_cache_time(thr)                                                   \
     (uint64_t) (nxt_thread_time(thr) * 100)
 
 

--- a/src/nxt_clang.h
+++ b/src/nxt_clang.h
@@ -16,45 +16,37 @@
 #if (NXT_CLANG)
 
 /* Any __asm__ directive disables loop vectorization in GCC and Clang. */
-#define                                                                       \
-nxt_pragma_loop_disable_vectorization                                         \
+#define nxt_pragma_loop_disable_vectorization                                 \
     __asm__("")
 
 #else
 
-#define                                                                       \
-nxt_pragma_loop_disable_vectorization
+#define nxt_pragma_loop_disable_vectorization
 
 #endif
 
 
 #if (NXT_HAVE_BUILTIN_EXPECT)
 
-#define                                                                       \
-nxt_expect(c, x)                                                              \
+#define nxt_expect(c, x)                                                      \
     __builtin_expect((long) (x), (c))
 
-#define                                                                       \
-nxt_fast_path(x)                                                              \
+#define nxt_fast_path(x)                                                      \
     nxt_expect(1, x)
 
-#define                                                                       \
-nxt_slow_path(x)                                                              \
+#define nxt_slow_path(x)                                                      \
     nxt_expect(0, x)
 
 
 #else
 
-#define                                                                       \
-nxt_expect(c, x)                                                              \
+#define nxt_expect(c, x)                                                      \
     (x)
 
-#define                                                                       \
-nxt_fast_path(x)                                                              \
+#define nxt_fast_path(x)                                                      \
     (x)
 
-#define                                                                       \
-nxt_slow_path(x)                                                              \
+#define nxt_slow_path(x)                                                      \
     (x)
 
 #endif
@@ -62,28 +54,24 @@ nxt_slow_path(x)                                                              \
 
 #if (NXT_HAVE_BUILTIN_UNREACHABLE)
 
-#define                                                                       \
-nxt_unreachable()                                                             \
+#define nxt_unreachable()                                                     \
     __builtin_unreachable()
 
 #else
 
-#define                                                                       \
-nxt_unreachable()
+#define nxt_unreachable()
 
 #endif
 
 
 #if (NXT_HAVE_BUILTIN_PREFETCH)
 
-#define                                                                       \
-nxt_prefetch(a)                                                               \
+#define nxt_prefetch(a)                                                       \
     __builtin_prefetch(a)
 
 #else
 
-#define                                                                       \
-nxt_prefetch(a)
+#define nxt_prefetch(a)
 
 #endif
 
@@ -206,13 +194,11 @@ nxt_popcount(unsigned int x)
 #endif
 
 
-#define                                                                       \
-nxt_alloca(size)                                                              \
+#define nxt_alloca(size)                                                      \
     alloca(size)
 
 
-#define                                                                       \
-nxt_container_of(p, type, field)                                              \
+#define nxt_container_of(p, type, field)                                      \
     (type *) ((u_char *) (p) - offsetof(type, field))
 
 
@@ -224,30 +210,25 @@ nxt_container_of(p, type, field)                                              \
     *(type *) ((u_char *) p + offset)
 
 
-#define                                                                       \
-nxt_nitems(x)                                                                 \
+#define nxt_nitems(x)                                                         \
     (sizeof(x) / sizeof((x)[0]))
 
 
 /* GCC and Clang use __builtin_abs() instead of libc abs(). */
 
-#define                                                                       \
-nxt_abs(val)                                                                  \
+#define nxt_abs(val)                                                          \
     abs(val)
 
 
-#define                                                                       \
-nxt_max(val1, val2)                                                           \
+#define nxt_max(val1, val2)                                                   \
     ((val1 < val2) ? (val2) : (val1))
 
 
-#define                                                                       \
-nxt_min(val1, val2)                                                           \
+#define nxt_min(val1, val2)                                                   \
     ((val1 > val2) ? (val2) : (val1))
 
 
-#define                                                                       \
-nxt_bswap32(val)                                                              \
+#define nxt_bswap32(val)                                                      \
     (   ((val)               >> 24)                                           \
      | (((val) & 0x00FF0000) >>  8)                                           \
      | (((val) & 0x0000FF00) <<  8)                                           \
@@ -258,18 +239,15 @@ nxt_bswap32(val)                                                              \
     ((((value) - 1) & (value)) == 0)
 
 
-#define                                                                       \
-nxt_align_size(d, a)                                                          \
+#define nxt_align_size(d, a)                                                  \
     (((d) + ((size_t) (a) - 1)) & ~((size_t) (a) - 1))
 
 
-#define                                                                       \
-nxt_align_ptr(p, a)                                                           \
+#define nxt_align_ptr(p, a)                                                   \
     (u_char *) (((uintptr_t) (p) + ((uintptr_t) (a) - 1))                     \
                   & ~((uintptr_t) (a) - 1))
 
-#define                                                                       \
-nxt_trunc_ptr(p, a)                                                           \
+#define nxt_trunc_ptr(p, a)                                                   \
     (u_char *) ((uintptr_t) (p) & ~((uintptr_t) (a) - 1))
 
 

--- a/src/nxt_djb_hash.h
+++ b/src/nxt_djb_hash.h
@@ -18,8 +18,7 @@ NXT_EXPORT uint32_t nxt_djb_hash_lowcase(const void *data, size_t len);
 #define NXT_DJB_HASH_INIT  5381
 
 
-#define                                                                       \
-nxt_djb_hash_add(hash, val)                                                   \
+#define nxt_djb_hash_add(hash, val)                                           \
     ((uint32_t) ((((hash) << 5) + (hash)) ^ (uint32_t) (val)))
 
 

--- a/src/nxt_dyld.h
+++ b/src/nxt_dyld.h
@@ -17,8 +17,7 @@ typedef struct {
 #define NXT_DYLD_ANY  RTLD_DEFAULT
 
 
-#define                                                                       \
-nxt_dyld_is_valid(dyld)                                                       \
+#define nxt_dyld_is_valid(dyld)                                               \
     ((dyld)->handle != NULL)
 
 

--- a/src/nxt_errno.h
+++ b/src/nxt_errno.h
@@ -65,20 +65,16 @@ typedef int                        nxt_err_t;
 #define NXT_DONE                   (-4)
 
 
-#define                                                                       \
-nxt_errno                                                                     \
+#define nxt_errno                                                             \
     errno
 
-#define                                                                       \
-nxt_socket_errno                                                              \
+#define nxt_socket_errno                                                      \
     errno
 
-#define                                                                       \
-nxt_set_errno(err)                                                            \
+#define nxt_set_errno(err)                                                    \
     errno = err
 
-#define                                                                       \
-nxt_set_socket_errno(err)                                                     \
+#define nxt_set_socket_errno(err)                                             \
     errno = err
 
 

--- a/src/nxt_event_engine.h
+++ b/src/nxt_event_engine.h
@@ -351,43 +351,35 @@ void nxt_fd_event_hash_delete(nxt_task_t *task, nxt_lvlhsh_t *lvlhsh,
 void nxt_fd_event_hash_destroy(nxt_lvlhsh_t *lvlhsh);
 
 
-#define                                                                       \
-nxt_fd_event_disable(engine, ev)                                              \
+#define nxt_fd_event_disable(engine, ev)                                      \
     (engine)->event.disable(engine, ev)
 
 
-#define                                                                       \
-nxt_fd_event_delete(engine, ev)                                               \
+#define nxt_fd_event_delete(engine, ev)                                       \
     (engine)->event.delete(engine, ev)
 
 
-#define                                                                       \
-nxt_fd_event_close(engine, ev)                                                \
+#define nxt_fd_event_close(engine, ev)                                        \
     (engine)->event.close(engine, ev)
 
 
-#define                                                                       \
-nxt_fd_event_enable_read(engine, ev)                                          \
+#define nxt_fd_event_enable_read(engine, ev)                                  \
     (engine)->event.enable_read(engine, ev)
 
 
-#define                                                                       \
-nxt_fd_event_enable_write(engine, ev)                                         \
+#define nxt_fd_event_enable_write(engine, ev)                                 \
     (engine)->event.enable_write(engine, ev)
 
 
-#define                                                                       \
-nxt_fd_event_disable_read(engine, ev)                                         \
+#define nxt_fd_event_disable_read(engine, ev)                                 \
     (engine)->event.disable_read(engine, ev)
 
 
-#define                                                                       \
-nxt_fd_event_disable_write(engine, ev)                                        \
+#define nxt_fd_event_disable_write(engine, ev)                                \
     (engine)->event.disable_write(engine, ev)
 
 
-#define                                                                       \
-nxt_fd_event_block_read(engine, ev)                                           \
+#define nxt_fd_event_block_read(engine, ev)                                   \
     do {                                                                      \
         if (nxt_fd_event_is_active((ev)->read)) {                             \
             (engine)->event.block_read(engine, ev);                           \
@@ -395,8 +387,7 @@ nxt_fd_event_block_read(engine, ev)                                           \
     } while (0)
 
 
-#define                                                                       \
-nxt_fd_event_block_write(engine, ev)                                          \
+#define nxt_fd_event_block_write(engine, ev)                                  \
     do {                                                                      \
         if (nxt_fd_event_is_active((ev)->write)) {                            \
             (engine)->event.block_write(engine, ev);                          \
@@ -404,18 +395,15 @@ nxt_fd_event_block_write(engine, ev)                                          \
     } while (0)
 
 
-#define                                                                       \
-nxt_fd_event_oneshot_read(engine, ev)                                         \
+#define nxt_fd_event_oneshot_read(engine, ev)                                 \
     (engine)->event.oneshot_read(engine, ev)
 
 
-#define                                                                       \
-nxt_fd_event_oneshot_write(engine, ev)                                        \
+#define nxt_fd_event_oneshot_write(engine, ev)                                \
     (engine)->event.oneshot_write(engine, ev)
 
 
-#define                                                                       \
-nxt_fd_event_enable_accept(engine, ev)                                        \
+#define nxt_fd_event_enable_accept(engine, ev)                                \
     (engine)->event.enable_accept(engine, ev)
 
 

--- a/src/nxt_fastcgi_source.c
+++ b/src/nxt_fastcgi_source.c
@@ -18,8 +18,7 @@ typedef struct {
 } nxt_fastcgi_param_t;
 
 
-#define                                                                       \
-nxt_fastcgi_set_record_length(p, length)                                      \
+#define nxt_fastcgi_set_record_length(p, length)                              \
     do {                                                                      \
         uint32_t  len = length;                                               \
                                                                               \

--- a/src/nxt_fd_event.h
+++ b/src/nxt_fd_event.h
@@ -44,13 +44,11 @@ typedef enum {
 } nxt_fd_event_state_t;
 
 
-#define                                                                       \
-nxt_fd_event_is_disabled(state)                                               \
+#define nxt_fd_event_is_disabled(state)                                       \
     ((state) < NXT_EVENT_ONESHOT)
 
 
-#define                                                                       \
-nxt_fd_event_is_active(state)                                                 \
+#define nxt_fd_event_is_active(state)                                         \
     ((state) >= NXT_EVENT_ONESHOT)
 
 

--- a/src/nxt_fiber.c
+++ b/src/nxt_fiber.c
@@ -14,8 +14,7 @@ static void nxt_fiber_switch(nxt_task_t *task, nxt_fiber_t *fib);
 static void nxt_fiber_timer_handler(nxt_task_t *task, void *obj, void *data);
 
 
-#define                                                                       \
-nxt_fiber_enqueue(thr, task, fib)                                             \
+#define nxt_fiber_enqueue(thr, task, fib)                                     \
     nxt_work_queue_add(&(thr)->engine->fast_work_queue,                       \
                               nxt_fiber_switch_handler, task, fib, NULL)
 

--- a/src/nxt_file.h
+++ b/src/nxt_file.h
@@ -27,23 +27,19 @@ typedef struct {
 } nxt_file_name_str_t;
 
 
-#define                                                                       \
-nxt_file_name_str_set(file_name, mem_pool, name)                              \
+#define nxt_file_name_str_set(file_name, mem_pool, name)                      \
     ((file_name) = (nxt_file_name_t *) (name), NXT_OK)
 
 
-#define                                                                       \
-nxt_file_name_alloc(mem_pool, len)                                            \
+#define nxt_file_name_alloc(mem_pool, len)                                    \
     nxt_mp_nget(mem_pool, len)
 
 
-#define                                                                       \
-nxt_file_name_copy(dst, src, len)                                             \
+#define nxt_file_name_copy(dst, src, len)                                     \
     nxt_cpymem(dst, src, len)
 
 
-#define                                                                       \
-nxt_file_name_add(dst, src, len)                                              \
+#define nxt_file_name_add(dst, src, len)                                      \
     nxt_cpymem(dst, src, len)
 
 
@@ -51,21 +47,18 @@ nxt_file_name_add(dst, src, len)                                              \
 
 /* MacOSX, Cygwin. */
 
-#define                                                                       \
-nxt_file_name_eq(fn1, fn2)                                                    \
+#define nxt_file_name_eq(fn1, fn2)                                            \
     (nxt_strcasecmp(fn1, fn2) == 0)
 
 #else
 
-#define                                                                       \
-nxt_file_name_eq(fn1, fn2)                                                    \
+#define nxt_file_name_eq(fn1, fn2)                                            \
     (nxt_strcmp(fn1, fn2) == 0)
 
 #endif
 
 
-#define                                                                       \
-nxt_file_name_is_absolute(name)                                               \
+#define nxt_file_name_is_absolute(name)                                       \
     (name[0] == '/')
 
 
@@ -168,20 +161,16 @@ NXT_EXPORT void nxt_file_read_ahead(nxt_file_t *file, nxt_off_t offset,
 NXT_EXPORT nxt_int_t nxt_file_info(nxt_file_t *file, nxt_file_info_t *fi);
 
 
-#define                                                                       \
-nxt_is_dir(fi)                                                                \
+#define nxt_is_dir(fi)                                                        \
     (S_ISDIR((fi)->st_mode))
 
-#define                                                                       \
-nxt_is_file(fi)                                                               \
+#define nxt_is_file(fi)                                                       \
     (S_ISREG((fi)->st_mode))
 
-#define                                                                       \
-nxt_file_size(fi)                                                             \
+#define nxt_file_size(fi)                                                     \
     (fi)->st_size
 
-#define                                                                       \
-nxt_file_mtime(fi)                                                            \
+#define nxt_file_mtime(fi)                                                    \
     (fi)->st_mtime
 
 
@@ -206,12 +195,10 @@ NXT_EXPORT nxt_int_t nxt_stderr_start(void);
 #define nxt_stderr  STDERR_FILENO
 
 
-#define                                                                       \
-nxt_write_console(fd, buf, size)                                              \
+#define nxt_write_console(fd, buf, size)                                      \
     write(fd, buf, size)
 
-#define                                                                       \
-nxt_write_syslog(priority, message)                                           \
+#define nxt_write_syslog(priority, message)                                   \
     syslog(priority, "%s", message)
 
 

--- a/src/nxt_http_chunk_parse.c
+++ b/src/nxt_http_chunk_parse.c
@@ -12,8 +12,7 @@
 #define NXT_HTTP_CHUNK_END            2
 
 
-#define                                                                       \
-nxt_size_is_sufficient(cs)                                                    \
+#define nxt_size_is_sufficient(cs)                                            \
     (cs < ((__typeof__(cs)) 1 << (sizeof(cs) * 8 - 4)))
 
 

--- a/src/nxt_http_parse.c
+++ b/src/nxt_http_parse.c
@@ -827,8 +827,7 @@ nxt_http_parse_field_end(nxt_http_request_parse_t *rp, u_char **pos,
 }
 
 
-#define                                                                       \
-nxt_http_is_normal(c)                                                         \
+#define nxt_http_is_normal(c)                                                 \
     (nxt_fast_path((nxt_http_normal[c / 8] & (1 << (c & 7))) != 0))
 
 

--- a/src/nxt_job.h
+++ b/src/nxt_job.h
@@ -67,21 +67,18 @@ NXT_EXPORT void nxt_job_return(nxt_task_t *task, nxt_job_t *job,
     nxt_work_handler_t handler);
 
 
-#define                                                                       \
-nxt_job_cancel(job)                                                           \
+#define nxt_job_cancel(job)                                                   \
     (job)->cancel = 1
 
 
 #if (NXT_DEBUG)
 
-#define                                                                       \
-nxt_job_set_name(job, text)                                                   \
+#define nxt_job_set_name(job, text)                                           \
     (job)->name = text
 
 #else
 
-#define                                                                       \
-nxt_job_set_name(job, text)
+#define nxt_job_set_name(job, text)
 
 #endif
 

--- a/src/nxt_list.h
+++ b/src/nxt_list.h
@@ -37,18 +37,15 @@ typedef struct {
 } nxt_list_next_t;
 
 
-#define                                                                       \
-nxt_list_part(list)                                                           \
+#define nxt_list_part(list)                                                   \
     (&(list)->part)
 
 
-#define                                                                       \
-nxt_list_data(part)                                                           \
+#define nxt_list_data(part)                                                   \
     ((void *) part->data)
 
 
-#define                                                                       \
-nxt_list_first(list)                                                          \
+#define nxt_list_first(list)                                                  \
     nxt_list_data(nxt_list_part(list))
 
 
@@ -102,8 +99,7 @@ NXT_EXPORT void *nxt_list_zero_add(nxt_list_t *list);
 NXT_EXPORT void *nxt_list_next(nxt_list_t *list, nxt_list_next_t *next);
 
 
-#define                                                                       \
-nxt_list_next_value(list, next)                                               \
+#define nxt_list_next_value(list, next)                                       \
     (nxt_pointer_to(nxt_list_data((next)->part), (next)->elt * (list)->size))
 
 

--- a/src/nxt_log.h
+++ b/src/nxt_log.h
@@ -41,8 +41,7 @@ NXT_EXPORT void nxt_cdecl nxt_log_handler(nxt_uint_t level, nxt_log_t *log,
     const char *fmt, ...);
 
 
-#define                                                                       \
-nxt_log_level_enough(log, level)                                              \
+#define nxt_log_level_enough(log, level)                                      \
     ((log)->level >= (level))
 
 
@@ -83,8 +82,7 @@ nxt_log_level_enough(log, level)                                              \
     } while (0)
 
 
-#define                                                                       \
-nxt_log_error(_level, _log, ...)                                              \
+#define nxt_log_error(_level, _log, ...)                                      \
     do {                                                                      \
         nxt_log_t   *_log_ = (_log);                                          \
         nxt_uint_t  _level_ = (_level);                                       \
@@ -107,8 +105,7 @@ nxt_log_error(_level, _log, ...)                                              \
     } while (0)
 
 
-#define                                                                       \
-nxt_log_debug(_log, ...)                                                      \
+#define nxt_log_debug(_log, ...)                                              \
     do {                                                                      \
         nxt_log_t  *_log_ = (_log);                                           \
                                                                               \
@@ -131,8 +128,7 @@ nxt_log_debug(_log, ...)                                                      \
 
 #define nxt_debug(...)
 
-#define                                                                       \
-nxt_log_debug(...)
+#define nxt_log_debug(...)
 
 #define nxt_assert(c)
 
@@ -151,18 +147,15 @@ nxt_log_debug(...)
 #endif
 
 
-#define                                                                       \
-nxt_main_log_alert(...)                                                       \
+#define nxt_main_log_alert(...)                                               \
     nxt_log_alert(&nxt_main_log, __VA_ARGS__)
 
 
-#define                                                                       \
-nxt_main_log_error(level, ...)                                                \
+#define nxt_main_log_error(level, ...)                                        \
     nxt_log_error(level, &nxt_main_log, __VA_ARGS__)
 
 
-#define                                                                       \
-nxt_main_log_debug(...)                                                       \
+#define nxt_main_log_debug(...)                                               \
     nxt_log_debug(&nxt_main_log, __VA_ARGS__)
 
 

--- a/src/nxt_log_moderation.h
+++ b/src/nxt_log_moderation.h
@@ -23,8 +23,7 @@ typedef struct {
 #define NXT_LOG_MODERATION  0, -1, 0, 0, NXT_TIMER
 
 
-#define                                                                       \
-nxt_log_alert_moderate(_mod, _log, ...)                                       \
+#define nxt_log_alert_moderate(_mod, _log, ...)                               \
     do {                                                                      \
         nxt_log_t  *_log_ = _log;                                             \
                                                                               \
@@ -34,8 +33,7 @@ nxt_log_alert_moderate(_mod, _log, ...)                                       \
     } while (0)
 
 
-#define                                                                       \
-nxt_log_moderate(_mod, _level, _log, ...)                                     \
+#define nxt_log_moderate(_mod, _level, _log, ...)                             \
     do {                                                                      \
         nxt_log_t  *_log_ = _log;                                             \
                                                                               \

--- a/src/nxt_lvlhsh.c
+++ b/src/nxt_lvlhsh.c
@@ -43,121 +43,98 @@
  * several levels.
  */
 
-#define                                                                       \
-nxt_lvlhsh_is_bucket(p)                                                       \
+#define nxt_lvlhsh_is_bucket(p)                                               \
     ((uintptr_t) (p) & 1)
 
 
-#define                                                                       \
-nxt_lvlhsh_count_inc(n)                                                       \
+#define nxt_lvlhsh_count_inc(n)                                               \
     n = (void *) ((uintptr_t) (n) + 2)
 
 
-#define                                                                       \
-nxt_lvlhsh_count_dec(n)                                                       \
+#define nxt_lvlhsh_count_dec(n)                                               \
     n = (void *) ((uintptr_t) (n) - 2)
 
 
-#define                                                                       \
-nxt_lvlhsh_level_size(proto, nlvl)                                            \
+#define nxt_lvlhsh_level_size(proto, nlvl)                                    \
     ((uintptr_t) 1 << proto->shift[nlvl])
 
 
-#define                                                                       \
-nxt_lvlhsh_level(lvl, mask)                                                   \
+#define nxt_lvlhsh_level(lvl, mask)                                           \
     (void **) ((uintptr_t) lvl & (~mask << 2))
 
 
-#define                                                                       \
-nxt_lvlhsh_level_entries(lvl, mask)                                           \
+#define nxt_lvlhsh_level_entries(lvl, mask)                                   \
     ((uintptr_t) lvl & (mask << 1))
 
 
-#define                                                                       \
-nxt_lvlhsh_store_bucket(slot, bkt)                                            \
+#define nxt_lvlhsh_store_bucket(slot, bkt)                                    \
     slot = (void **) ((uintptr_t) bkt | 2 | 1)
 
 
-#define                                                                       \
-nxt_lvlhsh_bucket_size(proto)                                                 \
+#define nxt_lvlhsh_bucket_size(proto)                                         \
     proto->bucket_size
 
 
-#define                                                                       \
-nxt_lvlhsh_bucket(proto, bkt)                                                 \
+#define nxt_lvlhsh_bucket(proto, bkt)                                         \
     (uint32_t *) ((uintptr_t) bkt & ~(uintptr_t) proto->bucket_mask)
 
 
-#define                                                                       \
-nxt_lvlhsh_bucket_entries(proto, bkt)                                         \
+#define nxt_lvlhsh_bucket_entries(proto, bkt)                                 \
     (((uintptr_t) bkt & (uintptr_t) proto->bucket_mask) >> 1)
 
 
-#define                                                                       \
-nxt_lvlhsh_bucket_end(proto, bkt)                                             \
+#define nxt_lvlhsh_bucket_end(proto, bkt)                                     \
     &bkt[proto->bucket_end]
 
 
-#define                                                                       \
-nxt_lvlhsh_free_entry(e)                                                      \
+#define nxt_lvlhsh_free_entry(e)                                              \
     (!(nxt_lvlhsh_valid_entry(e)))
 
 
-#define                                                                       \
-nxt_lvlhsh_next_bucket(proto, bkt)                                            \
+#define nxt_lvlhsh_next_bucket(proto, bkt)                                    \
     ((void **) &bkt[proto->bucket_end])
 
 #if (NXT_64BIT)
 
-#define                                                                       \
-nxt_lvlhsh_valid_entry(e)                                                     \
+#define nxt_lvlhsh_valid_entry(e)                                             \
     (((e)[0] | (e)[1]) != 0)
 
 
-#define                                                                       \
-nxt_lvlhsh_entry_value(e)                                                     \
+#define nxt_lvlhsh_entry_value(e)                                             \
     (void *) (((uintptr_t) (e)[1] << 32) + (e)[0])
 
 
-#define                                                                       \
-nxt_lvlhsh_set_entry_value(e, n)                                              \
+#define nxt_lvlhsh_set_entry_value(e, n)                                      \
     (e)[0] = (uint32_t)  (uintptr_t) n;                                       \
     (e)[1] = (uint32_t) ((uintptr_t) n >> 32)
 
 
-#define                                                                       \
-nxt_lvlhsh_entry_key(e)                                                       \
+#define nxt_lvlhsh_entry_key(e)                                               \
     (e)[2]
 
 
-#define                                                                       \
-nxt_lvlhsh_set_entry_key(e, n)                                                \
+#define nxt_lvlhsh_set_entry_key(e, n)                                        \
     (e)[2] = n
 
 #else
 
-#define                                                                       \
-nxt_lvlhsh_valid_entry(e)                                                     \
+#define nxt_lvlhsh_valid_entry(e)                                             \
     ((e)[0] != 0)
 
 
-#define                                                                       \
-nxt_lvlhsh_entry_value(e)                                                     \
+#define nxt_lvlhsh_entry_value(e)                                             \
     (void *) (e)[0]
 
 
-#define                                                                       \
-nxt_lvlhsh_set_entry_value(e, n)                                              \
+#define nxt_lvlhsh_set_entry_value(e, n)                                      \
     (e)[0] = (uint32_t) n
 
 
-#define                                                                       \
-nxt_lvlhsh_entry_key(e)                                                       \
+#define nxt_lvlhsh_entry_key(e)                                               \
     (e)[1]
 
 
-#define                                                                       \
-nxt_lvlhsh_set_entry_key(e, n)                                                \
+#define nxt_lvlhsh_set_entry_key(e, n)                                        \
     (e)[1] = n
 
 #endif

--- a/src/nxt_lvlhsh.h
+++ b/src/nxt_lvlhsh.h
@@ -114,13 +114,11 @@ typedef struct {
 } nxt_lvlhsh_each_t;
 
 
-#define                                                                       \
-nxt_lvlhsh_is_empty(lh)                                                       \
+#define nxt_lvlhsh_is_empty(lh)                                               \
     ((lh)->slot == NULL)
 
 
-#define                                                                       \
-nxt_lvlhsh_init(lh)                                                           \
+#define nxt_lvlhsh_init(lh)                                                   \
     (lh)->slot = NULL
 
 /*

--- a/src/nxt_malloc.h
+++ b/src/nxt_malloc.h
@@ -24,8 +24,7 @@ NXT_EXPORT void nxt_free(void *p);
 
 #else
 
-#define                                                                       \
-nxt_free(p)                                                                   \
+#define nxt_free(p)                                                           \
     free(p)
 
 #endif
@@ -54,12 +53,10 @@ nxt_free(p)                                                                   \
  * Glibc malloc_usable_size() is fast operation.
  */
 
-#define                                                                       \
-nxt_malloc_usable_size(p, size)                                               \
+#define nxt_malloc_usable_size(p, size)                                       \
     size = malloc_usable_size(p)
 
-#define                                                                       \
-nxt_malloc_cutback(cutback, size)                                             \
+#define nxt_malloc_cutback(cutback, size)                                     \
     size = ((cutback) && size > 127 * 1024) ? size - 32 : size
 
 #elif (NXT_FREEBSD)
@@ -81,12 +78,10 @@ nxt_malloc_cutback(cutback, size)                                             \
  * are lesser than 1M.  Larger allocations require mutex acquiring.
  */
 
-#define                                                                       \
-nxt_malloc_usable_size(p, size)                                               \
+#define nxt_malloc_usable_size(p, size)                                       \
     size = malloc_usable_size(p)
 
-#define                                                                       \
-nxt_malloc_cutback(cutback, size)
+#define nxt_malloc_cutback(cutback, size)
 
 #endif
 
@@ -103,20 +98,16 @@ nxt_malloc_cutback(cutback, size)
  * malloc_good_size() is faster than malloc_size()
  */
 
-#define                                                                       \
-nxt_malloc_usable_size(p, size)                                               \
+#define nxt_malloc_usable_size(p, size)                                       \
     size = malloc_good_size(size)
 
-#define                                                                       \
-nxt_malloc_cutback(cutback, size)
+#define nxt_malloc_cutback(cutback, size)
 
 #else
 
-#define                                                                       \
-nxt_malloc_usable_size(p, size)
+#define nxt_malloc_usable_size(p, size)
 
-#define                                                                       \
-nxt_malloc_cutback(cutback, size)
+#define nxt_malloc_cutback(cutback, size)
 
 #endif
 

--- a/src/nxt_mem_map.h
+++ b/src/nxt_mem_map.h
@@ -43,17 +43,14 @@
 #define NXT_MEM_MAP_FILE      (MAP_SHARED | NXT_MEM_MAP_PREFAULT)
 
 
-#define                                                                       \
-    nxt_mem_map_file_ctx_t(ctx)
+#define     nxt_mem_map_file_ctx_t(ctx)
 
 
-#define                                                                       \
-nxt_mem_map(addr, ctx, len, protection, flags, fd, offset)                    \
+#define nxt_mem_map(addr, ctx, len, protection, flags, fd, offset)            \
     nxt_mem_mmap(addr, len, protection, flags, fd, offset)
 
 
-#define                                                                       \
-nxt_mem_unmap(addr, ctx, len)                                                 \
+#define nxt_mem_unmap(addr, ctx, len)                                         \
     nxt_mem_munmap(addr, len)
 
 

--- a/src/nxt_mem_zone.c
+++ b/src/nxt_mem_zone.c
@@ -87,48 +87,39 @@ struct nxt_mem_zone_s {
 };
 
 
-#define                                                                       \
-nxt_mem_zone_page_addr(zone, page)                                            \
+#define nxt_mem_zone_page_addr(zone, page)                                    \
     (void *) (zone->start + ((page - zone->pages) << zone->page_size_shift))
 
 
-#define                                                                       \
-nxt_mem_zone_addr_page(zone, addr)                                            \
+#define nxt_mem_zone_addr_page(zone, addr)                                    \
     &zone->pages[((u_char *) addr - zone->start) >> zone->page_size_shift]
 
 
-#define                                                                       \
-nxt_mem_zone_page_is_free(page)                                               \
+#define nxt_mem_zone_page_is_free(page)                                       \
     (page->size < NXT_MEM_ZONE_PAGE_USED)
 
 
-#define                                                                       \
-nxt_mem_zone_page_is_chunked(page)                                            \
+#define nxt_mem_zone_page_is_chunked(page)                                    \
     (page->size >= 16)
 
 
-#define                                                                       \
-nxt_mem_zone_page_bitmap(zone, slot)                                          \
+#define nxt_mem_zone_page_bitmap(zone, slot)                                  \
     (slot->size < zone->small_bitmap_min_size)
 
 
-#define                                                                       \
-nxt_mem_zone_set_chunk_free(map, chunk)                                       \
+#define nxt_mem_zone_set_chunk_free(map, chunk)                               \
     map[chunk / 8] &= ~(0x80 >> (chunk & 7))
 
 
-#define                                                                       \
-nxt_mem_zone_chunk_is_free(map, chunk)                                        \
+#define nxt_mem_zone_chunk_is_free(map, chunk)                                \
     ((map[chunk / 8] & (0x80 >> (chunk & 7))) == 0)
 
 
-#define                                                                       \
-nxt_mem_zone_fresh_junk(p, size)                                              \
+#define nxt_mem_zone_fresh_junk(p, size)                                      \
     nxt_memset((p), 0xA5, size)
 
 
-#define                                                                       \
-nxt_mem_zone_free_junk(p, size)                                               \
+#define nxt_mem_zone_free_junk(p, size)                                       \
     nxt_memset((p), 0x5A, size)
 
 

--- a/src/nxt_mem_zone.h
+++ b/src/nxt_mem_zone.h
@@ -14,8 +14,7 @@ typedef struct nxt_mem_zone_s  nxt_mem_zone_t;
 NXT_EXPORT nxt_mem_zone_t *nxt_mem_zone_init(u_char *start, size_t zone_size,
     nxt_uint_t page_size);
 
-#define                                                                       \
-nxt_mem_zone_alloc(zone, size)                                                \
+#define nxt_mem_zone_alloc(zone, size)                                        \
     nxt_mem_zone_align((zone), 1, (size))
 
 NXT_EXPORT void *nxt_mem_zone_align(nxt_mem_zone_t *zone, size_t alignment,

--- a/src/nxt_queue.h
+++ b/src/nxt_queue.h
@@ -21,16 +21,14 @@ typedef struct {
 } nxt_queue_t;
 
 
-#define                                                                       \
-nxt_queue_init(queue)                                                         \
+#define nxt_queue_init(queue)                                                 \
     do {                                                                      \
         (queue)->head.prev = &(queue)->head;                                  \
         (queue)->head.next = &(queue)->head;                                  \
     } while (0)
 
 
-#define                                                                       \
-nxt_queue_sentinel(link)                                                      \
+#define nxt_queue_sentinel(link)                                              \
     do {                                                                      \
         (link)->prev = (link);                                                \
         (link)->next = (link);                                                \
@@ -42,13 +40,11 @@ nxt_queue_sentinel(link)                                                      \
  * using nxt_queue_remove().
  */
 
-#define                                                                       \
-nxt_queue_self(link)                                                          \
+#define nxt_queue_self(link)                                                  \
     nxt_queue_sentinel(link)
 
 
-#define                                                                       \
-nxt_queue_is_empty(queue)                                                     \
+#define nxt_queue_is_empty(queue)                                             \
     (&(queue)->head == (queue)->head.prev)
 
 /*
@@ -73,38 +69,31 @@ nxt_queue_is_empty(queue)                                                     \
  *      tp = nxt_queue_link_data(lnk, nxt_type_t, link);
  */
 
-#define                                                                       \
-nxt_queue_first(queue)                                                        \
+#define nxt_queue_first(queue)                                                \
     (queue)->head.next
 
 
-#define                                                                       \
-nxt_queue_last(queue)                                                         \
+#define nxt_queue_last(queue)                                                 \
     (queue)->head.prev
 
 
-#define                                                                       \
-nxt_queue_head(queue)                                                         \
+#define nxt_queue_head(queue)                                                 \
     (&(queue)->head)
 
 
-#define                                                                       \
-nxt_queue_tail(queue)                                                         \
+#define nxt_queue_tail(queue)                                                 \
     (&(queue)->head)
 
 
-#define                                                                       \
-nxt_queue_next(link)                                                          \
+#define nxt_queue_next(link)                                                  \
     (link)->next
 
 
-#define                                                                       \
-nxt_queue_prev(link)                                                          \
+#define nxt_queue_prev(link)                                                  \
     (link)->prev
 
 
-#define                                                                       \
-nxt_queue_insert_head(queue, link)                                            \
+#define nxt_queue_insert_head(queue, link)                                    \
     do {                                                                      \
         (link)->next = (queue)->head.next;                                    \
         (link)->next->prev = (link);                                          \
@@ -113,8 +102,7 @@ nxt_queue_insert_head(queue, link)                                            \
     } while (0)
 
 
-#define                                                                       \
-nxt_queue_insert_tail(queue, link)                                            \
+#define nxt_queue_insert_tail(queue, link)                                    \
     do {                                                                      \
         (link)->prev = (queue)->head.prev;                                    \
         (link)->prev->next = (link);                                          \
@@ -123,8 +111,7 @@ nxt_queue_insert_tail(queue, link)                                            \
     } while (0)
 
 
-#define                                                                       \
-nxt_queue_insert_after(target, link)                                          \
+#define nxt_queue_insert_after(target, link)                                  \
     do {                                                                      \
         (link)->next = (target)->next;                                        \
         (link)->next->prev = (link);                                          \
@@ -133,8 +120,7 @@ nxt_queue_insert_after(target, link)                                          \
     } while (0)
 
 
-#define                                                                       \
-nxt_queue_insert_before(target, link)                                         \
+#define nxt_queue_insert_before(target, link)                                 \
     do {                                                                      \
         (link)->next = (target);                                              \
         (link)->prev = (target)->prev;                                        \
@@ -145,8 +131,7 @@ nxt_queue_insert_before(target, link)                                         \
 
 #if (NXT_DEBUG)
 
-#define                                                                       \
-nxt_queue_remove(link)                                                        \
+#define nxt_queue_remove(link)                                                \
     do {                                                                      \
         (link)->next->prev = (link)->prev;                                    \
         (link)->prev->next = (link)->next;                                    \
@@ -156,8 +141,7 @@ nxt_queue_remove(link)                                                        \
 
 #else
 
-#define                                                                       \
-nxt_queue_remove(link)                                                        \
+#define nxt_queue_remove(link)                                                \
     do {                                                                      \
         (link)->next->prev = (link)->prev;                                    \
         (link)->prev->next = (link)->next;                                    \
@@ -171,8 +155,7 @@ nxt_queue_remove(link)                                                        \
  * the "tail" is the new tail queue.
  */
 
-#define                                                                       \
-nxt_queue_split(queue, link, tail)                                            \
+#define nxt_queue_split(queue, link, tail)                                    \
     do {                                                                      \
         (tail)->head.prev = (queue)->head.prev;                               \
         (tail)->head.prev->next = &(tail)->head;                              \
@@ -185,8 +168,7 @@ nxt_queue_split(queue, link, tail)                                            \
 
 /* Truncate the queue "queue" starting at element "link". */
 
-#define                                                                       \
-nxt_queue_truncate(queue, link)                                               \
+#define nxt_queue_truncate(queue, link)                                       \
     do {                                                                      \
         (queue)->head.prev = (link)->prev;                                    \
         (queue)->head.prev->next = &(queue)->head;                            \
@@ -199,8 +181,7 @@ nxt_queue_truncate(queue, link)                                               \
  * it must be initiated with nxt_queue_init(tail).
  */
 
-#define                                                                       \
-nxt_queue_add(queue, tail)                                                    \
+#define nxt_queue_add(queue, tail)                                            \
     do {                                                                      \
         (queue)->head.prev->next = (tail)->head.next;                         \
         (tail)->head.next->prev = (queue)->head.prev;                         \
@@ -209,8 +190,7 @@ nxt_queue_add(queue, tail)                                                    \
     } while (0)
 
 
-#define                                                                       \
-nxt_queue_link_data(lnk, type, link)                                          \
+#define nxt_queue_link_data(lnk, type, link)                                  \
     nxt_container_of(lnk, type, link)
 
 

--- a/src/nxt_service.h
+++ b/src/nxt_service.h
@@ -15,8 +15,7 @@ typedef struct {
 } nxt_service_t;
 
 
-#define                                                                       \
-nxt_service_is_module(s)                                                      \
+#define nxt_service_is_module(s)                                              \
     ((s)->type == NULL)
 
 

--- a/src/nxt_signal.h
+++ b/src/nxt_signal.h
@@ -36,12 +36,10 @@ typedef struct {
 
 nxt_event_signals_t *nxt_event_engine_signals(const nxt_sig_event_t *sigev);
 
-#define                                                                       \
-nxt_event_engine_signals_start(engine)                                        \
+#define nxt_event_engine_signals_start(engine)                                \
     nxt_signal_thread_start(engine)
 
-#define                                                                       \
-nxt_event_engine_signals_stop(engine)                                         \
+#define nxt_event_engine_signals_stop(engine)                                 \
     nxt_signal_thread_stop(engine)
 
 

--- a/src/nxt_socket.h
+++ b/src/nxt_socket.h
@@ -118,12 +118,10 @@ NXT_EXPORT ssize_t nxt_socketpair_recv(nxt_fd_event_t *ev,
     nxt_iobuf_t *iob, nxt_uint_t niob, void *oob);
 
 
-#define                                                                       \
-nxt_socket_nonblocking(task, fd)                                              \
+#define nxt_socket_nonblocking(task, fd)                                      \
     nxt_fd_nonblocking(task, fd)
 
-#define                                                                       \
-nxt_socket_blocking(task, fd)                                                 \
+#define nxt_socket_blocking(task, fd)                                         \
     nxt_fd_blocking(task, fd)
 
 

--- a/src/nxt_source.h
+++ b/src/nxt_source.h
@@ -22,8 +22,7 @@ typedef void (*nxt_source_handler_t)(void *source_context,
     nxt_source_hook_t *query);
 
 
-#define                                                                       \
-nxt_source_filter(thr, wq, task, next, out)                                   \
+#define nxt_source_filter(thr, wq, task, next, out)                           \
     do {                                                                      \
         if (thr->engine->batch != 0) {                                        \
             nxt_thread_work_queue_add(thr, wq, nxt_source_filter_handler,     \

--- a/src/nxt_sprintf.c
+++ b/src/nxt_sprintf.c
@@ -90,8 +90,7 @@ static u_char *nxt_number(nxt_sprintf_t *spf, u_char *buf, double n);
 
 
 /* A right way of "f == 0.0". */
-#define                                                                       \
-nxt_double_is_zero(f)                                                         \
+#define nxt_double_is_zero(f)                                                 \
     (fabs(f) <= FLT_EPSILON)
 
 

--- a/src/nxt_string.h
+++ b/src/nxt_string.h
@@ -8,50 +8,40 @@
 #define _NXT_STRING_H_INCLUDED_
 
 
-#define                                                                       \
-nxt_lowcase(c)                                                                \
+#define nxt_lowcase(c)                                                        \
     (u_char) ((c >= 'A' && c <= 'Z') ? c | 0x20 : c)
 
-#define                                                                       \
-nxt_upcase(c)                                                                 \
+#define nxt_upcase(c)                                                         \
     (u_char) ((c >= 'a' && c <= 'z') ? c & ~0x20 : c)
 
-#define                                                                       \
-nxt_isdigit(c)                                                                \
+#define nxt_isdigit(c)                                                        \
     ((u_char) ((c) - '0') <= 9)
 
-#define                                                                       \
-nxt_strtod(s, endptr)                                                         \
+#define nxt_strtod(s, endptr)                                                 \
     strtod((char *) s, (char **) endptr)
 
 
-#define                                                                       \
-nxt_strlen(s)                                                                 \
+#define nxt_strlen(s)                                                         \
     strlen((char *) s)
 
 
-#define                                                                       \
-nxt_strdup(s)                                                                 \
+#define nxt_strdup(s)                                                         \
     strdup((char *) s)
 
 
-#define                                                                       \
-nxt_strchr(buf, delim)                                                        \
+#define nxt_strchr(buf, delim)                                                \
     (u_char *) strchr((char *) buf, delim)
 
 
-#define                                                                       \
-nxt_memzero(buf, length)                                                      \
+#define nxt_memzero(buf, length)                                              \
     (void) memset(buf, 0, length)
 
 
-#define                                                                       \
-nxt_memset(buf, c, length)                                                    \
+#define nxt_memset(buf, c, length)                                            \
     (void) memset(buf, c, length)
 
 
-#define                                                                       \
-nxt_memcpy(dst, src, length)                                                  \
+#define nxt_memcpy(dst, src, length)                                          \
     (void) memcpy(dst, src, length)
 
 
@@ -72,28 +62,23 @@ nxt_cpymem(void *dst, const void *src, size_t length)
 }
 
 
-#define                                                                       \
-nxt_memmove(dst, src, length)                                                 \
+#define nxt_memmove(dst, src, length)                                         \
     (void) memmove(dst, src, length)
 
 
-#define                                                                       \
-nxt_memcmp(s1, s2, length)                                                    \
+#define nxt_memcmp(s1, s2, length)                                            \
     memcmp((char *) s1, (char *) s2, length)
 
 
-#define                                                                       \
-nxt_memchr(s, c, length)                                                      \
+#define nxt_memchr(s, c, length)                                              \
     memchr((char *) s, c, length)
 
 
-#define                                                                       \
-nxt_strcmp(s1, s2)                                                            \
+#define nxt_strcmp(s1, s2)                                                    \
     strcmp((char *) s1, (char *) s2)
 
 
-#define                                                                       \
-nxt_strncmp(s1, s2, length)                                                   \
+#define nxt_strncmp(s1, s2, length)                                           \
     strncmp((char *) s1, (char *) s2, length)
 
 
@@ -125,16 +110,14 @@ typedef struct {
 #define nxt_null_string       { 0, NULL }
 
 
-#define                                                                       \
-nxt_str_set(str, text)                                                        \
+#define nxt_str_set(str, text)                                                \
     do {                                                                      \
         (str)->length = nxt_length(text);                                     \
         (str)->start = (u_char *) text;                                       \
     } while (0)
 
 
-#define                                                                       \
-nxt_str_null(str)                                                             \
+#define nxt_str_null(str)                                                     \
     do {                                                                      \
         (str)->length = 0;                                                    \
         (str)->start = NULL;                                                  \
@@ -147,35 +130,29 @@ NXT_EXPORT nxt_str_t *nxt_str_dup(nxt_mp_t *mp, nxt_str_t *dst,
 NXT_EXPORT char *nxt_str_cstrz(nxt_mp_t *mp, const nxt_str_t *src);
 
 
-#define                                                                       \
-nxt_strstr_eq(s1, s2)                                                         \
+#define nxt_strstr_eq(s1, s2)                                                 \
     (((s1)->length == (s2)->length)                                           \
       && (nxt_memcmp((s1)->start, (s2)->start, (s1)->length) == 0))
 
 
-#define                                                                       \
-nxt_strcasestr_eq(s1, s2)                                                     \
+#define nxt_strcasestr_eq(s1, s2)                                             \
     (((s1)->length == (s2)->length)                                           \
       && (nxt_memcasecmp((s1)->start, (s2)->start, (s1)->length) == 0))
 
 
-#define                                                                       \
-nxt_str_eq(s, p, _length)                                                     \
+#define nxt_str_eq(s, p, _length)                                             \
     (((s)->length == _length) && (nxt_memcmp((s)->start, p, _length) == 0))
 
 
-#define                                                                       \
-nxt_str_start(s, p, _length)                                                  \
+#define nxt_str_start(s, p, _length)                                          \
     (((s)->length >= _length) && (nxt_memcmp((s)->start, p, _length) == 0))
 
 
-#define                                                                       \
-nxt_strchr_eq(s, c)                                                           \
+#define nxt_strchr_eq(s, c)                                                   \
     (((s)->length == 1) && ((s)->start[0] == c))
 
 
-#define                                                                       \
-nxt_strchr_start(s, c)                                                        \
+#define nxt_strchr_start(s, c)                                                \
     (((s)->length != 0) && ((s)->start[0] == c))
 
 

--- a/src/nxt_thread.h
+++ b/src/nxt_thread.h
@@ -30,19 +30,15 @@
 
 #if (NXT_HAVE_THREAD_STORAGE_CLASS)
 
-#define                                                                       \
-nxt_thread_extern_data(type, tsd)                                             \
+#define nxt_thread_extern_data(type, tsd)                                     \
     NXT_EXPORT extern __thread type  tsd
 
-#define                                                                       \
-nxt_thread_declare_data(type, tsd)                                            \
+#define nxt_thread_declare_data(type, tsd)                                    \
     __thread type  tsd
 
-#define                                                                       \
-nxt_thread_init_data(tsd)
+#define nxt_thread_init_data(tsd)
 
-#define                                                                       \
-nxt_thread_get_data(tsd)                                                      \
+#define nxt_thread_get_data(tsd)                                              \
     &tsd
 
 
@@ -67,18 +63,15 @@ typedef struct {
 } nxt_thread_specific_data_t[1];
 
 
-#define                                                                       \
-nxt_thread_extern_data(type, tsd)                                             \
+#define nxt_thread_extern_data(type, tsd)                                     \
     NXT_EXPORT extern nxt_thread_specific_data_t  tsd
 
-#define                                                                       \
-nxt_thread_declare_data(type, tsd)                                            \
+#define nxt_thread_declare_data(type, tsd)                                    \
     nxt_thread_specific_data_t tsd = { { (nxt_atomic_int_t) -1, sizeof(type) } }
 
 NXT_EXPORT void nxt_thread_init_data(nxt_thread_specific_data_t tsd);
 
-#define                                                                       \
-nxt_thread_get_data(tsd)                                                      \
+#define nxt_thread_get_data(tsd)                                              \
     pthread_getspecific((pthread_key_t) tsd->key)
 
 #endif
@@ -101,8 +94,7 @@ NXT_EXPORT void nxt_thread_cancel(nxt_thread_handle_t handle);
 NXT_EXPORT void nxt_thread_wait(nxt_thread_handle_t handle);
 
 
-#define                                                                       \
-nxt_thread_handle()                                                           \
+#define nxt_thread_handle()                                                   \
     pthread_self()
 
 
@@ -125,18 +117,15 @@ NXT_EXPORT nxt_err_t nxt_thread_cond_wait(nxt_thread_cond_t *cond,
 
 
 #if (NXT_HAVE_PTHREAD_YIELD)
-#define                                                                       \
-nxt_thread_yield()                                                            \
+#define nxt_thread_yield()                                                    \
     pthread_yield()
 
 #elif (NXT_HAVE_PTHREAD_YIELD_NP)
-#define                                                                       \
-nxt_thread_yield()                                                            \
+#define nxt_thread_yield()                                                    \
     pthread_yield_np()
 
 #else
-#define                                                                       \
-nxt_thread_yield()                                                            \
+#define nxt_thread_yield()                                                    \
     nxt_sched_yield()
 
 #endif

--- a/src/nxt_thread_id.h
+++ b/src/nxt_thread_id.h
@@ -179,12 +179,10 @@ NXT_EXPORT nxt_tid_t nxt_thread_tid(nxt_thread_t *thr);
 typedef pthread_t  nxt_thread_handle_t;
 
 
-#define                                                                       \
-nxt_thread_handle_clear(th)                                                   \
+#define nxt_thread_handle_clear(th)                                           \
     th = (pthread_t) 0
 
-#define                                                                       \
-nxt_thread_handle_equal(th0, th1)                                             \
+#define nxt_thread_handle_equal(th0, th1)                                     \
     pthread_equal(th0, th1)
 
 

--- a/src/nxt_thread_time.h
+++ b/src/nxt_thread_time.h
@@ -70,21 +70,18 @@ NXT_EXPORT u_char *nxt_thread_time_string(nxt_thread_t *thr,
 void nxt_time_thread_start(nxt_msec_t interval);
 
 
-#define                                                                       \
-nxt_thread_monotonic_time(thr)                                                \
+#define nxt_thread_monotonic_time(thr)                                        \
     (thr)->time.now.monotonic
 
 
 #if (NXT_DEBUG)
 
-#define                                                                       \
-nxt_thread_time_debug_update(thr)                                             \
+#define nxt_thread_time_debug_update(thr)                                     \
     nxt_thread_time_update(thr)
 
 #else
 
-#define                                                                       \
-nxt_thread_time_debug_update(thr)
+#define nxt_thread_time_debug_update(thr)
 
 #endif
 

--- a/src/nxt_time.h
+++ b/src/nxt_time.h
@@ -74,20 +74,17 @@ NXT_EXPORT void nxt_timezone_update(void);
 
 #if (NXT_HAVE_TM_GMTOFF)
 
-#define                                                                       \
-nxt_timezone(tm)                                                              \
+#define nxt_timezone(tm)                                                      \
     ((tm)->tm_gmtoff)
 
 #elif (NXT_HAVE_ALTZONE)
 
-#define                                                                       \
-nxt_timezone(tm)                                                              \
+#define nxt_timezone(tm)                                                      \
     (-(((tm)->tm_isdst > 0) ? altzone : timezone))
 
 #else
 
-#define                                                                       \
-nxt_timezone(tm)                                                              \
+#define nxt_timezone(tm)                                                      \
     (-(((tm)->tm_isdst > 0) ? timezone + 3600 : timezone))
 
 #endif
@@ -103,8 +100,7 @@ typedef int32_t            nxt_msec_int_t;
  * every 49 days.  This signed subtraction takes into account that overflow.
  * "nxt_msec_diff(m1, m2) < 0" means that m1 is lesser than m2.
  */
-#define                                                                       \
-nxt_msec_diff(m1, m2)                                                         \
+#define nxt_msec_diff(m1, m2)                                                 \
     ((int32_t) ((m1) - (m2)))
 
 

--- a/src/nxt_unix.h
+++ b/src/nxt_unix.h
@@ -275,23 +275,19 @@
 
 typedef struct iovec   nxt_iobuf_t;
 
-#define                                                                       \
-nxt_iobuf_data(iob)                                                           \
+#define nxt_iobuf_data(iob)                                                   \
     (iob)->iov_base
 
-#define                                                                       \
-nxt_iobuf_size(iob)                                                           \
+#define nxt_iobuf_size(iob)                                                   \
     (iob)->iov_len
 
-#define                                                                       \
-nxt_iobuf_set(iob, p, size)                                                   \
+#define nxt_iobuf_set(iob, p, size)                                           \
     do {                                                                      \
         (iob)->iov_base = (void *) p;                                         \
         (iob)->iov_len = size;                                                \
     } while (0)
 
-#define                                                                       \
-nxt_iobuf_add(iob, size)                                                      \
+#define nxt_iobuf_add(iob, size)                                              \
     (iob)->iov_len += size
 
 

--- a/src/nxt_vector.h
+++ b/src/nxt_vector.h
@@ -41,19 +41,16 @@ NXT_EXPORT void *nxt_vector_zero_add(nxt_vector_t *vector,
 NXT_EXPORT void nxt_vector_remove(nxt_vector_t *vector, void *item);
 
 
-#define                                                                       \
-nxt_vector_last(vector)                                                       \
+#define nxt_vector_last(vector)                                               \
     nxt_pointer_to((vector)->start,                                           \
                    (vector)->item_size * ((vector)->items - 1))
 
 
-#define                                                                       \
-nxt_vector_reset(vector)                                                      \
+#define nxt_vector_reset(vector)                                              \
     (vector)->items = 0;
 
 
-#define                                                                       \
-nxt_vector_is_empty(vector)                                                   \
+#define nxt_vector_is_empty(vector)                                           \
     ((vector)->items == 0)
 
 

--- a/src/nxt_work_queue.h
+++ b/src/nxt_work_queue.h
@@ -109,8 +109,7 @@ NXT_EXPORT void nxt_work_queue_thread_adopt(nxt_work_queue_t *wq);
 
 #else
 
-#define                                                                       \
-nxt_work_queue_name(_wq, _name)
+#define nxt_work_queue_name(_wq, _name)
 
 #define nxt_work_queue_thread_adopt(_wq)
 

--- a/src/test/nxt_rbtree1_test.c
+++ b/src/test/nxt_rbtree1_test.c
@@ -9,13 +9,11 @@
 #include "nxt_rbtree1.h"
 
 
-#define                                                                       \
-nxt_rbtree1_is_empty(tree)                                                    \
+#define nxt_rbtree1_is_empty(tree)                                            \
     (((tree)->root) == (tree)->sentinel)
 
 
-#define                                                                       \
-nxt_rbtree1_is_there_successor(tree, node)                                    \
+#define nxt_rbtree1_is_there_successor(tree, node)                            \
     ((node) != (tree)->sentinel)
 
 


### PR DESCRIPTION
We had a mix of styles for declaring function-like macros:

Style A:
```c
 #define                    \
 foo()                      \
     do {                   \
         ...                \
     } while (0)
```

Style B:
```c
 #define foo()              \
     do {                   \
         ...                \
     } while (0)
```

We had a similar number of occurences of each style:

```sh
 $ grep -rnI '^\w*(.*\\' | wc -l
 244
 $ grep -rn 'define.*(.*)' | wc -l
 239
```

(Those regexes aren't perfect, but a very decent approximation.)

Real examples:

```c
 $ find src -type f | xargs sed -n '/^nxt_double_is_zero/,/^$/p'
 nxt_double_is_zero(f)                                                         \
     (fabs(f) <= FLT_EPSILON)
```

```c
 $ find src -type f | xargs sed -n '/define nxt_http_field_set/,/^$/p'
 #define nxt_http_field_set(_field, _name, _value)                             \
     do {                                                                      \
         (_field)->name_length = nxt_length(_name);                            \
         (_field)->value_length = nxt_length(_value);                          \
         (_field)->name = (u_char *) _name;                                    \
         (_field)->value = (u_char *) _value;                                  \
     } while (0)
```

I'd like to standardize on a single style for them, and IMO,
having the identifier in the same line as #define is a better
option for the following reasons:

- Programmers are used to `#define foo() ...` (readability).
- One less line of code.
- The program for finding them is really simple (see below).

```sh
 function grep_ngx_func()
 {
     if (($# != 1)); then
         >&2 echo "Usage: ${FUNCNAME[0]} <func>";
         return 1;
     fi;

     find src -type f \
     | grep '\.[ch]$' \
     | xargs grep -l "$1" \
     | sort \
     | xargs pcregrep -Mn "(?s)^\$[\w\s*]+?^$1\(.*?^}";

     find src -type f \
     | grep '\.[ch]$' \
     | xargs grep -l "$1" \
     | sort \
     | xargs pcregrep -Mn "(?s)define $1\(.*?^$" \
     | sed -E '1s/^[^:]+:[0-9]+:/&\n\n/';
 }
```

```sh
 $ grep_ngx_func
 Usage: grep_ngx_func <func>
```
```c
 $ grep_ngx_func nxt_http_field_set
 src/nxt_http.h:98:

 #define nxt_http_field_set(_field, _name, _value)                             \
     do {                                                                      \
         (_field)->name_length = nxt_length(_name);                            \
         (_field)->value_length = nxt_length(_value);                          \
         (_field)->name = (u_char *) _name;                                    \
         (_field)->value = (u_char *) _value;                                  \
     } while (0)
```
```c
 $ grep_ngx_func nxt_sprintf
 src/nxt_sprintf.c:56:

 u_char * nxt_cdecl
 nxt_sprintf(u_char *buf, u_char *end, const char *fmt, ...)
 {
     u_char   *p;
     va_list  args;

     va_start(args, fmt);
     p = nxt_vsprintf(buf, end, fmt, args);
     va_end(args);

     return p;
 }
```

................
Scripted change:
................

```sh
$ find src -type f \
  | grep '\.[ch]$' \
  | xargs sed -i '/define *\\$/{N;s/ *\\\n/ /;s/        //}'
```