### PR TITLE
Added (fixed) support for abstract Unix sockets.

### DIFF
--- a/docs/changes.xml
+++ b/docs/changes.xml
@@ -37,6 +37,12 @@ increased the applications' startup timeout.
 </para>
 </change>
 
+<change type="change">
+<para>
+disallowed abstract Unix domain socket syntax in non-Linux systems.
+</para>
+</change>
+
 <change type="feature">
 <para>
 supporting abstract UNIX sockets.

--- a/docs/changes.xml
+++ b/docs/changes.xml
@@ -39,6 +39,12 @@ increased the applications' startup timeout.
 
 <change type="feature">
 <para>
+supporting abstract UNIX sockets.
+</para>
+</change>
+
+<change type="feature">
+<para>
 supporting UNIX sockets in address matching.
 </para>
 </change>

--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -1480,9 +1480,14 @@ nxt_conf_vldt_listener(nxt_conf_validation_t *vldt, nxt_str_t *name,
     nxt_conf_value_t *value)
 {
     nxt_int_t       ret;
+    nxt_str_t       str;
     nxt_sockaddr_t  *sa;
 
-    sa = nxt_sockaddr_parse(vldt->pool, name);
+    if (nxt_slow_path(nxt_str_dup(vldt->pool, &str, name) == NULL)) {
+        return NXT_ERROR;
+    }
+
+    sa = nxt_sockaddr_parse(vldt->pool, &str);
     if (nxt_slow_path(sa == NULL)) {
         return nxt_conf_vldt_error(vldt,
                                    "The listener address \"%V\" is invalid.",

--- a/src/nxt_main_process.c
+++ b/src/nxt_main_process.c
@@ -1187,7 +1187,9 @@ nxt_main_listening_socket(nxt_sockaddr_t *sa, nxt_listening_socket_t *ls)
 
 #if (NXT_HAVE_UNIX_DOMAIN)
 
-    if (sa->u.sockaddr.sa_family == AF_UNIX) {
+    if (sa->u.sockaddr.sa_family == AF_UNIX
+        && sa->u.sockaddr_un.sun_path[0] != '\0')
+    {
         char     *filename;
         mode_t   access;
 

--- a/src/nxt_sockaddr.c
+++ b/src/nxt_sockaddr.c
@@ -610,8 +610,11 @@ nxt_sockaddr_unix_parse(nxt_mp_t *mp, nxt_str_t *addr)
      *   are covered by the specified length of the address structure.
      *   (Null bytes in the name have no special significance.)
      */
-    if (path[0] == '@') {
+    switch (path[0]) {
+    case '@':
         path[0] = '\0';
+        /* fall through */
+    case '\0':
         socklen--;
 #if !(NXT_LINUX)
         nxt_thread_log_error(NXT_LOG_ERR,

--- a/src/nxt_sockaddr.c
+++ b/src/nxt_sockaddr.c
@@ -601,8 +601,6 @@ nxt_sockaddr_unix_parse(nxt_mp_t *mp, nxt_str_t *addr)
 
     socklen = offsetof(struct sockaddr_un, sun_path) + length + 1;
 
-#if (NXT_LINUX)
-
     /*
      * Linux unix(7):
      *
@@ -615,9 +613,12 @@ nxt_sockaddr_unix_parse(nxt_mp_t *mp, nxt_str_t *addr)
     if (path[0] == '@') {
         path[0] = '\0';
         socklen--;
-    }
-
+#if !(NXT_LINUX)
+        nxt_thread_log_error(NXT_LOG_ERR,
+                             "abstract unix domain sockets are not supported");
+        return NULL;
 #endif
+    }
 
     sa = nxt_sockaddr_alloc(mp, socklen, addr->length);
 


### PR DESCRIPTION
Unix domain sockets are normally backed by files in the
filesystem.  This has historically been problematic when closing
and opening again such sockets, since SO_REUSEADDR is ignored for
Unix sockets (POSIX left the behavior of SO_REUSEADDR as
implementation-defined, and most --if not all-- implementations
decided to just ignore this flag).

Many solutions are available for this problem, but all of them
have important caveats:

- unlink(2) the file when it's not needed anymore.

  This is not easy, because the process that controls the fd may
  not be the same process that created the file, and may not have
  file permissions to remove it.

  Further solutions can be applied to that caveat:

  - unlink(2) the file right after creation.

    This will remove the pathname from the filesystem without
    closing the socket (it will continue alive until the last fd
    is closed).  This is not useful for us, since we need the
    pathname of the socket as its interface.

  - chown(2) or chmod(2) the directory that contains the socket.

    For removing a file from the filesystem, a process needs
    write permissions in the containing directory.  We could
    put sockets in dummy directories that can be chown(2)ed to
    nobody.  This could be dangerous, though, as we don't control
    the socket names.  It is our users who configure the socket
    name in their configuration, and so it's easy that they don't
    understand the many implications of not chosing an appropriate
    socket pathname.  A user could unknowingly put the socket in a
    directory that is not supposed to be owned by user nobody, and
    if we blindly chown(2) or chmod(2) the directory, we could be
    creating a big security hole.

  - Ask the main process to remove the socket.

    This would require a very complex communication mechanism with
    the main process, which is not impossible, but let's avoid it
    if there are simpler solutions.

  - Give the child process the CAP_DAC_OVERRIDE capability.

    That is one of the most powerful capabilities.  A process with
    that capability can be considered root for most practical
    aspects.  Even if the capability is disabled for most of the
    lifetime of the process, there's a slight chance that a
    malicious actor could activate it and then easily do serious
    damage to the system.

- unlink(2) the file right before calling bind(2).

  This is dangerous because another process (for example, another
  running instance of unitd(8)), could be using the socket, and
  removing the pathname from the filesystem would be problematic.
  To do this correctly, a lot of checks should be added before the
  actual unlink(2), which is bug-prone, and difficult to do
  correctly, and atomically.

- Use abstract-namespace Unix domain sockets.

  This is the simplest solution, as it only requires accepting a
  slightly different syntax (basically a @ prefix) for the socket
  name, to transform it into a string starting with a null byte
  ('\0') that the kernel can understand.  The patch is minimal.

  Since abstract sockets live in an abstract namespace, they don't
  create files in the filesystem, so there's no need to remove
  them later.  The kernel removes the name when the last fd to it
  has been closed.

  One caveat is that only Linux currently supports this kind of
  Unix sockets.  Of course, a solution to that could be to ask
  other kernels to implement such a feature.

  Another caveat is that filesystem permissions can't be used to
  control access to the socket file (since, of course, there's no
  file).  Anyone knowing the socket name can access to it.  The
  only method to control access to it is by using
  network_namespaces(7).  Since in unitd(8) we're using 0666 file
  sockets, abstract sockets should be more insecure than that
  (anyone can already read/write to the listener sockets).

- Ask the kernel to implement an simpler way to unlink(2) socket
  files when they are not needed anymore.  I've suggested that to
  the <linux-fsdevel@vger.kernel.org> mailing list, in:
<lore.kernel.org/linux-fsdevel/0bc5f919-bcfd-8fd0-a16b-9f060088158a@gmail.com/T>

In this commit, I decided to go for the easiest/simplest solution.

This closes #669 issue on GitHub.