### PR TITLE
Support URI $ sub-delimiters

### DIFF
--- a/docs/changes.xml
+++ b/docs/changes.xml
@@ -45,6 +45,12 @@ supporting empty strings in the "location" option of the "return" action.
 
 <change type="feature">
 <para>
+translate '$$' to a literal '$' during variable substitution.
+</para>
+</change>
+
+<change type="feature">
+<para>
 variables support in the "location" option of the "return" action.
 </para>
 </change>

--- a/src/nxt_http_variables.c
+++ b/src/nxt_http_variables.c
@@ -13,6 +13,8 @@ static nxt_int_t nxt_http_var_uri(nxt_task_t *task, nxt_var_query_t *query,
     nxt_str_t *str, void *ctx);
 static nxt_int_t nxt_http_var_host(nxt_task_t *task, nxt_var_query_t *query,
     nxt_str_t *str, void *ctx);
+static nxt_int_t nxt_http_var_dollar(nxt_task_t *task, nxt_var_query_t *query,
+    nxt_str_t *str, void *ctx);
 
 
 static nxt_var_decl_t  nxt_http_vars[] = {
@@ -26,6 +28,10 @@ static nxt_var_decl_t  nxt_http_vars[] = {
 
     { nxt_string("host"),
       &nxt_http_var_host,
+      0 },
+
+    { nxt_string("$"),
+      &nxt_http_var_dollar,
       0 },
 };
 
@@ -74,6 +80,16 @@ nxt_http_var_host(nxt_task_t *task, nxt_var_query_t *query, nxt_str_t *str,
     r = ctx;
 
     *str = r->host;
+
+    return NXT_OK;
+}
+
+
+static nxt_int_t
+nxt_http_var_dollar(nxt_task_t *task, nxt_var_query_t *query, nxt_str_t *str,
+    void *ctx)
+{
+    nxt_str_set(str, "$");
 
     return NXT_OK;
 }

--- a/src/nxt_var.c
+++ b/src/nxt_var.c
@@ -362,6 +362,14 @@ nxt_var_next_part(u_char *start, size_t length, nxt_str_t *part,
             return NULL;
         }
 
+        /* Allow $$ to represent a literal '$' */
+        if (*p == '$') {
+            part->start = p;
+            part->length = 1;
+
+            return p + 1;
+        }
+
         if (*p == '{') {
             bracket = 1;
 

--- a/test/test_static_chroot.py
+++ b/test/test_static_chroot.py
@@ -227,6 +227,3 @@ class TestStaticChroot(TestApplicationProto):
         assert 'error' in self.update_action(
             temp_dir + '/assets$uri', temp_dir + '/assets/d$r$uri'
         )
-        assert 'error' in self.update_action(
-            temp_dir + '/assets$uri', temp_dir + '/assets/$$uri'
-        )

--- a/test/test_static_variables.py
+++ b/test/test_static_variables.py
@@ -73,7 +73,3 @@ class TestStaticVariables(TestApplicationProto):
 
     def test_static_variables_invalid(self, temp_dir):
         assert 'error' in self.update_share(temp_dir + '/assets/d$r$uri')
-        assert 'error' in self.update_share(temp_dir + '/assets/$$uri')
-        assert 'error' in self.update_share(
-            [temp_dir + '/assets$uri', temp_dir + '/assets/dir', '$$uri']
-        )


### PR DESCRIPTION
This pull request adds support for $ sub-delimiters, or more generally it allows to specify a _$_ in URIs that would otherwise clash with variables.

All the tests under the test/ directory pass, well except for a couple of chroot ones which also fail under master.

It comprises three commits

```
Andrew Clayton (3):
      Support URI $ sub-delimiters.
      Tests: Remove some no longer invalid tests.
      Tests: Add tests for $ sub-delimiters.
```

#### Support URI $ sub-delimiters.

This allows to specify things like

```json
"location": "https://$host/path/$$sub1$$sub2"
```
in the Unit config which would translate to something like

```
https://example.com/path/$sub1$sub2
```

#### Tests: Remove some no longer invalid tests.

This removes some tests that were testing invalid paths that were using $$, which of course if now valid.

#### Tests: Add tests for $ sub-delimiters.

This adds some new tests for using $$ in URIs

Summary of changes

```
 docs/changes.xml              |  6 ++++++
 src/nxt_http_variables.c      | 16 ++++++++++++++++
 src/nxt_var.c                 |  8 ++++++++
 test/test_return.py           | 15 +++++++++++++++
 test/test_static_chroot.py    |  3 ---
 test/test_static_variables.py |  4 ----
 6 files changed, 45 insertions(+), 7 deletions(-)
```