### PR TITLE
Socket: Created control socket & pid file directories.

### DIFF
--- a/src/nxt_controller.c
+++ b/src/nxt_controller.c
@@ -666,6 +666,14 @@ nxt_runtime_controller_socket(nxt_task_t *task, nxt_runtime_t *rt)
 #endif
     ls->handler = nxt_controller_conn_init;
 
+#if (NXT_HAVE_UNIX_DOMAIN)
+    if (ls->sockaddr->u.sockaddr.sa_family == AF_UNIX) {
+        const char *path = ls->sockaddr->u.sockaddr_un.sun_path;
+
+        nxt_fs_mkdir_parent((const u_char *) path, 0755);
+    }
+#endif
+
     if (nxt_listen_socket_create(task, rt->mem_pool, ls) != NXT_OK) {
         return NXT_ERROR;
     }

--- a/src/nxt_fs.c
+++ b/src/nxt_fs.c
@@ -273,6 +273,31 @@ nxt_fs_mkdir_all(const u_char *dir, mode_t mode)
 }
 
 
+nxt_int_t
+nxt_fs_mkdir_parent(const u_char *path, mode_t mode)
+{
+    char       *ptr, *dir;
+    nxt_int_t  ret;
+
+    dir = nxt_strdup(path);
+    if (nxt_slow_path(dir == NULL)) {
+        return NXT_ERROR;
+    }
+
+    ret = NXT_OK;
+
+    ptr = strrchr(dir, '/');
+    if (nxt_fast_path(ptr != NULL)) {
+        *ptr = '\0';
+        ret = nxt_fs_mkdir((const u_char *) dir, mode);
+    }
+
+    nxt_free(dir);
+
+    return ret;
+}
+
+
 static nxt_int_t
 nxt_fs_mkdir(const u_char *dir, mode_t mode)
 {

--- a/src/nxt_fs.h
+++ b/src/nxt_fs.h
@@ -36,6 +36,7 @@ typedef struct {
 } nxt_fs_mount_t;
 
 
+nxt_int_t nxt_fs_mkdir_parent(const u_char *path, mode_t mode);
 nxt_int_t nxt_fs_mkdir_all(const u_char *dir, mode_t mode);
 nxt_int_t nxt_fs_mount(nxt_task_t *task, nxt_fs_mount_t *mnt);
 void nxt_fs_unmount(const u_char *path);

--- a/src/nxt_runtime.c
+++ b/src/nxt_runtime.c
@@ -1369,6 +1369,8 @@ nxt_runtime_pid_file_create(nxt_task_t *task, nxt_file_name_t *pid_file)
 
     file.name = pid_file;
 
+    nxt_fs_mkdir_parent(pid_file, 0755);
+
     n = nxt_file_open(task, &file, O_WRONLY, O_CREAT | O_TRUNC,
                       NXT_FILE_DEFAULT_ACCESS);
 


### PR DESCRIPTION
@alejandro-colomar reported an issue on GitHub whereby Unit would fail
to start due to not being able to create the control socket (a Unix
Domain Socket)

  2022/08/05 20:12:22 [alert] 21613#21613 bind(6,
  unix:/opt/local/unit/var/run/unit/control.unit.sock.tmp) failed (2:
  No such file or directory)

This could happen if the control socket was set to a directory that
doesn't exist. A common place to put the control socket would be under
/run/unit, and while /run will exist, /run/unit may well not (/run
is/should be cleared on each boot).

The pid file would also generally go under /run/unit, though this is
created after the control socket, however it could go someplace else so
we should also ensure its directory exists.

This commit ensures that the full directory paths to where the control
socket and pid file will be located exists before trying to create them.

Closes: https://github.com/nginx/unit/issues/742
Reported-by: Alejandro Colomar <alx.manpages@gmail.com>
Reviewed-by: Alejandro Colomar <alx.manpages@gmail.com>
Tested-by: Alejandro Colomar <alx.manpages@gmail.com>
Signed-off-by: Andrew Clayton <andrew@digital-domain.net>