### PR TITLE
Ruby: fixed contents of SCRIPT_NAME.

### DIFF
--- a/docs/changes.xml
+++ b/docs/changes.xml
@@ -75,6 +75,12 @@ increased the applications' startup timeout.
 </para>
 </change>
 
+<change type="bugfix">
+<para>
+force SCRIPT_NAME in Ruby to always be an empty string.
+</para>
+</change>
+
 </changes>
 
 

--- a/src/ruby/nxt_ruby.h
+++ b/src/ruby/nxt_ruby.h
@@ -22,7 +22,6 @@
 
 typedef struct {
     VALUE                    env;
-    VALUE                    script;
     VALUE                    io_input;
     VALUE                    io_error;
     VALUE                    thread;

--- a/test/test_ruby_application.py
+++ b/test/test_ruby_application.py
@@ -44,7 +44,7 @@ class TestRubyApplication(TestApplicationRuby):
             'Request-Method': 'POST',
             'Request-Uri': '/',
             'Http-Host': 'localhost',
-            'Script-Name': 'config.ru',
+            'Script-Name': '',
             'Server-Protocol': 'HTTP/1.1',
             'Custom-Header': 'blah',
             'Rack-Version': '13',


### PR DESCRIPTION
Having the basename of the script pathname was incorrect.  While
we don't have something more accurate, the best thing to do is to
have it empty (which should be most of the time).

Fixes (git) commit 0032543fa65f454c471c968998190b027c1ff270,
which was 'Ruby: added the Rack environment parameter "SCRIPT_NAME".'.

Closes: <https://github.com/nginx/unit/issues/715>