### PR TITLE
Fixed memcpy(dest, NULL, 0) Undefined Behavior.

### DIFF
--- a/src/nxt_http_return.c
+++ b/src/nxt_http_return.c
@@ -73,11 +73,13 @@ nxt_http_return(nxt_task_t *task, nxt_http_request_t *r,
     nxt_http_action_t *action)
 {
     nxt_int_t               ret;
-    nxt_str_t               loc;
     nxt_http_return_ctx_t   *ctx;
     nxt_http_return_conf_t  *conf;
 
     conf = action->u.conf;
+
+#if (NXT_DEBUG)
+    nxt_str_t  loc;
 
     if (conf->location == NULL) {
         nxt_str_set(&loc, "");
@@ -87,6 +89,7 @@ nxt_http_return(nxt_task_t *task, nxt_http_request_t *r,
     }
 
     nxt_debug(task, "http return: %d (loc: \"%V\")", conf->status, &loc);
+#endif
 
     if (conf->status >= NXT_HTTP_BAD_REQUEST
         && conf->status <= NXT_HTTP_SERVER_ERROR_MAX)

--- a/src/nxt_http_return.c
+++ b/src/nxt_http_return.c
@@ -80,7 +80,7 @@ nxt_http_return(nxt_task_t *task, nxt_http_request_t *r,
     conf = action->u.conf;
 
     if (conf->location == NULL) {
-        nxt_str_null(&loc);
+        nxt_str_set(&loc, "");
 
     } else {
         nxt_var_raw(conf->location, &loc);


### PR DESCRIPTION
nxt_str_null() setted the loc.start pointer to NULL, which was
being passed to malloc(3) through nxt_debug().  That caused
Undefined Behavior, so we now pass an empty string.