### PR TITLE
Optimized arrays of pointers to arrays of arrays.

### DIFF
--- a/auto/sources
+++ b/auto/sources
@@ -5,6 +5,7 @@
 
 NXT_LIB_SRCS=" \
     src/nxt_lib.c \
+    src/nxt_calendar.c \
     src/nxt_gmtime.c \
     src/nxt_errno.c \
     src/nxt_time.c \

--- a/src/nxt_calendar.c
+++ b/src/nxt_calendar.c
@@ -2,7 +2,8 @@
 #include <nxt_main.h>
 
 
-const char  nxt_wday[][4] = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };
-
-const char  nxt_month[][4] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                               "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
+const nxt_calendar_t  nxt_calendar = {
+    .wday  = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" },
+    .month = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+               "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" },
+};

--- a/src/nxt_calendar.c
+++ b/src/nxt_calendar.c
@@ -1,0 +1,8 @@
+
+#include <nxt_main.h>
+
+
+const char  nxt_wday[][4] = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };
+
+const char  nxt_month[][4] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                               "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };

--- a/src/nxt_calendar.h
+++ b/src/nxt_calendar.h
@@ -3,8 +3,13 @@
 #define _NXT_CALENDAR_H_INCLUDED_
 
 
-extern const char  nxt_wday[][4];
-extern const char  nxt_month[][4];
+typedef struct {
+    const char  wday[7][4];
+    const char  month[12][4];
+} nxt_calendar_t;
+
+
+extern const nxt_calendar_t  nxt_calendar;
 
 
 #endif  /* _NXT_HTTP_H_INCLUDED_ */

--- a/src/nxt_calendar.h
+++ b/src/nxt_calendar.h
@@ -1,0 +1,10 @@
+
+#ifndef _NXT_CALENDAR_H_INCLUDED_
+#define _NXT_CALENDAR_H_INCLUDED_
+
+
+extern const char  nxt_wday[][4];
+extern const char  nxt_month[][4];
+
+
+#endif  /* _NXT_HTTP_H_INCLUDED_ */

--- a/src/nxt_controller.c
+++ b/src/nxt_controller.c
@@ -2129,15 +2129,8 @@ static u_char *
 nxt_controller_date(u_char *buf, nxt_realtime_t *now, struct tm *tm,
     size_t size, const char *format)
 {
-    static const char  week[][4] = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri",
-                                    "Sat" };
-
-    static const char  month[][4] = { "Jan", "Feb", "Mar", "Apr",
-                                      "May", "Jun", "Jul", "Aug",
-                                      "Sep", "Oct", "Nov", "Dec" };
-
     return nxt_sprintf(buf, buf + size, format,
-                       week[tm->tm_wday], tm->tm_mday,
-                       month[tm->tm_mon], tm->tm_year + 1900,
+                       nxt_wday[tm->tm_wday], tm->tm_mday,
+                       nxt_month[tm->tm_mon], tm->tm_year + 1900,
                        tm->tm_hour, tm->tm_min, tm->tm_sec);
 }

--- a/src/nxt_controller.c
+++ b/src/nxt_controller.c
@@ -2129,12 +2129,12 @@ static u_char *
 nxt_controller_date(u_char *buf, nxt_realtime_t *now, struct tm *tm,
     size_t size, const char *format)
 {
-    static const char *const  week[] = { "Sun", "Mon", "Tue", "Wed", "Thu",
-                                         "Fri", "Sat" };
+    static const char  week[][4] = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri",
+                                    "Sat" };
 
