### PR TITLE
Add nxt_stpecpy(), and use it in isolation code to replace (and optimize) unsafe code

### DIFF
--- a/src/nxt_string.c
+++ b/src/nxt_string.c
@@ -151,6 +151,26 @@ nxt_cpystrn(u_char *dst, const u_char *src, size_t length)
 }
 
 
+char *
+nxt_stpecpy(char *dst, char past_end[0], const char *restrict src)
+{
+    char *p;
+
+    if (dst == past_end) {
+        return past_end;
+    }
+
+    p = memccpy(dst, src, '\0', past_end - dst);
+    if (p != NULL) {
+        return p - 1;
+    }
+
+    /* truncation detected */
+    past_end[-1] = '\0';
+    return past_end;
+}
+
+
 nxt_int_t
 nxt_strcasecmp(const u_char *s1, const u_char *s2)
 {

--- a/src/nxt_string.h
+++ b/src/nxt_string.h
@@ -76,6 +76,8 @@ nxt_cpymem(void *dst, const void *src, size_t length)
 
 NXT_EXPORT u_char *nxt_cpystr(u_char *dst, const u_char *src);
 NXT_EXPORT u_char *nxt_cpystrn(u_char *dst, const u_char *src, size_t length);
+NXT_EXPORT char *nxt_stpecpy(char *dst, char *past_end,
+    const char *restrict src);
 NXT_EXPORT nxt_int_t nxt_strcasecmp(const u_char *s1, const u_char *s2);
 NXT_EXPORT nxt_int_t nxt_strncasecmp(const u_char *s1, const u_char *s2,
     size_t length);


### PR DESCRIPTION
```
/*
 * SYNOPSIS
 *      char *stpecpy(char *dst, char past_end[0], const char *restrict src);
 *
 * ARGUMENTS
 *      dst     Destination string.  Will be null-terminated after the
 *              call.
 *
 *      past_end
 *              Pointer to one past the last byte in the 'dst' buffer.
 *              This is used to truncate the output string if
 *              necessary.
 *
 *      src     Source string to copy from.  This string should be
 *              terminated with a NUL byte.
 *
 * DESCRIPTION
 *      This function is similar to stpcpy(3), but it truncates the
 *      output string as necessary.
 *
 *      You can chain calls to this function as you would do with
 *      stpcpy(3).  Only after the last call it is necessary to check
 *      for truncation (but don't forget to do so):
 *
 *          past_end = buf + sizeof(buf);
 *          p = buf;
 *          p = stpecpy(p, past_end, "foo");
 *          p = stpecpy(p, past_end, "bar");
 *          p = stpecpy(p, past_end, "baz");
 *          if (p == past_end) {
 *              --p;
 *              // Handle truncation.
 *          }
 *
 *      This function is an improvement over strscpy(9) and strlcpy(3)
 *      (and strlcat(3)), both in terms of usability and performance.
 *
 * RETURN VALUE
 *      This function returns a pointer to the 'end' of the destination
 *      string, that is, a pointer to its NUL byte.
 *
 *      However, if the destination string has been truncated, it
 *      returns a pointer to one past the end (past_end).
 *
 * ERRORS
 *      This function has no errors.  If strlcpy(3)-like behavior is
 *      desired, that is, if you want to crash if the input string is
 *      invalid (doesn't contain a terminating NUL byte), you may use
 *      stpecpyx() instead:
 *
 *      inline char *
 *      stpecpyx(char *dst, const char *restrict src, char past_end[0])
 *      {
 *          if (unlikely(src[strlen(src)] != '\0'))
 *              raise(SIGSEGV);
 *
 *          return stpecpy(dst, src, past_end);
 *      }
 *
 * CAVEATS
 *      Truncation is normally a bug, and you should detect it.  Only
 *      if a truncated string is not a problem, it makes sense to ignore
 *      the return value of this function.
 */

This function is in the public domain, and its design can be found in
the Codidact forum, in the following link.

Link: <https://software.codidact.com/posts/285946/287522#answer-287522>
Signed-off-by: Alejandro Colomar <alx@nginx.com>
```