### PR TITLE
HTTP: refactored cookie parser.

### DIFF
--- a/src/nxt_http_request.c
+++ b/src/nxt_http_request.c
@@ -1045,20 +1045,21 @@ nxt_http_cookie_parse(nxt_array_t *cookies, u_char *start, const u_char *end)
         for (p = value; p > name && p[-1] == ' '; p--) { /* void */ }
 
         name_length = p - name;
+        if (name_length == 0) {
+            return NXT_ERROR;
+        }
 
-        if (name_length > 0) {
-            p = last;
+        p = last;
 
-            if (value < last) {
-                value++;
-                while (value < last && value[0] == ' ') { value++; }
-                while (p > value && p[-1] == ' ') { p--; }
-            }
+        if (value < last) {
+            value++;
+            while (value < last && value[0] == ' ') { value++; }
+            while (p > value && p[-1] == ' ') { p--; }
+        }
 
-            nv = nxt_http_cookie(cookies, name, name_length, value, p);
-            if (nxt_slow_path(nv == NULL)) {
-                return NXT_ERROR;
-            }
+        nv = nxt_http_cookie(cookies, name, name_length, value, p);
+        if (nxt_slow_path(nv == NULL)) {
+            return NXT_ERROR;
         }
     }
 


### PR DESCRIPTION
As per https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1 cookie-value = *cookie-octet / ( DQUOTE *cookie-octet DQUOTE ) cookie-octet = %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E

So '=' is a valid character in cookie-value. The previous parser could not handle this situation. Now it supports parsing cookie-value which with '='.