### PR TITLE
Configuration: make large_header_buffer_size a valid setting.

### DIFF
--- a/docs/changes.xml
+++ b/docs/changes.xml
@@ -51,6 +51,15 @@ ability to specify a custom index file name when serving static files.
 
 <change type="feature">
 <para>
+added new "header_buffer_size", "large_header_buffer_size",
+"large_header_buffers", "proxy_buffer_size", "proxy_header_buffer_size",
+"proxy_timeout", "proxy_send_timeout" and "proxy_read_timeout" options for
+"settings.http".
+</para>
+</change>
+
+<change type="feature">
+<para>
 variables support in the "location" option of the "return" action.
 </para>
 </change>

--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -306,7 +306,13 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_http_members[] = {
         .name       = nxt_string("max_body_size"),
         .type       = NXT_CONF_VLDT_INTEGER,
     }, {
+        .name       = nxt_string("header_buffer_size"),
+        .type       = NXT_CONF_VLDT_INTEGER,
+    }, {
         .name       = nxt_string("large_header_buffer_size"),
+        .type       = NXT_CONF_VLDT_INTEGER,
+    }, {
+        .name       = nxt_string("large_header_buffers"),
         .type       = NXT_CONF_VLDT_INTEGER,
     }, {
         .name       = nxt_string("body_temp_path"),

--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -321,6 +321,21 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_http_members[] = {
         .name       = nxt_string("discard_unsafe_fields"),
         .type       = NXT_CONF_VLDT_BOOLEAN,
     }, {
+        .name       = nxt_string("proxy_buffer_size"),
+        .type       = NXT_CONF_VLDT_INTEGER,
+    }, {
+        .name       = nxt_string("proxy_header_buffer_size"),
+        .type       = NXT_CONF_VLDT_INTEGER,
+    }, {
+        .name       = nxt_string("proxy_timeout"),
+        .type       = NXT_CONF_VLDT_INTEGER,
+    }, {
+        .name       = nxt_string("proxy_send_timeout"),
+        .type       = NXT_CONF_VLDT_INTEGER,
+    }, {
+        .name       = nxt_string("proxy_read_timeout"),
+        .type       = NXT_CONF_VLDT_INTEGER,
+    }, {
         .name       = nxt_string("websocket"),
         .type       = NXT_CONF_VLDT_OBJECT,
         .validator  = nxt_conf_vldt_object,

--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -306,6 +306,9 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_http_members[] = {
         .name       = nxt_string("max_body_size"),
         .type       = NXT_CONF_VLDT_INTEGER,
     }, {
+        .name       = nxt_string("large_header_buffer_size"),
+        .type       = NXT_CONF_VLDT_INTEGER,
+    }, {
         .name       = nxt_string("body_temp_path"),
         .type       = NXT_CONF_VLDT_STRING,
     }, {

--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -1449,6 +1449,36 @@ static nxt_conf_map_t  nxt_router_http_conf[] = {
         NXT_CONF_MAP_INT8,
         offsetof(nxt_socket_conf_t, discard_unsafe_fields),
     },
+
+    {
+        nxt_string("proxy_buffer_size"),
+        NXT_CONF_MAP_SIZE,
+        offsetof(nxt_socket_conf_t, proxy_buffer_size),
+    },
+
+    {
+        nxt_string("proxy_header_buffer_size"),
+        NXT_CONF_MAP_SIZE,
+        offsetof(nxt_socket_conf_t, proxy_header_buffer_size),
+    },
+
+    {
+        nxt_string("proxy_timeout"),
+        NXT_CONF_MAP_MSEC,
+        offsetof(nxt_socket_conf_t, proxy_timeout),
+    },
+
+    {
+        nxt_string("proxy_send_timeout"),
+        NXT_CONF_MAP_MSEC,
+        offsetof(nxt_socket_conf_t, proxy_send_timeout),
+    },
+
+    {
+        nxt_string("proxy_read_timeout"),
+        NXT_CONF_MAP_MSEC,
+        offsetof(nxt_socket_conf_t, proxy_read_timeout),
+    },
 };
 
 


### PR DESCRIPTION
This pull request has been updated and expanded on. It now consists of five commits

- Docs: update changelog for some new settings.
- Router: remove unused proxy_buffers structure member.
- Configuration: add some missing proxy settings options.
- Configuration: enable the setting of some more http options.
- Configuration: make large_header_buffer_size a valid setting.

In reverse order

#### Configuration: make large_header_buffer_size a valid setting.

This commit allows to fix the issue reported [here](https://github.com/nginx/unit/issues/521) by allowing the *settings.http.large_header_buffer_size* option to be set in the config.

This is done as a separate commit as this is directly dealing with a user reported issue.

 #### Configuration: enable the setting of some more http options.

This enables the setting of *header_buffer_size* & *large_header_buffers* in the *settings.http* options. These were simply missing from the list of valid config options.

#### Configuration: add some missing proxy settings options.

This adds a bunch of *proxy* options to be processed and as valid *settings.http* config options.

I've done this as a separate commit from the previous one as this was a slightly different situation in that these proxy options weren't listed in the nxt_router_http_conf array (nor as valid config options) and so weren't even looked at for updating.

It's also easier to squash this with the previous commit (if so desired) than split it up after the fact.

#### Router: remove unused proxy_buffers structure member.

This removes an unused structure member from *nxt_socket_conf_t* and while it did get set, it was never actually used anywhere. Removing it shrinks the nxt_socket_conf_t structure to fit in 3 cachelines (on x86-64 at least).

#### Docs: update changelog for some new settings.

This updates the changelog to mention all the new config options.