### PR TITLE
Static: Fixed finding the file extension.

### DIFF
--- a/docs/changes.xml
+++ b/docs/changes.xml
@@ -31,6 +31,13 @@ NGINX Unit updated to 1.28.0.
          date="" time=""
          packager="Konstantin Pavlov &lt;thresh@nginx.com&gt;">
 
+<change type="bugfix">
+<para>
+an index file that didn't contain a file extension was incorrectly
+handled, and caused a use-after-free bug.
+</para>
+</change>
+
 </changes>
 
 

--- a/src/nxt_http_static.c
+++ b/src/nxt_http_static.c
@@ -756,9 +756,7 @@ nxt_http_static_extract_extension(nxt_str_t *path, nxt_str_t *exten)
     end = path->start + path->length;
     p = end;
 
-    for ( ;; ) {
-        /* There's always '/' in the beginning of the request path. */
-
+    while (p > path->start) {
         p--;
         ch = *p;
 
@@ -767,11 +765,14 @@ nxt_http_static_extract_extension(nxt_str_t *path, nxt_str_t *exten)
             p++;
             /* Fall through. */
         case '.':
-            exten->length = end - p;
-            exten->start = p;
-            return;
+            goto extension;
         }
     }
+
+extension:
+
+    exten->length = end - p;
+    exten->start = p;
 }
 
 


### PR DESCRIPTION
The code for finding the extension made a few assumptions that are
no longer true.  It didn't account for pathnames that didn't
contain '/', including the empty string, or the NULL string.

This fix works by limiting the search to the beginning of the
string, so that if no '/' is found in it, it doesn't continue
searching before the beginning of the string.

This also happens to work for NULL.  It is technically Undefined
Behavior, as we rely on `NULL + 0 == NULL` and `NULL - NULL == 0`.
But that is the only sane behavior for an implementation, and all
existing POSIX implementations will Just Work for this code.

Link: <https://stackoverflow.com/q/67291052/6872717>

The same code seems to be defined behavior in C++, which normally
will share implementation in the compiler for these cases, and
therefore it is really unlikely to be in trouble.

Link: <https://stackoverflow.com/q/59409034/6872717>