### PR TITLE
Fixed out-of-bounds reads and writes.

### DIFF
--- a/src/nxt_application.c
+++ b/src/nxt_application.c
@@ -309,17 +309,22 @@ nxt_discovery_modules(nxt_task_t *task, const char *path)
                             mnt[j].data == NULL ? (u_char *) "" : mnt[j].data);
         }
 
+        if (nxt_slow_path(p > end - 3)) {
+            nxt_alert(task, "discovery buffer truncation");
+            goto fail;
+        }
+
         *p++ = ']';
         *p++ = '}';
         *p++ = ',';
     }
 
-    *p++ = ']';
-
-    if (nxt_slow_path(p > end)) {
-        nxt_alert(task, "discovery write past the buffer");
+    if (nxt_slow_path(p > end - 1)) {
+        nxt_alert(task, "discovery buffer truncation");
         goto fail;
     }
+
+    *p++ = ']';
 
     b->mem.free = p;
 

--- a/src/nxt_clone.c
+++ b/src/nxt_clone.c
@@ -44,12 +44,12 @@ nxt_clone_credential_setgroups(nxt_task_t *task, pid_t child_pid,
 
     end = path + PATH_MAX;
     p = nxt_sprintf(path, end, "/proc/%d/setgroups", child_pid);
-    *p = '\0';
-
     if (nxt_slow_path(p == end)) {
-        nxt_alert(task, "error write past the buffer: %s", path);
+        nxt_alert(task, "buffer truncation: %s", path);
         return NXT_ERROR;
     }
+
+    *p = '\0';
 
     fd = open((char *)path, O_RDWR);
 
@@ -183,13 +183,13 @@ nxt_clone_credential_map_set(nxt_task_t *task, const char* mapfile, pid_t pid,
         end = mapinfo + len;
         p = nxt_sprintf(mapinfo, end, "%d %d 1",
                         default_container, default_host);
-        *p = '\0';
-
         if (nxt_slow_path(p == end)) {
-            nxt_alert(task, "write past mapinfo buffer");
+            nxt_alert(task, "truncation in mapinfo buffer");
             nxt_free(mapinfo);
             return NXT_ERROR;
         }
+
+        *p = '\0';
     }
 
     ret = nxt_clone_credential_map_write(task, mapfile, pid, mapinfo);


### PR DESCRIPTION
```
This patch fixes out-of-bounds reads and writes by placing some checks in the
right place.  However, this is only a workaround, and proper fixing requires:

-  Changing nxt_sprintf() to detect truncation.
-  Changing/adding other string copy functions to detect truncation.

Fixes: c554941b ("Initial applications isolation support using Linux namespaces.")
Fixes: e2b53e16 ("Added "rootfs" feature.")
Closes: <https://github.com/nginx/unit/issues/795>
Cc: Andrei Zeliankou <zelenkov@nginx.com>
Cc: Zhidao HONG <z.hong@f5.com>
Cc: Andrew Clayton <a.clayton@nginx.com>
Signed-off-by: Alejandro Colomar <alx@nginx.com>
```