### PR TITLE
Uncover memcpy(0, 0, 0) Undefined Behavior

### DIFF
--- a/src/nxt_string.h
+++ b/src/nxt_string.h
@@ -58,6 +58,10 @@ NXT_EXPORT void nxt_memcpy_upcase(u_char *dst, const u_char *src,
 nxt_inline void *
 nxt_cpymem(void *dst, const void *src, size_t length)
 {
+    if (dst == NULL || src == NULL) {
+        abort();
+    }
+
     return ((u_char *) memcpy(dst, src, length)) + length;
 }
 


### PR DESCRIPTION
This patch should NOT be applied to unit.  It's only a testing patch that uncovers (most) hidden cases of `memcpy(NULL, NULL, 0)` by aborting unit.

Please peruse the patch to test until unit doesn't abort.