-    static const char *const  month[] = { "Jan", "Feb", "Mar", "Apr",
-                                          "May", "Jun", "Jul", "Aug",
-                                          "Sep", "Oct", "Nov", "Dec" };
+    static const char  month[][4] = { "Jan", "Feb", "Mar", "Apr",
+                                      "May", "Jun", "Jul", "Aug",
+                                      "Sep", "Oct", "Nov", "Dec" };
 
     return nxt_sprintf(buf, buf + size, format,
                        week[tm->tm_wday], tm->tm_mday,

--- a/src/nxt_controller.c
+++ b/src/nxt_controller.c
@@ -2129,11 +2129,12 @@ static u_char *
 nxt_controller_date(u_char *buf, nxt_realtime_t *now, struct tm *tm,
     size_t size, const char *format)
 {
-    static const char  *week[] = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri",
-                                   "Sat" };
+    static const char *const  week[] = { "Sun", "Mon", "Tue", "Wed", "Thu",
+                                         "Fri", "Sat" };
 
-    static const char  *month[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                                    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
+    static const char *const  month[] = { "Jan", "Feb", "Mar", "Apr",
+                                          "May", "Jun", "Jul", "Aug",
+                                          "Sep", "Oct", "Nov", "Dec" };
 
     return nxt_sprintf(buf, buf + size, format,
                        week[tm->tm_wday], tm->tm_mday,

--- a/src/nxt_controller.c
+++ b/src/nxt_controller.c
@@ -2130,7 +2130,7 @@ nxt_controller_date(u_char *buf, nxt_realtime_t *now, struct tm *tm,
     size_t size, const char *format)
 {
     return nxt_sprintf(buf, buf + size, format,
-                       nxt_wday[tm->tm_wday], tm->tm_mday,
-                       nxt_month[tm->tm_mon], tm->tm_year + 1900,
+                       nxt_calendar.wday[tm->tm_wday], tm->tm_mday,
+                       nxt_calendar.month[tm->tm_mon], tm->tm_year + 1900,
                        tm->tm_hour, tm->tm_min, tm->tm_sec);
 }

--- a/src/nxt_http.h
+++ b/src/nxt_http.h
@@ -288,8 +288,8 @@ nxt_http_date(u_char *buf, struct tm *tm)
 {
     return nxt_sprintf(buf, buf + NXT_HTTP_DATE_LEN,
                        "%s, %02d %s %4d %02d:%02d:%02d GMT",
-                       nxt_wday[tm->tm_wday], tm->tm_mday,
-                       nxt_month[tm->tm_mon], tm->tm_year + 1900,
+                       nxt_calendar.wday[tm->tm_wday], tm->tm_mday,
+                       nxt_calendar.month[tm->tm_mon], tm->tm_year + 1900,
                        tm->tm_hour, tm->tm_min, tm->tm_sec);
 }
 

--- a/src/nxt_http.h
+++ b/src/nxt_http.h
@@ -286,12 +286,12 @@ struct nxt_http_client_ip_s {
 nxt_inline u_char *
 nxt_http_date(u_char *buf, struct tm *tm)
 {
-    static const char *const  week[] = { "Sun", "Mon", "Tue", "Wed", "Thu",
-                                         "Fri", "Sat" };
+    static const char  week[][4] = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri",
+                                     "Sat" };
 
-    static const char *const  month[] = { "Jan", "Feb", "Mar", "Apr",
-                                          "May", "Jun", "Jul", "Aug",
-                                          "Sep", "Oct", "Nov", "Dec" };
+    static const char  month[][4] = { "Jan", "Feb", "Mar", "Apr",
+                                      "May", "Jun", "Jul", "Aug",
+                                      "Sep", "Oct", "Nov", "Dec" };
 
     return nxt_sprintf(buf, buf + NXT_HTTP_DATE_LEN,
                        "%s, %02d %s %4d %02d:%02d:%02d GMT",

--- a/src/nxt_http.h
+++ b/src/nxt_http.h
@@ -286,17 +286,10 @@ struct nxt_http_client_ip_s {
 nxt_inline u_char *
 nxt_http_date(u_char *buf, struct tm *tm)
 {
-    static const char  week[][4] = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri",
-                                     "Sat" };
-
-    static const char  month[][4] = { "Jan", "Feb", "Mar", "Apr",
-                                      "May", "Jun", "Jul", "Aug",
-                                      "Sep", "Oct", "Nov", "Dec" };
-
     return nxt_sprintf(buf, buf + NXT_HTTP_DATE_LEN,
                        "%s, %02d %s %4d %02d:%02d:%02d GMT",
-                       week[tm->tm_wday], tm->tm_mday,
-                       month[tm->tm_mon], tm->tm_year + 1900,
+                       nxt_wday[tm->tm_wday], tm->tm_mday,
+                       nxt_month[tm->tm_mon], tm->tm_year + 1900,
                        tm->tm_hour, tm->tm_min, tm->tm_sec);
 }
 

--- a/src/nxt_http.h
+++ b/src/nxt_http.h
@@ -286,11 +286,12 @@ struct nxt_http_client_ip_s {
 nxt_inline u_char *
 nxt_http_date(u_char *buf, struct tm *tm)
 {
-    static const char  *week[] = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri",
-                                   "Sat" };
+    static const char *const  week[] = { "Sun", "Mon", "Tue", "Wed", "Thu",
+                                         "Fri", "Sat" };
 
-    static const char  *month[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                                    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
+    static const char *const  month[] = { "Jan", "Feb", "Mar", "Apr",
+                                          "May", "Jun", "Jul", "Aug",
+                                          "Sep", "Oct", "Nov", "Dec" };
 
     return nxt_sprintf(buf, buf + NXT_HTTP_DATE_LEN,
                        "%s, %02d %s %4d %02d:%02d:%02d GMT",

--- a/src/nxt_isolation.c
+++ b/src/nxt_isolation.c
@@ -849,7 +849,7 @@ nxt_isolation_make_private_mount(nxt_task_t *task, const char *rootfs)
     nxt_int_t      ret, index, nmounts;
     struct mntent  *ent;
 
-    static const char  *mount_path = "/proc/self/mounts";
+    static const char *const  mount_path = "/proc/self/mounts";
 
     ret = NXT_ERROR;
     ent = NULL;

--- a/src/nxt_isolation.c
+++ b/src/nxt_isolation.c
@@ -849,7 +849,7 @@ nxt_isolation_make_private_mount(nxt_task_t *task, const char *rootfs)
     nxt_int_t      ret, index, nmounts;
     struct mntent  *ent;
 
-    static const char *const  mount_path = "/proc/self/mounts";
+    static const char  mount_path[] = "/proc/self/mounts";
 
     ret = NXT_ERROR;
     ent = NULL;

--- a/src/nxt_main.h
+++ b/src/nxt_main.h
@@ -28,6 +28,7 @@ typedef struct nxt_thread_pool_s     nxt_thread_pool_t;
 
 typedef void (*nxt_work_handler_t)(nxt_task_t *task, void *obj, void *data);
 
+#include <nxt_calendar.h>
 #include <nxt_unix.h>
 #include <nxt_clang.h>
 #include <nxt_types.h>

--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -3821,10 +3821,6 @@ nxt_router_access_log_date(u_char *buf, nxt_realtime_t *now, struct tm *tm,
     u_char  sign;
     time_t  gmtoff;
 
-    static const char  month[][4] = { "Jan", "Feb", "Mar", "Apr",
-                                      "May", "Jun", "Jul", "Aug",
-                                      "Sep", "Oct", "Nov", "Dec" };
-
     gmtoff = nxt_timezone(tm) / 60;
 
     if (gmtoff < 0) {
@@ -3836,7 +3832,7 @@ nxt_router_access_log_date(u_char *buf, nxt_realtime_t *now, struct tm *tm,
     }
 
     return nxt_sprintf(buf, buf + size, format,
-                       tm->tm_mday, month[tm->tm_mon], tm->tm_year + 1900,
+                       tm->tm_mday, nxt_month[tm->tm_mon], tm->tm_year + 1900,
                        tm->tm_hour, tm->tm_min, tm->tm_sec,
                        sign, gmtoff / 60, gmtoff % 60);
 }

--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -3821,9 +3821,9 @@ nxt_router_access_log_date(u_char *buf, nxt_realtime_t *now, struct tm *tm,
     u_char  sign;
     time_t  gmtoff;
 
-    static const char *const  month[] = { "Jan", "Feb", "Mar", "Apr",
-                                          "May", "Jun", "Jul", "Aug",
-                                          "Sep", "Oct", "Nov", "Dec" };
+    static const char  month[][4] = { "Jan", "Feb", "Mar", "Apr",
+                                      "May", "Jun", "Jul", "Aug",
+                                      "Sep", "Oct", "Nov", "Dec" };
 
     gmtoff = nxt_timezone(tm) / 60;
 

--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -3821,8 +3821,9 @@ nxt_router_access_log_date(u_char *buf, nxt_realtime_t *now, struct tm *tm,
     u_char  sign;
     time_t  gmtoff;
 
-    static const char  *month[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                                    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
+    static const char *const  month[] = { "Jan", "Feb", "Mar", "Apr",
+                                          "May", "Jun", "Jul", "Aug",
+                                          "Sep", "Oct", "Nov", "Dec" };
 
     gmtoff = nxt_timezone(tm) / 60;
 

--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -3832,7 +3832,8 @@ nxt_router_access_log_date(u_char *buf, nxt_realtime_t *now, struct tm *tm,
     }
 
     return nxt_sprintf(buf, buf + size, format,
-                       tm->tm_mday, nxt_month[tm->tm_mon], tm->tm_year + 1900,
+                       tm->tm_mday, nxt_calendar.month[tm->tm_mon],
+                       tm->tm_year + 1900,
                        tm->tm_hour, tm->tm_min, tm->tm_sec,
                        sign, gmtoff / 60, gmtoff % 60);
 }

--- a/src/nxt_unit.c
+++ b/src/nxt_unit.c
@@ -6655,7 +6655,7 @@ nxt_unit_req_log(nxt_unit_request_info_t *req, int level, const char *fmt, ...)
 }
 
 
-static const char * nxt_unit_log_levels[] = {
+static const char *const  nxt_unit_log_levels[] = {
     "alert",
     "error",
     "warn",

--- a/src/nxt_unit.c
+++ b/src/nxt_unit.c
@@ -6655,7 +6655,7 @@ nxt_unit_req_log(nxt_unit_request_info_t *req, int level, const char *fmt, ...)
 }
 
 
-static const char  nxt_unit_log_levels[][7] = {
+static const char  nxt_unit_log_levels[][8] = {
     "alert",
     "error",
     "warn",

--- a/src/nxt_unit.c
+++ b/src/nxt_unit.c
@@ -6655,7 +6655,7 @@ nxt_unit_req_log(nxt_unit_request_info_t *req, int level, const char *fmt, ...)
 }
 
 
-static const char *const  nxt_unit_log_levels[] = {
+static const char  nxt_unit_log_levels[][7] = {
     "alert",
     "error",
     "warn",


### PR DESCRIPTION
That allows the linker to put them in read-only memory, and
optimize program startup time.

I also merged identical definitions into a single one, which the
linker would have done anyway, but that way we reduce source code
duplication.

See also: <https://www.akkadia.org/drepper/dsohowto.pdf> 2.4.3
Closes: <https://github.com/nginx/unit/issues/720>