### PR TITLE
Add a $dollar variable that translates to a literal '$'

### DIFF
--- a/docs/changes.xml
+++ b/docs/changes.xml
@@ -62,6 +62,13 @@ increased the applications' startup timeout.
 </para>
 </change>
 
+<change type="feature">
+<para>
+added a new variable, $dollar, that translates to a literal "$" during
+variable substitution.
+</para>
+</change>
+
 </changes>
 
 

--- a/src/nxt_http_variables.c
+++ b/src/nxt_http_variables.c
@@ -7,6 +7,8 @@
 #include <nxt_http.h>
 
 
+static nxt_int_t nxt_http_var_dollar(nxt_task_t *task, nxt_str_t *str,
+    void *ctx, uint16_t field);
 static nxt_int_t nxt_http_var_method(nxt_task_t *task, nxt_str_t *str,
     void *ctx, uint16_t field);
 static nxt_int_t nxt_http_var_request_uri(nxt_task_t *task, nxt_str_t *str,
@@ -41,6 +43,9 @@ static nxt_int_t nxt_http_var_cookie(nxt_task_t *task, nxt_str_t *str,
 
 static nxt_var_decl_t  nxt_http_vars[] = {
     {
+        .name = nxt_string("dollar"),
+        .handler = nxt_http_var_dollar,
+    }, {
         .name = nxt_string("method"),
         .handler = nxt_http_var_method,
     }, {
@@ -93,6 +98,15 @@ nxt_int_t
 nxt_http_register_variables(void)
 {
     return nxt_var_register(nxt_http_vars, nxt_nitems(nxt_http_vars));
+}
+
+
+static nxt_int_t
+nxt_http_var_dollar(nxt_task_t *task, nxt_str_t *str, void *ctx, uint16_t field)
+{
+    nxt_str_set(str, "$");
+
+    return NXT_OK;
 }
 
 

--- a/test/test_variables.py
+++ b/test/test_variables.py
@@ -114,6 +114,27 @@ class TestVariables(TestApplicationProto):
         check_user_agent('', 404)
         check_user_agent('no', 404)
 
+    def test_variables_dollar(self):
+        assert 'success' in self.conf(
+            {
+                "listeners": {"*:7080": {"pass": "routes"}},
+                "routes": [{"action": {"return": 301}}],
+            }
+        )
+
+        def check_dollar(location, expect):
+            assert 'success' in self.conf(
+                '"' + location + '"',
+                'routes/0/action/location',
+            )
+            assert self.get()['headers']['Location'] == expect
+
+        check_dollar(
+            'https://${host}${uri}path${dollar}dollar',
+            'https://localhost/path$dollar',
+        )
+        check_dollar('path$dollar${dollar}', 'path$$')
+
     def test_variables_many(self):
         self.conf_routes("\"routes$uri$method\"")
         assert self.get(url='/5')['status'] == 206, 'many'


### PR DESCRIPTION
This pull-request is for supporting a new variable called 'dollar' that can be
used for specifying _$_ 's in URIs etc. One such use case being $ sub-delimiters.

This pull-request comprises the following commits

- Var: added a $dollar variable that translates to a '$'.
- Tests: added tests for translating $sign into a literal $.

Wasn't sure if it _really_ needed tests as the current variable tests should
cover it, but added just a couple of new tests to ensure we are getting $'s
out. That commit can simply be dropped if it's not wanted.

So if you wanted to specify a URL like

    https://example.com/path/15$1588/9925$2976.html

that would go in the unit config like

    https://example.com/path/15${dollar}1588/9925${dollar}2976.html

All tests pass.

This relates to this [issue](https://github.com/nginx/unit/issues/675).