### PR TITLE
Build: Add a make check target.

### DIFF
--- a/auto/make
+++ b/auto/make
@@ -430,6 +430,12 @@ cat << END > Makefile
 
 include $NXT_MAKEFILE
 
+PYTEST := $NXT_PYTEST_NAME
+
+.PHONY: check
+check: unitd
+	\$(PYTEST)
+
 .PHONY: clean
 clean:
 		rm -rf $NXT_BUILD_DIR *.dSYM Makefile

--- a/auto/pytest
+++ b/auto/pytest
@@ -1,0 +1,58 @@
+
+# Copyright (C) Andrew Clayton
+
+
+$echo -n "checking for pytest ... "
+cat << END >> $NXT_AUTOCONF_ERR
+----------------------------------------
+checking for pytest
+END
+
+
+# Allow error exit status.
+set +e
+
+NXT_PYTEST_NAME=
+
+PYTEST_DEFAULT_NAME=pytest
+PYTEST_FOUND_STR="not found"
+PYTEST_GO=
+
+PYTEST_CMDS="
+    pytest
+    pytest-3
+"
+
+for pyt_cmd in $PYTEST_CMDS
+do
+    if `/bin/sh -c "($pyt_cmd --version)" 2>&1 >> $NXT_AUTOCONF_ERR 2>&1`
+    then
+        NXT_PYTEST_NAME=$pyt_cmd
+        break
+    fi
+done
+
+if `/bin/sh -c "(go version)" 2>&1 >> $NXT_AUTOCONF_ERR 2>&1`
+then
+    PYTEST_GO=go
+fi
+
+if [ ! -z $NXT_PYTEST_NAME ]
+then
+    PYTEST_FOUND_STR="found"
+fi
+
+if [ ! -z $NXT_PYTEST_NAME ] && [ -z $PYTEST_GO ]
+then
+    PYTEST_FOUND_STR=${PYTEST_FOUND_STR}" but is missing golang"
+fi
+
+$echo $PYTEST_FOUND_STR
+
+if [ -z $NXT_PYTEST_NAME ]
+then
+    NXT_PYTEST_NAME=$PYTEST_DEFAULT_NAME
+fi
+
+# Stop on error exit status again.
+set -e

--- a/configure
+++ b/configure
@@ -163,6 +163,7 @@ cat << END >> $NXT_AUTO_CONFIG_H
 END
 
 . auto/test_build
+. auto/pytest
 . auto/sources
 . auto/save
 


### PR DESCRIPTION
While unit comes with a test suite, it is not entirely obvious how to
run it!.

As suggested by @alejandro-colomar add a make check target which is a
common target for running such things. This is added to the Makefile in
the repository root. It will build unit first if required.

If pytest fails to run for some reason (but not due to tests failing)
then a message is displayed saying what packages need to be installed on
some common platforms.

On FreeBSD and Fedora, pytest can be run as pytest or pytest-3, on
Debian it is pytest-3, so make tries running pytest first then pytest-3
if pytest wasn't found.