### PR TITLE
Add support for a user configuration file.

### DIFF
--- a/src/nxt_controller.c
+++ b/src/nxt_controller.c
@@ -174,6 +174,12 @@ nxt_controller_prefork(nxt_task_t *task, nxt_process_t *process, nxt_mp_t *mp)
     nxt_conf_ver = 12500;
 
     ret = nxt_controller_file_read(task, rt->conf, &ctrl_init.conf, mp);
+
+    if (nxt_slow_path(ret == NXT_DECLINED)) {
+        ret = nxt_controller_file_read(task, rt->conf_init, &ctrl_init.conf,
+                                       mp);
+    }
+
     if (nxt_slow_path(ret == NXT_ERROR)) {
         return NXT_ERROR;
     }

--- a/src/nxt_runtime.c
+++ b/src/nxt_runtime.c
@@ -865,6 +865,13 @@ nxt_runtime_conf_init(nxt_task_t *task, nxt_runtime_t *rt)
 
     rt->conf = (char *) file_name.start;
 
+    ret = nxt_file_name_create(rt->mem_pool, &file_name, "%s%Z", NXT_CONF);
+    if (nxt_slow_path(ret != NXT_OK)) {
+        return NXT_ERROR;
+    }
+
+    rt->conf_init = (char *) file_name.start;
+
     ret = nxt_file_name_create(rt->mem_pool, &file_name, "%s.tmp%Z", rt->conf);
     if (nxt_slow_path(ret != NXT_OK)) {
         return NXT_ERROR;

--- a/src/nxt_runtime.h
+++ b/src/nxt_runtime.h
@@ -69,6 +69,7 @@ struct nxt_runtime_s {
     const char             *ver;
     const char             *ver_tmp;
     const char             *conf;
+    const char             *conf_init;
     const char             *conf_tmp;
     const char             *control;
     const char             *tmp;


### PR DESCRIPTION
Add support for a user-specified user configuration file, normally
under $sysconfdir, that is, `/etc`.  I'd recommend using `/etc/unit/unitd.conf.json` for the default pathname.

The part for setting the file's default pathname, and for changing it, will be implemented in the auto
scripts, but since it will depend on the PR that adds a default
prefix, that code is not yet written in this commit.  TODO.