### PR TITLE
Static: returning 404 when "index" is a non-regular file.

### DIFF
--- a/src/nxt_http_static.c
+++ b/src/nxt_http_static.c
@@ -571,7 +571,9 @@ nxt_http_static_send_ready(nxt_task_t *task, void *obj, void *data)
         /* Not a file. */
         nxt_file_close(task, f);
 
-        if (nxt_slow_path(!nxt_is_dir(&fi))) {
+        if (nxt_slow_path(!nxt_is_dir(&fi)
+                          || ctx->share.start[ctx->share.length - 1] == '/'))
+        {
             nxt_log(task, NXT_LOG_ERR, "\"%FN\" is not a regular file",
                     f->name);
 


### PR DESCRIPTION
Before this patch, if "index" is a file, but not a regular file
nor a directory, so it may be for example a FIFO, Unit returned 404.
But if "index" is a directory, Unit returned 301.

For consistency, this patch makes Unit return 404 for every
non-regular file, including directories.

To trigger the incorrect (301) behavior, since the index file is
not configurable yet, one would need to make "index.html" be a
directory (or maybe a symlink to a directory).  As that seems
not a reasonable situation, we can assume this behavior is not
being triggered, and therefore I'm not adding an entry to the
changelog.

However, this change is important for the future addition of a
configurable "index" option.

Since tests are easier to write with a configurable "index", the
tests for this "bugfix" are included in the "index" patch set
instead of here.