### PR TITLE
fix php_module_startup call for PHP 8.2

### DIFF
--- a/auto/modules/php
+++ b/auto/modules/php
@@ -149,7 +149,7 @@ nxt_feature_test="
     #include <php_main.h>
 
     int main() {
-    #if PHP_VERSION_ID < 80200
+    #if (PHP_VERSION_ID < 80200)
         php_module_startup(NULL, NULL, 0);
     #else
         php_module_startup(NULL, NULL);

--- a/auto/modules/php
+++ b/auto/modules/php
@@ -149,7 +149,11 @@ nxt_feature_test="
     #include <php_main.h>
 
     int main() {
+    #if PHP_VERSION_ID < 80200
         php_module_startup(NULL, NULL, 0);
+    #else
+        php_module_startup(NULL, NULL);
+    #endif
         return 0;
     }"
 

--- a/src/nxt_php_sapi.c
+++ b/src/nxt_php_sapi.c
@@ -16,20 +16,20 @@
 #include <nxt_unit_request.h>
 
 
-#if PHP_VERSION_ID >= 50400
+#if (PHP_VERSION_ID >= 50400)
 #define NXT_HAVE_PHP_IGNORE_CWD 1
 #endif
 
-#if PHP_VERSION_ID >= 70100
+#if (PHP_VERSION_ID >= 70100)
 #define NXT_HAVE_PHP_LOG_MESSAGE_WITH_SYSLOG_TYPE 1
 #else
 #define NXT_HAVE_PHP_INTERRUPTS 1
 #endif
 
-#if PHP_VERSION_ID >= 70000
+#if (PHP_VERSION_ID >= 70000)
 #define NXT_PHP7 1
 #endif
-#if PHP_VERSION_ID >= 80000
+#if (PHP_VERSION_ID >= 80000)
 #define NXT_PHP8 1
 #endif
 
@@ -73,7 +73,7 @@ typedef int (*nxt_php_disable_t)(char *p, size_t size);
 typedef int (*nxt_php_disable_t)(char *p, uint TSRMLS_DC);
 #endif
 
-#if PHP_VERSION_ID < 70200
+#if (PHP_VERSION_ID < 70200)
 typedef void (*zif_handler)(INTERNAL_FUNCTION_PARAMETERS);
 #endif
 
@@ -139,7 +139,7 @@ static int nxt_php_read_post(char *buffer, uint count_bytes TSRMLS_DC);
 
 
 #ifdef NXT_PHP7
-#if PHP_VERSION_ID < 70200
+#if (PHP_VERSION_ID < 70200)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_fastcgi_finish_request, 0, 0,
                                         _IS_BOOL, NULL, 0)
 #else
@@ -355,7 +355,7 @@ static nxt_php_target_t  *nxt_php_targets;
 static nxt_int_t         nxt_php_last_target = -1;
 
 static nxt_unit_ctx_t    *nxt_php_unit_ctx;
-#if defined(ZTS) && PHP_VERSION_ID < 70400
+#if defined(ZTS) && (PHP_VERSION_ID < 70400)
 static void              ***tsrm_ls;
 #endif
 
@@ -377,7 +377,7 @@ nxt_php_setup(nxt_task_t *task, nxt_process_t *process,
 
 #ifdef ZTS
 
-#if PHP_VERSION_ID >= 70400
+#if (PHP_VERSION_ID >= 70400)
     php_tsrm_startup();
 #else
     tsrm_startup(1, 1, 0, NULL);

--- a/src/nxt_php_sapi.c
+++ b/src/nxt_php_sapi.c
@@ -1150,7 +1150,7 @@ nxt_php_vcwd_chdir(nxt_unit_request_info_t *req, u_char *dir)
 static int
 nxt_php_startup(sapi_module_struct *sapi_module)
 {
-#if PHP_VERSION_ID < 80200
+#if (PHP_VERSION_ID < 80200)
     return php_module_startup(sapi_module, &nxt_php_unit_module, 1);
 #else
     return php_module_startup(sapi_module, &nxt_php_unit_module);

--- a/src/nxt_php_sapi.c
+++ b/src/nxt_php_sapi.c
@@ -1150,7 +1150,11 @@ nxt_php_vcwd_chdir(nxt_unit_request_info_t *req, u_char *dir)
 static int
 nxt_php_startup(sapi_module_struct *sapi_module)
 {
+#if PHP_VERSION_ID < 80200
     return php_module_startup(sapi_module, &nxt_php_unit_module, 1);
+#else
+    return php_module_startup(sapi_module, &nxt_php_unit_module);
+#endif
 }
 
 


### PR DESCRIPTION
Without this patch

```
+ : PHP module configuration
+ ./configure php --config=/opt/remi/php82/root/usr/bin/php-config --module=php82
configuring PHP module
checking for PHP ... found
 + PHP SAPI: [apache2handler litespeed fpm phpdbg cli embed cgi]
checking for PHP version ... 8.2.0-dev
checking for PHP embed SAPI ... not found

./configure: error: no PHP embed SAPI found.

```