### PR TITLE
Refining the default configuration

### DIFF
--- a/src/nxt_controller.c
+++ b/src/nxt_controller.c
@@ -487,7 +487,7 @@ nxt_controller_conf_default(void)
     nxt_conf_value_t  *conf;
 
     static const nxt_str_t json
-        = nxt_string("{ \"listeners\": {}, \"applications\": {} }");
+        = nxt_string("{ \"applications\":{}, \"listeners\":{}, \"routes\":{} }");
 
     mp = nxt_mp_create(1024, 128, 256, 32);
 


### PR DESCRIPTION
Misleading "Value doesn't exist." error due to non-existent default field routes.