### PR TITLE
Router: Log decissions about matching

### DIFF
--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -360,7 +360,7 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_http_members[] = {
 static nxt_conf_vldt_object_t  nxt_conf_vldt_log_members[] = {
     {
         .name       = nxt_string("level"),
-        .type       = NXT_CONF_VLDT_INTEGER,
+        .type       = NXT_CONF_VLDT_INTEGER | NXT_CONF_VLDT_STRING,
     },
 
     NXT_CONF_VLDT_END

--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -229,6 +229,7 @@ static nxt_int_t nxt_conf_vldt_cgroup_path(nxt_conf_validation_t *vldt,
 
 static nxt_conf_vldt_object_t  nxt_conf_vldt_setting_members[];
 static nxt_conf_vldt_object_t  nxt_conf_vldt_http_members[];
+static nxt_conf_vldt_object_t  nxt_conf_vldt_log_members[];
 static nxt_conf_vldt_object_t  nxt_conf_vldt_websocket_members[];
 static nxt_conf_vldt_object_t  nxt_conf_vldt_static_members[];
 static nxt_conf_vldt_object_t  nxt_conf_vldt_forwarded_members[];
@@ -298,6 +299,12 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_setting_members[] = {
         .validator  = nxt_conf_vldt_object,
         .u.members  = nxt_conf_vldt_http_members,
     },
+    {
+        .name       = nxt_string("log"),
+        .type       = NXT_CONF_VLDT_OBJECT,
+        .validator  = nxt_conf_vldt_object,
+        .u.members  = nxt_conf_vldt_log_members,
+    },
 
     NXT_CONF_VLDT_END
 };
@@ -344,6 +351,16 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_http_members[] = {
         .type       = NXT_CONF_VLDT_OBJECT,
         .validator  = nxt_conf_vldt_object,
         .u.members  = nxt_conf_vldt_static_members,
+    },
+
+    NXT_CONF_VLDT_END
+};
+
+
+static nxt_conf_vldt_object_t  nxt_conf_vldt_log_members[] = {
+    {
+        .name       = nxt_string("level"),
+        .type       = NXT_CONF_VLDT_INTEGER,
     },
 
     NXT_CONF_VLDT_END

--- a/src/nxt_h1proto.c
+++ b/src/nxt_h1proto.c
@@ -653,6 +653,9 @@ nxt_h1p_header_process(nxt_task_t *task, nxt_h1proto_t *h1p,
     r->path = &h1p->parser.path;
     r->args = &h1p->parser.args;
 
+    nxt_log(task, NXT_LOG_DIAG, "http request line: \"%V %V %V\"", r->method,
+            &r->target, &r->version);
+
     r->fields = h1p->parser.fields;
 
     ret = nxt_http_fields_process(r->fields, &nxt_h1p_fields_hash, r);

--- a/src/nxt_http.h
+++ b/src/nxt_http.h
@@ -362,7 +362,7 @@ nxt_int_t nxt_http_route_addr_rule(nxt_http_request_t *r,
     nxt_http_route_addr_rule_t *addr_rule, nxt_sockaddr_t *sockaddr);
 nxt_http_route_rule_t *nxt_http_route_types_rule_create(nxt_task_t *task,
     nxt_mp_t *mp, nxt_conf_value_t *types);
-nxt_int_t nxt_http_route_test_rule(nxt_http_request_t *r,
+nxt_int_t nxt_http_route_test_rule(nxt_task_t *task, nxt_http_request_t *r,
     nxt_http_route_rule_t *rule, u_char *start, size_t length);
 
 nxt_int_t nxt_http_action_init(nxt_task_t *task, nxt_router_temp_conf_t *tmcf,

--- a/src/nxt_http_request.c
+++ b/src/nxt_http_request.c
@@ -579,7 +579,8 @@ nxt_http_action_t *
 nxt_http_application_handler(nxt_task_t *task, nxt_http_request_t *r,
     nxt_http_action_t *action)
 {
-    nxt_debug(task, "http application handler");
+    nxt_debug(task, "http application handler: \"applications/%V\"",
+              action->u.pass);
 
     /*
      * TODO: need an application flag to get local address

--- a/src/nxt_http_return.c
+++ b/src/nxt_http_return.c
@@ -92,7 +92,7 @@ nxt_http_return(nxt_task_t *task, nxt_http_request_t *r,
         nxt_tstr_str(conf->location, &loc);
     }
 
-    nxt_debug(task, "http return: %d (loc: \"%V\")", conf->status, &loc);
+    nxt_debug(task, "http return: %d (location: \"%V\")", conf->status, &loc);
 #endif
 
     if (conf->status >= NXT_HTTP_BAD_REQUEST

--- a/src/nxt_http_route.c
+++ b/src/nxt_http_route.c
@@ -1549,6 +1549,14 @@ nxt_http_route_handler(nxt_task_t *task, nxt_http_request_t *r,
     for (i = 0; i < route->items; i++) {
         action = nxt_http_route_match(task, r, route->match[i]);
         if (action != NULL) {
+            if (start->u.pass->start == NULL) {
+                nxt_log(task, NXT_LOG_DIAG, "selected: \"routes/%z/action\"",
+                        i);
+            } else {
+                nxt_log(task, NXT_LOG_DIAG, "selected: \"routes/%V/%z/action\"",
+                        start->u.pass, i);
+            }
+
             return action;
         }
     }

--- a/src/nxt_http_route.c
+++ b/src/nxt_http_route.c
@@ -204,27 +204,27 @@ static nxt_http_action_t *nxt_http_route_handler(nxt_task_t *task,
     nxt_http_request_t *r, nxt_http_action_t *start);
 static nxt_http_action_t *nxt_http_route_match(nxt_task_t *task,
     nxt_http_request_t *r, nxt_http_route_match_t *match);
-static nxt_int_t nxt_http_route_table(nxt_http_request_t *r,
+static nxt_int_t nxt_http_route_table(nxt_task_t *task, nxt_http_request_t *r,
     nxt_http_route_table_t *table);
-static nxt_int_t nxt_http_route_ruleset(nxt_http_request_t *r,
+static nxt_int_t nxt_http_route_ruleset(nxt_task_t *task, nxt_http_request_t *r,
     nxt_http_route_ruleset_t *ruleset);
-static nxt_int_t nxt_http_route_rule(nxt_http_request_t *r,
+static nxt_int_t nxt_http_route_rule(nxt_task_t *task, nxt_http_request_t *r,
     nxt_http_route_rule_t *rule);
-static nxt_int_t nxt_http_route_header(nxt_http_request_t *r,
+static nxt_int_t nxt_http_route_header(nxt_task_t *task, nxt_http_request_t *r,
     nxt_http_route_rule_t *rule);
-static nxt_int_t nxt_http_route_arguments(nxt_http_request_t *r,
+static nxt_int_t nxt_http_route_arguments(nxt_task_t *task,
+    nxt_http_request_t *r, nxt_http_route_rule_t *rule);
+static nxt_int_t nxt_http_route_test_argument(nxt_task_t *task,
+    nxt_http_request_t *r, nxt_http_route_rule_t *rule, nxt_array_t *array);
+static nxt_int_t nxt_http_route_scheme(nxt_task_t *task, nxt_http_request_t *r,
     nxt_http_route_rule_t *rule);
-static nxt_int_t nxt_http_route_test_argument(nxt_http_request_t *r,
-    nxt_http_route_rule_t *rule, nxt_array_t *array);
-static nxt_int_t nxt_http_route_scheme(nxt_http_request_t *r,
+static nxt_int_t nxt_http_route_query(nxt_task_t *task, nxt_http_request_t *r,
     nxt_http_route_rule_t *rule);
-static nxt_int_t nxt_http_route_query(nxt_http_request_t *r,
+static nxt_int_t nxt_http_route_cookies(nxt_task_t *task, nxt_http_request_t *r,
     nxt_http_route_rule_t *rule);
-static nxt_int_t nxt_http_route_cookies(nxt_http_request_t *r,
-    nxt_http_route_rule_t *rule);
-static nxt_int_t nxt_http_route_test_cookie(nxt_http_request_t *r,
-    nxt_http_route_rule_t *rule, nxt_array_t *array);
-static nxt_int_t nxt_http_route_pattern(nxt_http_request_t *r,
+static nxt_int_t nxt_http_route_test_cookie(nxt_task_t *task,
+    nxt_http_request_t *r, nxt_http_route_rule_t *rule, nxt_array_t *array);
+static nxt_int_t nxt_http_route_pattern(nxt_task_t *task, nxt_http_request_t *r,
     nxt_http_route_pattern_t *pattern, u_char *start, size_t length);
 static nxt_int_t nxt_http_route_memcmp(u_char *start, u_char *test,
     size_t length, nxt_bool_t case_sensitive);
@@ -1572,7 +1572,7 @@ nxt_http_route_match(nxt_task_t *task, nxt_http_request_t *r,
     while (test < end) {
         switch (test->rule->object) {
         case NXT_HTTP_ROUTE_TABLE:
-            ret = nxt_http_route_table(r, test->table);
+            ret = nxt_http_route_table(task, r, test->table);
             break;
         case NXT_HTTP_ROUTE_SOURCE:
             ret = nxt_http_route_addr_rule(r, test->addr_rule, r->remote);
@@ -1585,7 +1585,7 @@ nxt_http_route_match(nxt_task_t *task, nxt_http_request_t *r,
             ret = nxt_http_route_addr_rule(r, test->addr_rule, r->local);
             break;
         default:
-            ret = nxt_http_route_rule(r, test->rule);
+            ret = nxt_http_route_rule(task, r, test->rule);
             break;
         }
 
@@ -1602,7 +1602,8 @@ nxt_http_route_match(nxt_task_t *task, nxt_http_request_t *r,
 
 
 static nxt_int_t
-nxt_http_route_table(nxt_http_request_t *r, nxt_http_route_table_t *table)
+nxt_http_route_table(nxt_task_t *task, nxt_http_request_t *r,
+    nxt_http_route_table_t *table)
 {
     nxt_int_t                 ret;
     nxt_http_route_ruleset_t  **ruleset, **end;
@@ -1612,7 +1613,7 @@ nxt_http_route_table(nxt_http_request_t *r, nxt_http_route_table_t *table)
     end = ruleset + table->items;
 
     while (ruleset < end) {
-        ret = nxt_http_route_ruleset(r, *ruleset);
+        ret = nxt_http_route_ruleset(task, r, *ruleset);
 
         if (ret != 0) {
             return ret;
@@ -1626,7 +1627,8 @@ nxt_http_route_table(nxt_http_request_t *r, nxt_http_route_table_t *table)
 
 
 static nxt_int_t
-nxt_http_route_ruleset(nxt_http_request_t *r, nxt_http_route_ruleset_t *ruleset)
+nxt_http_route_ruleset(nxt_task_t *task, nxt_http_request_t *r,
+    nxt_http_route_ruleset_t *ruleset)
 {
     nxt_int_t              ret;
     nxt_http_route_rule_t  **rule, **end;
@@ -1635,7 +1637,7 @@ nxt_http_route_ruleset(nxt_http_request_t *r, nxt_http_route_ruleset_t *ruleset)
     end = rule + ruleset->items;
 
     while (rule < end) {
-        ret = nxt_http_route_rule(r, *rule);
+        ret = nxt_http_route_rule(task, r, *rule);
 
         if (ret <= 0) {
             return ret;
@@ -1649,7 +1651,8 @@ nxt_http_route_ruleset(nxt_http_request_t *r, nxt_http_route_ruleset_t *ruleset)
 
 
 static nxt_int_t
-nxt_http_route_rule(nxt_http_request_t *r, nxt_http_route_rule_t *rule)
+nxt_http_route_rule(nxt_task_t *task, nxt_http_request_t *r,
+    nxt_http_route_rule_t *rule)
 {
     void       *p, **pp;
     u_char     *start;
@@ -1659,19 +1662,19 @@ nxt_http_route_rule(nxt_http_request_t *r, nxt_http_route_rule_t *rule)
     switch (rule->object) {
 
     case NXT_HTTP_ROUTE_HEADER:
-        return nxt_http_route_header(r, rule);
+        return nxt_http_route_header(task, r, rule);
 
     case NXT_HTTP_ROUTE_ARGUMENT:
-        return nxt_http_route_arguments(r, rule);
+        return nxt_http_route_arguments(task, r, rule);
 
     case NXT_HTTP_ROUTE_COOKIE:
-        return nxt_http_route_cookies(r, rule);
+        return nxt_http_route_cookies(task, r, rule);
 
     case NXT_HTTP_ROUTE_SCHEME:
-        return nxt_http_route_scheme(r, rule);
+        return nxt_http_route_scheme(task, r, rule);
 
     case NXT_HTTP_ROUTE_QUERY:
-        return nxt_http_route_query(r, rule);
+        return nxt_http_route_query(task, r, rule);
 
     default:
         break;
@@ -1695,7 +1698,7 @@ nxt_http_route_rule(nxt_http_request_t *r, nxt_http_route_rule_t *rule)
     length = s->length;
     start = s->start;
 
-    return nxt_http_route_test_rule(r, rule, start, length);
+    return nxt_http_route_test_rule(task, r, rule, start, length);
 }
 
 
@@ -1875,7 +1878,8 @@ nxt_http_route_addr_rule(nxt_http_request_t *r,
 
 
 static nxt_int_t
-nxt_http_route_header(nxt_http_request_t *r, nxt_http_route_rule_t *rule)
+nxt_http_route_header(nxt_task_t *task, nxt_http_request_t *r,
+    nxt_http_route_rule_t *rule)
 {
     nxt_int_t         ret;
     nxt_http_field_t  *f;
@@ -1892,7 +1896,8 @@ nxt_http_route_header(nxt_http_request_t *r, nxt_http_route_rule_t *rule)
             continue;
         }
 
-        ret = nxt_http_route_test_rule(r, rule, f->value, f->value_length);
+        ret = nxt_http_route_test_rule(task, r, rule, f->value,
+                                       f->value_length);
         if (nxt_slow_path(ret == NXT_ERROR)) {
             return NXT_ERROR;
         }
@@ -1908,7 +1913,8 @@ nxt_http_route_header(nxt_http_request_t *r, nxt_http_route_rule_t *rule)
 
 
 static nxt_int_t
-nxt_http_route_arguments(nxt_http_request_t *r, nxt_http_route_rule_t *rule)
+nxt_http_route_arguments(nxt_task_t *task, nxt_http_request_t *r,
+    nxt_http_route_rule_t *rule)
 {
     nxt_array_t  *arguments;
 
@@ -1917,12 +1923,12 @@ nxt_http_route_arguments(nxt_http_request_t *r, nxt_http_route_rule_t *rule)
         return -1;
     }
 
-    return nxt_http_route_test_argument(r, rule, arguments);
+    return nxt_http_route_test_argument(task, r, rule, arguments);
 }
 
 
 static nxt_int_t
-nxt_http_route_test_argument(nxt_http_request_t *r,
+nxt_http_route_test_argument(nxt_task_t *task, nxt_http_request_t *r,
     nxt_http_route_rule_t *rule, nxt_array_t *array)
 {
     nxt_int_t              ret;
@@ -1939,7 +1945,7 @@ nxt_http_route_test_argument(nxt_http_request_t *r,
             && rule->u.name.length == nv->name_length
             && memcmp(rule->u.name.start, nv->name, nv->name_length) == 0)
         {
-            ret = nxt_http_route_test_rule(r, rule, nv->value,
+            ret = nxt_http_route_test_rule(task, r, rule, nv->value,
                                            nv->value_length);
             if (nxt_slow_path(ret == NXT_ERROR)) {
                 return NXT_ERROR;
@@ -1958,20 +1964,24 @@ nxt_http_route_test_argument(nxt_http_request_t *r,
 
 
 static nxt_int_t
-nxt_http_route_scheme(nxt_http_request_t *r, nxt_http_route_rule_t *rule)
+nxt_http_route_scheme(nxt_task_t *task, nxt_http_request_t *r,
+    nxt_http_route_rule_t *rule)
 {
-    nxt_bool_t                      https;
+    nxt_bool_t                      https, match;
     nxt_http_route_pattern_slice_t  *pattern_slice;
 
     pattern_slice = rule->pattern[0].u.pattern_slices->elts;
     https = (pattern_slice->length == nxt_length("https"));
 
-    return (r->tls == https);
+    match = (r->tls == https);
+
+    return match;
 }
 
 
 static nxt_int_t
-nxt_http_route_query(nxt_http_request_t *r, nxt_http_route_rule_t *rule)
+nxt_http_route_query(nxt_task_t *task, nxt_http_request_t *r,
+    nxt_http_route_rule_t *rule)
 {
     nxt_array_t  *arguments;
 
@@ -1980,13 +1990,14 @@ nxt_http_route_query(nxt_http_request_t *r, nxt_http_route_rule_t *rule)
         return -1;
     }
 
-    return nxt_http_route_test_rule(r, rule, r->args_decoded.start,
+    return nxt_http_route_test_rule(task, r, rule, r->args_decoded.start,
                                     r->args_decoded.length);
 }
 
 
 static nxt_int_t
-nxt_http_route_cookies(nxt_http_request_t *r, nxt_http_route_rule_t *rule)
+nxt_http_route_cookies(nxt_task_t *task, nxt_http_request_t *r,
+    nxt_http_route_rule_t *rule)
 {
     nxt_array_t  *cookies;
 
@@ -1995,12 +2006,12 @@ nxt_http_route_cookies(nxt_http_request_t *r, nxt_http_route_rule_t *rule)
         return -1;
     }
 
-    return nxt_http_route_test_cookie(r, rule, cookies);
+    return nxt_http_route_test_cookie(task, r, rule, cookies);
 }
 
 
 static nxt_int_t
-nxt_http_route_test_cookie(nxt_http_request_t *r,
+nxt_http_route_test_cookie(nxt_task_t *task, nxt_http_request_t *r,
     nxt_http_route_rule_t *rule, nxt_array_t *array)
 {
     nxt_int_t              ret;
@@ -2017,7 +2028,7 @@ nxt_http_route_test_cookie(nxt_http_request_t *r,
             && rule->u.name.length == nv->name_length
             && memcmp(rule->u.name.start, nv->name, nv->name_length) == 0)
         {
-            ret = nxt_http_route_test_rule(r, rule, nv->value,
+            ret = nxt_http_route_test_rule(task, r, rule, nv->value,
                                            nv->value_length);
             if (nxt_slow_path(ret == NXT_ERROR)) {
                 return NXT_ERROR;
@@ -2036,8 +2047,8 @@ nxt_http_route_test_cookie(nxt_http_request_t *r,
 
 
 nxt_int_t
-nxt_http_route_test_rule(nxt_http_request_t *r, nxt_http_route_rule_t *rule,
-    u_char *start, size_t length)
+nxt_http_route_test_rule(nxt_task_t *task, nxt_http_request_t *r,
+    nxt_http_route_rule_t *rule, u_char *start, size_t length)
 {
     nxt_int_t                 ret;
     nxt_http_route_pattern_t  *pattern, *end;
@@ -2047,7 +2058,7 @@ nxt_http_route_test_rule(nxt_http_request_t *r, nxt_http_route_rule_t *rule,
     end = pattern + rule->items;
 
     while (pattern < end) {
-        ret = nxt_http_route_pattern(r, pattern, start, length);
+        ret = nxt_http_route_pattern(task, r, pattern, start, length);
         if (nxt_slow_path(ret == NXT_ERROR)) {
             return NXT_ERROR;
         }
@@ -2067,12 +2078,13 @@ nxt_http_route_test_rule(nxt_http_request_t *r, nxt_http_route_rule_t *rule,
 
 
 static nxt_int_t
-nxt_http_route_pattern(nxt_http_request_t *r, nxt_http_route_pattern_t *pattern,
-    u_char *start, size_t length)
+nxt_http_route_pattern(nxt_task_t *task, nxt_http_request_t *r,
+    nxt_http_route_pattern_t *pattern, u_char *start, size_t length)
 {
     u_char                          *p, *end, *test;
     size_t                          test_length;
     uint32_t                        i;
+    nxt_int_t                       match;
     nxt_array_t                     *pattern_slices;
     nxt_http_route_pattern_slice_t  *pattern_slice;
 
@@ -2085,7 +2097,9 @@ nxt_http_route_pattern(nxt_http_request_t *r, nxt_http_route_pattern_t *pattern,
             }
         }
 
-        return nxt_regex_match(pattern->u.regex, start, length, r->regex_match);
+        match = nxt_regex_match(pattern->u.regex, start, length,
+                                r->regex_match);
+        return match;
     }
 #endif
 
@@ -2105,14 +2119,16 @@ nxt_http_route_pattern(nxt_http_request_t *r, nxt_http_route_pattern_t *pattern,
 
         switch (pattern_slice->type) {
         case NXT_HTTP_ROUTE_PATTERN_EXACT:
-            return ((length == pattern->min_length) &&
-                    nxt_http_route_memcmp(start, test, test_length,
-                                          pattern->case_sensitive));
+            match = ((length == pattern->min_length) &&
+                     nxt_http_route_memcmp(start, test, test_length,
+                                           pattern->case_sensitive));
+            return match;
 
         case NXT_HTTP_ROUTE_PATTERN_BEGIN:
-            if (nxt_http_route_memcmp(start, test, test_length,
-                                      pattern->case_sensitive))
-            {
+            match = nxt_http_route_memcmp(start, test, test_length,
+                                          pattern->case_sensitive);
+
+            if (match) {
                 start += test_length;
                 break;
             }
@@ -2122,9 +2138,9 @@ nxt_http_route_pattern(nxt_http_request_t *r, nxt_http_route_pattern_t *pattern,
         case NXT_HTTP_ROUTE_PATTERN_END:
             p = end - test_length;
 
-            if (nxt_http_route_memcmp(p, test, test_length,
-                                      pattern->case_sensitive))
-            {
+            match = nxt_http_route_memcmp(p, test, test_length,
+                                          pattern->case_sensitive);
+            if (match) {
                 end = p;
                 break;
             }
@@ -2139,11 +2155,14 @@ nxt_http_route_pattern(nxt_http_request_t *r, nxt_http_route_pattern_t *pattern,
                 p = nxt_memcasestrn(start, end, (char *) test, test_length);
             }
 
-            if (p == NULL) {
-                return 0;
+            match = (p != NULL);
+
+            if (match) {
+                start = p + test_length;
+                break;
             }
 
-            start = p + test_length;
+            return 0;
         }
     }
 

--- a/src/nxt_http_route.c
+++ b/src/nxt_http_route.c
@@ -1544,6 +1544,12 @@ nxt_http_route_handler(nxt_task_t *task, nxt_http_request_t *r,
     nxt_http_route_t        *route;
     nxt_http_action_t       *action;
 
+    if (start->u.pass->start == NULL) {
+        nxt_debug(task, "http route handler: \"routes\"");
+    } else {
+        nxt_debug(task, "http route handler: \"routes/%V\"", start->u.pass);
+    }
+
     route = start->u.route;
 
     for (i = 0; i < route->items; i++) {

--- a/src/nxt_http_route.c
+++ b/src/nxt_http_route.c
@@ -1540,21 +1540,17 @@ static nxt_http_action_t *
 nxt_http_route_handler(nxt_task_t *task, nxt_http_request_t *r,
     nxt_http_action_t *start)
 {
+    size_t                  i;
     nxt_http_route_t        *route;
     nxt_http_action_t       *action;
-    nxt_http_route_match_t  **match, **end;
 
     route = start->u.route;
-    match = &route->match[0];
-    end = match + route->items;
 
-    while (match < end) {
-        action = nxt_http_route_match(task, r, *match);
+    for (i = 0; i < route->items; i++) {
+        action = nxt_http_route_match(task, r, route->match[i]);
         if (action != NULL) {
             return action;
         }
-
-        match++;
     }
 
     nxt_http_request_error(task, r, NXT_HTTP_NOT_FOUND);

--- a/src/nxt_http_route.c
+++ b/src/nxt_http_route.c
@@ -2099,11 +2099,17 @@ nxt_http_route_pattern(nxt_task_t *task, nxt_http_request_t *r,
 
         match = nxt_regex_match(pattern->u.regex, start, length,
                                 r->regex_match);
+        nxt_debug(task,
+                  "match try (string) regex: \"%V\", string: \"%*s\", match: %i",
+                  &pattern->u.regex->pattern, length, start, match);
+
         return match;
     }
 #endif
 
     if (length < pattern->min_length) {
+        nxt_debug(task, "match try (string): \"%*s\", string is short",
+                  length, start);
         return 0;
     }
 
@@ -2116,17 +2122,25 @@ nxt_http_route_pattern(nxt_task_t *task, nxt_http_request_t *r,
     for (i = 0; i < pattern_slices->nelts; i++, pattern_slice++) {
         test = pattern_slice->start;
         test_length = pattern_slice->length;
+        length = end - start;
 
         switch (pattern_slice->type) {
         case NXT_HTTP_ROUTE_PATTERN_EXACT:
             match = ((length == pattern->min_length) &&
                      nxt_http_route_memcmp(start, test, test_length,
                                            pattern->case_sensitive));
+            nxt_debug(task,
+                      "match try (string) exact: \"%*s\", string: \"%*s\", match: %b",
+                      test_length, test, length, start, match);
+
             return match;
 
         case NXT_HTTP_ROUTE_PATTERN_BEGIN:
             match = nxt_http_route_memcmp(start, test, test_length,
                                           pattern->case_sensitive);
+            nxt_debug(task,
+                      "match try (string) begin: \"%*s\", string: \"%*s\", match: %b",
+                      test_length, test, length, start, match);
 
             if (match) {
                 start += test_length;
@@ -2140,6 +2154,10 @@ nxt_http_route_pattern(nxt_task_t *task, nxt_http_request_t *r,
 
             match = nxt_http_route_memcmp(p, test, test_length,
                                           pattern->case_sensitive);
+            nxt_debug(task,
+                      "match try (string) end: \"%*s\", string: \"%*s\", match: %b",
+                      test_length, test, length, start, match);
+
             if (match) {
                 end = p;
                 break;
@@ -2156,6 +2174,10 @@ nxt_http_route_pattern(nxt_task_t *task, nxt_http_request_t *r,
             }
 
             match = (p != NULL);
+
+            nxt_debug(task,
+                      "match try (string) substring: \"%*s\", string: \"%*s\", match: %b",
+                      test_length, test, length, start, match);
 
             if (match) {
                 start = p + test_length;

--- a/src/nxt_http_route.c
+++ b/src/nxt_http_route.c
@@ -1957,27 +1957,24 @@ nxt_http_route_test_argument(nxt_task_t *task, nxt_http_request_t *r,
 
     ret = 0;
 
-    nv = array->elts;
-    end = nv + array->nelts;
+    for (nv = array->elts, end = nv + array->nelts; nv < end; nv++) {
 
-    while (nv < end) {
-
-        if (rule->u.name.hash == nv->hash
-            && rule->u.name.length == nv->name_length
-            && memcmp(rule->u.name.start, nv->name, nv->name_length) == 0)
+        if (rule->u.name.hash != nv->hash
+            || rule->u.name.length != nv->name_length
+            || memcmp(rule->u.name.start, nv->name, nv->name_length) != 0)
         {
-            ret = nxt_http_route_test_rule(task, r, rule, nv->value,
-                                           nv->value_length);
-            if (nxt_slow_path(ret == NXT_ERROR)) {
-                return NXT_ERROR;
-            }
-
-            if (ret == 0) {
-                break;
-            }
+            continue;
         }
 
-        nv++;
+        ret = nxt_http_route_test_rule(task, r, rule, nv->value,
+                                       nv->value_length);
+        if (nxt_slow_path(ret == NXT_ERROR)) {
+            return NXT_ERROR;
+        }
+
+        if (ret == 0) {
+            return 0;
+        }
     }
 
     return ret;
@@ -2040,27 +2037,24 @@ nxt_http_route_test_cookie(nxt_task_t *task, nxt_http_request_t *r,
 
     ret = 0;
 
-    nv = array->elts;
-    end = nv + array->nelts;
+    for (nv = array->elts, end = nv + array->nelts; nv < end; nv++) {
 
-    while (nv < end) {
-
-        if (rule->u.name.hash == nv->hash
-            && rule->u.name.length == nv->name_length
-            && memcmp(rule->u.name.start, nv->name, nv->name_length) == 0)
+        if (rule->u.name.hash != nv->hash
+            || rule->u.name.length != nv->name_length
+            || memcmp(rule->u.name.start, nv->name, nv->name_length) != 0)
         {
-            ret = nxt_http_route_test_rule(task, r, rule, nv->value,
-                                           nv->value_length);
-            if (nxt_slow_path(ret == NXT_ERROR)) {
-                return NXT_ERROR;
-            }
-
-            if (ret == 0) {
-                break;
-            }
+            continue;
         }
 
-        nv++;
+        ret = nxt_http_route_test_rule(task, r, rule, nv->value,
+                                       nv->value_length);
+        if (nxt_slow_path(ret == NXT_ERROR)) {
+            return NXT_ERROR;
+        }
+
+        if (ret == 0) {
+            return 0;
+        }
     }
 
     return ret;
@@ -2078,7 +2072,7 @@ nxt_http_route_test_rule(nxt_task_t *task, nxt_http_request_t *r,
     pattern = &rule->pattern[0];
     end = pattern + rule->items;
 
-    while (pattern < end) {
+    for (; pattern < end; pattern++) {
         ret = nxt_http_route_pattern(task, r, pattern, start, length);
         if (nxt_slow_path(ret == NXT_ERROR)) {
             return NXT_ERROR;
@@ -2090,8 +2084,6 @@ nxt_http_route_test_rule(nxt_task_t *task, nxt_http_request_t *r,
         if (pattern->any == ret) {
             return ret;
         }
-
-        pattern++;
     }
 
     return ret;

--- a/src/nxt_http_route.c
+++ b/src/nxt_http_route.c
@@ -1553,6 +1553,13 @@ nxt_http_route_handler(nxt_task_t *task, nxt_http_request_t *r,
     route = start->u.route;
 
     for (i = 0; i < route->items; i++) {
+        if (start->u.pass->start == NULL) {
+            nxt_log(task, NXT_LOG_DIAG, "evaluating: \"routes/%z\"", i);
+        } else {
+            nxt_log(task, NXT_LOG_DIAG, "evaluating: \"routes/%V/%z\"",
+                    start->u.pass, i);
+        }
+
         action = nxt_http_route_match(task, r, route->match[i]);
         if (action != NULL) {
             if (start->u.pass->start == NULL) {

--- a/src/nxt_http_static.c
+++ b/src/nxt_http_static.c
@@ -192,6 +192,8 @@ nxt_http_static(nxt_task_t *task, nxt_http_request_t *r,
     nxt_bool_t             need_body;
     nxt_http_static_ctx_t  *ctx;
 
+    nxt_debug(task, "http static handler");
+
     if (nxt_slow_path(!nxt_str_eq(r->method, "GET", 3))) {
 
         if (!nxt_str_eq(r->method, "HEAD", 4)) {

--- a/src/nxt_http_static.c
+++ b/src/nxt_http_static.c
@@ -353,7 +353,7 @@ nxt_http_static_send_ready(nxt_task_t *task, void *obj, void *data)
             nxt_http_static_extract_extension(shr, &exten);
             mtype = nxt_http_static_mtype_get(&rtcf->mtypes_hash, &exten);
 
-            ret = nxt_http_route_test_rule(r, conf->types, mtype->start,
+            ret = nxt_http_route_test_rule(task, r, conf->types, mtype->start,
                                            mtype->length);
             if (nxt_slow_path(ret == NXT_ERROR)) {
                 goto fail;

--- a/src/nxt_http_static.c
+++ b/src/nxt_http_static.c
@@ -198,6 +198,7 @@ nxt_http_static(nxt_task_t *task, nxt_http_request_t *r,
 
         if (!nxt_str_eq(r->method, "HEAD", 4)) {
             if (action->fallback != NULL) {
+                nxt_debug(task, "http static handler: fallback");
                 return action->fallback;
             }
 
@@ -692,6 +693,7 @@ nxt_http_static_next(nxt_task_t *task, nxt_http_request_t *r,
     }
 
     if (action->fallback != NULL) {
+        nxt_debug(task, "http static handler: fallback");
         nxt_http_request_action(task, r, action->fallback);
         return;
     }

--- a/src/nxt_log.c
+++ b/src/nxt_log.c
@@ -20,7 +20,7 @@ nxt_log_t   nxt_main_log = {
 };
 
 
-nxt_str_t  nxt_log_levels[] = {
+nxt_str_t  nxt_log_levels[7] = {
     nxt_string("alert"),
     nxt_string("error"),
     nxt_string("warn"),

--- a/src/nxt_log.c
+++ b/src/nxt_log.c
@@ -20,12 +20,13 @@ nxt_log_t   nxt_main_log = {
 };
 
 
-nxt_str_t  nxt_log_levels[6] = {
+nxt_str_t  nxt_log_levels[] = {
     nxt_string("alert"),
     nxt_string("error"),
     nxt_string("warn"),
     nxt_string("notice"),
     nxt_string("info"),
+    nxt_string("diag"),
     nxt_string("debug")
 };
 

--- a/src/nxt_log.h
+++ b/src/nxt_log.h
@@ -163,7 +163,7 @@ NXT_EXPORT void nxt_cdecl nxt_log_handler(nxt_uint_t level, nxt_log_t *log,
 NXT_EXPORT extern nxt_uint_t  nxt_debug;
 NXT_EXPORT extern nxt_uint_t  nxt_trace;
 NXT_EXPORT extern nxt_log_t   nxt_main_log;
-NXT_EXPORT extern nxt_str_t   nxt_log_levels[];
+NXT_EXPORT extern nxt_str_t   nxt_log_levels[7];
 
 
 #endif /* _NXT_LOG_H_INCLUDED_ */

--- a/src/nxt_log.h
+++ b/src/nxt_log.h
@@ -13,7 +13,8 @@
 #define NXT_LOG_WARN       2
 #define NXT_LOG_NOTICE     3
 #define NXT_LOG_INFO       4
-#define NXT_LOG_DEBUG      5
+#define NXT_LOG_DIAG       5
+#define NXT_LOG_DEBUG      6
 
 
 #define NXT_MAX_ERROR_STR  2048

--- a/src/nxt_pcre.c
+++ b/src/nxt_pcre.c
@@ -8,12 +8,6 @@
 #include <pcre.h>
 
 
-struct nxt_regex_s {
-    pcre        *code;
-    pcre_extra  *extra;
-    nxt_str_t   pattern;
-};
-
 struct nxt_regex_match_s {
     int  ovecsize;
     int  ovec[];

--- a/src/nxt_pcre2.c
+++ b/src/nxt_pcre2.c
@@ -14,12 +14,6 @@ static void *nxt_pcre2_malloc(PCRE2_SIZE size, void *memory_data);
 static void nxt_pcre2_free(void *p, void *memory_data);
 
 
-struct nxt_regex_s {
-    pcre2_code  *code;
-    nxt_str_t   pattern;
-};
-
-
 nxt_regex_t *
 nxt_regex_compile(nxt_mp_t *mp, nxt_str_t *source, nxt_regex_err_t *err)
 {

--- a/src/nxt_regex.h
+++ b/src/nxt_regex.h
@@ -7,11 +7,20 @@
 #ifndef _NXT_REGEX_H_INCLUDED_
 #define _NXT_REGEX_H_INCLUDED_
 
+
 #if (NXT_HAVE_REGEX)
+
+#if (NXT_HAVE_PCRE2)
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
+#else
+#include <pcre.h>
+#endif
+
 
 typedef struct nxt_regex_s        nxt_regex_t;
 
- #if (NXT_HAVE_PCRE2)
+#if (NXT_HAVE_PCRE2)
 typedef void                      nxt_regex_match_t;
 #else
 typedef struct nxt_regex_match_s  nxt_regex_match_t;
@@ -27,6 +36,17 @@ typedef struct {
     const char  *msg;
 #endif
 } nxt_regex_err_t;
+
+
+struct nxt_regex_s {
+#if (NXT_HAVE_PCRE2)
+    pcre2_code  *code;
+#else
+    pcre        *code;
+    pcre_extra  *extra;
+#endif
+    nxt_str_t   pattern;
+};
 
 
 NXT_EXPORT void nxt_regex_init(void);

--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -106,6 +106,9 @@ static nxt_int_t nxt_router_conf_create(nxt_task_t *task,
     nxt_router_temp_conf_t *tmcf, u_char *start, u_char *end);
 static nxt_int_t nxt_router_conf_create_applications(nxt_task_t *task,
     nxt_router_temp_conf_t *tmcf, nxt_conf_value_t *applications);
+static nxt_int_t nxt_router_conf_create_listeners(nxt_task_t *task,
+    nxt_router_temp_conf_t *tmcf, nxt_conf_value_t *root,
+    nxt_conf_value_t *listeners);
 static nxt_int_t nxt_router_conf_process_static(nxt_task_t *task,
     nxt_router_conf_t *rtcf, nxt_conf_value_t *conf);
 static nxt_http_forward_t *nxt_router_conf_forward(nxt_task_t *task,
@@ -1541,41 +1544,20 @@ nxt_router_conf_create(nxt_task_t *task, nxt_router_temp_conf_t *tmcf,
     u_char *start, u_char *end)
 {
     nxt_mp_t                    *mp;
-    uint32_t                    next;
     nxt_int_t                   ret;
-    nxt_str_t                   name;
     nxt_app_t                   *app;
-    nxt_str_t                   *t;
     nxt_router_t                *router;
-#if (NXT_TLS)
-    nxt_uint_t                  n, i;
-    nxt_tls_init_t              *tls_init;
-    nxt_conf_value_t            *certificate;
-#endif
-    nxt_conf_value_t            *root, *conf, *http, *value, *websocket;
+    nxt_conf_value_t            *root, *conf, *value;
     nxt_conf_value_t            *applications;
-    nxt_conf_value_t            *listeners, *listener;
-    nxt_socket_conf_t           *skcf;
+    nxt_conf_value_t            *listeners;
     nxt_router_conf_t           *rtcf;
     nxt_http_routes_t           *routes;
-    nxt_router_listener_conf_t  lscf;
 
-    static nxt_str_t  http_path = nxt_string("/settings/http");
     static nxt_str_t  applications_path = nxt_string("/applications");
     static nxt_str_t  listeners_path = nxt_string("/listeners");
     static nxt_str_t  routes_path = nxt_string("/routes");
     static nxt_str_t  access_log_path = nxt_string("/access_log");
-#if (NXT_TLS)
-    static nxt_str_t  certificate_path = nxt_string("/tls/certificate");
-    static nxt_str_t  conf_commands_path = nxt_string("/tls/conf_commands");
-    static nxt_str_t  conf_cache_path = nxt_string("/tls/session/cache_size");
-    static nxt_str_t  conf_timeout_path = nxt_string("/tls/session/timeout");
-    static nxt_str_t  conf_tickets = nxt_string("/tls/session/tickets");
-#endif
     static nxt_str_t  static_path = nxt_string("/settings/http/static");
-    static nxt_str_t  websocket_path = nxt_string("/settings/http/websocket");
-    static nxt_str_t  forwarded_path = nxt_string("/forwarded");
-    static nxt_str_t  client_ip_path = nxt_string("/client_ip");
 
     root = nxt_conf_json_parse(tmcf->mem_pool, start, end, NULL);
     if (root == NULL) {
@@ -1630,174 +1612,12 @@ nxt_router_conf_create(nxt_task_t *task, nxt_router_temp_conf_t *tmcf,
         return ret;
     }
 
-    http = nxt_conf_get_path(root, &http_path);
-#if 0
-    if (http == NULL) {
-        nxt_alert(task, "no \"http\" block");
-        return NXT_ERROR;
-    }
-#endif
-
-    websocket = nxt_conf_get_path(root, &websocket_path);
-
     listeners = nxt_conf_get_path(root, &listeners_path);
 
     if (listeners != NULL) {
-        next = 0;
-
-        for ( ;; ) {
-            listener = nxt_conf_next_object_member(listeners, &name, &next);
-            if (listener == NULL) {
-                break;
-            }
-
-            skcf = nxt_router_socket_conf(task, tmcf, &name);
-            if (skcf == NULL) {
-                goto fail;
-            }
-
-            nxt_memzero(&lscf, sizeof(lscf));
-
-            ret = nxt_conf_map_object(mp, listener, nxt_router_listener_conf,
-                                      nxt_nitems(nxt_router_listener_conf),
-                                      &lscf);
-            if (ret != NXT_OK) {
-                nxt_alert(task, "listener map error");
-                goto fail;
-            }
-
-            nxt_debug(task, "application: %V", &lscf.application);
-
-            // STUB, default values if http block is not defined.
-            skcf->header_buffer_size = 2048;
-            skcf->large_header_buffer_size = 8192;
-            skcf->large_header_buffers = 4;
-            skcf->discard_unsafe_fields = 1;
-            skcf->body_buffer_size = 16 * 1024;
-            skcf->max_body_size = 8 * 1024 * 1024;
-            skcf->proxy_header_buffer_size = 64 * 1024;
-            skcf->proxy_buffer_size = 4096;
-            skcf->proxy_buffers = 256;
-            skcf->idle_timeout = 180 * 1000;
-            skcf->header_read_timeout = 30 * 1000;
-            skcf->body_read_timeout = 30 * 1000;
-            skcf->send_timeout = 30 * 1000;
-            skcf->proxy_timeout = 60 * 1000;
-            skcf->proxy_send_timeout = 30 * 1000;
-            skcf->proxy_read_timeout = 30 * 1000;
-
-            skcf->websocket_conf.max_frame_size = 1024 * 1024;
-            skcf->websocket_conf.read_timeout = 60 * 1000;
-            skcf->websocket_conf.keepalive_interval = 30 * 1000;
-
-            nxt_str_null(&skcf->body_temp_path);
-
-            if (http != NULL) {
-                ret = nxt_conf_map_object(mp, http, nxt_router_http_conf,
-                                          nxt_nitems(nxt_router_http_conf),
-                                          skcf);
-                if (ret != NXT_OK) {
-                    nxt_alert(task, "http map error");
-                    goto fail;
-                }
-            }
-
-            if (websocket != NULL) {
-                ret = nxt_conf_map_object(mp, websocket,
-                                          nxt_router_websocket_conf,
-                                          nxt_nitems(nxt_router_websocket_conf),
-                                          &skcf->websocket_conf);
-                if (ret != NXT_OK) {
-                    nxt_alert(task, "websocket map error");
-                    goto fail;
-                }
-            }
-
-            t = &skcf->body_temp_path;
-
-            if (t->length == 0) {
-                t->start = (u_char *) task->thread->runtime->tmp;
-                t->length = nxt_strlen(t->start);
-            }
-
-            conf = nxt_conf_get_path(listener, &forwarded_path);
-
-            if (conf != NULL) {
-                skcf->forwarded = nxt_router_conf_forward(task, mp, conf);
-                if (nxt_slow_path(skcf->forwarded == NULL)) {
-                    return NXT_ERROR;
-                }
-            }
-
-            conf = nxt_conf_get_path(listener, &client_ip_path);
-
-            if (conf != NULL) {
-                skcf->client_ip = nxt_router_conf_forward(task, mp, conf);
-                if (nxt_slow_path(skcf->client_ip == NULL)) {
-                    return NXT_ERROR;
-                }
-            }
-
-#if (NXT_TLS)
-            certificate = nxt_conf_get_path(listener, &certificate_path);
-
-            if (certificate != NULL) {
-                tls_init = nxt_mp_get(tmcf->mem_pool, sizeof(nxt_tls_init_t));
-                if (nxt_slow_path(tls_init == NULL)) {
-                    return NXT_ERROR;
-                }
-
-                tls_init->cache_size = 0;
-                tls_init->timeout = 300;
-
-                value = nxt_conf_get_path(listener, &conf_cache_path);
-                if (value != NULL) {
-                    tls_init->cache_size = nxt_conf_get_number(value);
-                }
-
-                value = nxt_conf_get_path(listener, &conf_timeout_path);
-                if (value != NULL) {
-                    tls_init->timeout = nxt_conf_get_number(value);
-                }
-
-                tls_init->conf_cmds = nxt_conf_get_path(listener,
-                                                        &conf_commands_path);
-
-                tls_init->tickets_conf = nxt_conf_get_path(listener,
-                                                           &conf_tickets);
-
-                n = nxt_conf_array_elements_count_or_1(certificate);
-
-                for (i = 0; i < n; i++) {
-                    value = nxt_conf_get_array_element_or_itself(certificate,
-                                                                 i);
-                    nxt_assert(value != NULL);
-
-                    ret = nxt_router_conf_tls_insert(tmcf, value, skcf,
-                                                     tls_init, i == 0);
-                    if (nxt_slow_path(ret != NXT_OK)) {
-                        goto fail;
-                    }
-                }
-            }
-#endif
-
-            skcf->listen->handler = nxt_http_conn_init;
-            skcf->router_conf = rtcf;
-            skcf->router_conf->count++;
-
-            if (lscf.pass.length != 0) {
-                skcf->action = nxt_http_action_create(task, tmcf, &lscf.pass);
-
-            /* COMPATIBILITY: listener application. */
-            } else if (lscf.application.length > 0) {
-                skcf->action = nxt_http_pass_application(task, rtcf,
-                                                         &lscf.application);
-            }
-
-            if (nxt_slow_path(skcf->action == NULL)) {
-                goto fail;
-            }
+        ret = nxt_router_conf_create_listeners(task, tmcf, root, listeners);
+        if (nxt_slow_path(ret == NXT_ERROR)) {
+            return NXT_ERROR;
         }
     }
 
@@ -2099,6 +1919,225 @@ nxt_router_conf_create_applications(nxt_task_t *task,
 app_fail:
 
     nxt_mp_destroy(app_mp);
+
+fail:
+
+    nxt_queue_each(app, &tmcf->apps, nxt_app_t, link) {
+
+        nxt_queue_remove(&app->link);
+        nxt_thread_mutex_destroy(&app->mutex);
+        nxt_mp_destroy(app->mem_pool);
+
+    } nxt_queue_loop;
+
+    return NXT_ERROR;
+}
+
+
+static nxt_int_t
+nxt_router_conf_create_listeners(nxt_task_t *task, nxt_router_temp_conf_t *tmcf,
+    nxt_conf_value_t *root, nxt_conf_value_t *listeners)
+{
+    nxt_mp_t                    *mp;
+    uint32_t                    next;
+    nxt_int_t                   ret;
+    nxt_str_t                   name;
+    nxt_app_t                   *app;
+    nxt_str_t                   *t;
+#if (NXT_TLS)
+    nxt_uint_t                  n, i;
+    nxt_tls_init_t              *tls_init;
+    nxt_conf_value_t            *certificate;
+#endif
+    nxt_conf_value_t            *conf, *http, *value, *websocket;
+    nxt_conf_value_t            *listener;
+    nxt_socket_conf_t           *skcf;
+    nxt_router_conf_t           *rtcf;
+    nxt_router_listener_conf_t  lscf;
+
+    static nxt_str_t  http_path = nxt_string("/settings/http");
+#if (NXT_TLS)
+    static nxt_str_t  certificate_path = nxt_string("/tls/certificate");
+    static nxt_str_t  conf_commands_path = nxt_string("/tls/conf_commands");
+    static nxt_str_t  conf_cache_path = nxt_string("/tls/session/cache_size");
+    static nxt_str_t  conf_timeout_path = nxt_string("/tls/session/timeout");
+    static nxt_str_t  conf_tickets = nxt_string("/tls/session/tickets");
+#endif
+    static nxt_str_t  websocket_path = nxt_string("/settings/http/websocket");
+    static nxt_str_t  forwarded_path = nxt_string("/forwarded");
+    static nxt_str_t  client_ip_path = nxt_string("/client_ip");
+
+    rtcf = tmcf->router_conf;
+    mp = rtcf->mem_pool;
+
+    http = nxt_conf_get_path(root, &http_path);
+#if 0
+    if (http == NULL) {
+        nxt_alert(task, "no \"http\" block");
+        return NXT_ERROR;
+    }
+#endif
+
+    websocket = nxt_conf_get_path(root, &websocket_path);
+
+    next = 0;
+
+    for ( ;; ) {
+        listener = nxt_conf_next_object_member(listeners, &name, &next);
+        if (listener == NULL) {
+            return NXT_OK;
+        }
+
+        skcf = nxt_router_socket_conf(task, tmcf, &name);
+        if (skcf == NULL) {
+            goto fail;
+        }
+
+        nxt_memzero(&lscf, sizeof(lscf));
+
+        ret = nxt_conf_map_object(mp, listener, nxt_router_listener_conf,
+                                  nxt_nitems(nxt_router_listener_conf),
+                                  &lscf);
+        if (ret != NXT_OK) {
+            nxt_alert(task, "listener map error");
+            goto fail;
+        }
+
+        nxt_debug(task, "application: %V", &lscf.application);
+
+        // STUB, default values if http block is not defined.
+        skcf->header_buffer_size = 2048;
+        skcf->large_header_buffer_size = 8192;
+        skcf->large_header_buffers = 4;
+        skcf->discard_unsafe_fields = 1;
+        skcf->body_buffer_size = 16 * 1024;
+        skcf->max_body_size = 8 * 1024 * 1024;
+        skcf->proxy_header_buffer_size = 64 * 1024;
+        skcf->proxy_buffer_size = 4096;
+        skcf->proxy_buffers = 256;
+        skcf->idle_timeout = 180 * 1000;
+        skcf->header_read_timeout = 30 * 1000;
+        skcf->body_read_timeout = 30 * 1000;
+        skcf->send_timeout = 30 * 1000;
+        skcf->proxy_timeout = 60 * 1000;
+        skcf->proxy_send_timeout = 30 * 1000;
+        skcf->proxy_read_timeout = 30 * 1000;
+
+        skcf->websocket_conf.max_frame_size = 1024 * 1024;
+        skcf->websocket_conf.read_timeout = 60 * 1000;
+        skcf->websocket_conf.keepalive_interval = 30 * 1000;
+
+        nxt_str_null(&skcf->body_temp_path);
+
+        if (http != NULL) {
+            ret = nxt_conf_map_object(mp, http, nxt_router_http_conf,
+                                      nxt_nitems(nxt_router_http_conf),
+                                      skcf);
+            if (ret != NXT_OK) {
+                nxt_alert(task, "http map error");
+                goto fail;
+            }
+        }
+
+        if (websocket != NULL) {
+            ret = nxt_conf_map_object(mp, websocket,
+                                      nxt_router_websocket_conf,
+                                      nxt_nitems(nxt_router_websocket_conf),
+                                      &skcf->websocket_conf);
+            if (ret != NXT_OK) {
+                nxt_alert(task, "websocket map error");
+                goto fail;
+            }
+        }
+
+        t = &skcf->body_temp_path;
+
+        if (t->length == 0) {
+            t->start = (u_char *) task->thread->runtime->tmp;
+            t->length = nxt_strlen(t->start);
+        }
+
+        conf = nxt_conf_get_path(listener, &forwarded_path);
+
+        if (conf != NULL) {
+            skcf->forwarded = nxt_router_conf_forward(task, mp, conf);
+            if (nxt_slow_path(skcf->forwarded == NULL)) {
+                return NXT_ERROR;
+            }
+        }
+
+        conf = nxt_conf_get_path(listener, &client_ip_path);
+
+        if (conf != NULL) {
+            skcf->client_ip = nxt_router_conf_forward(task, mp, conf);
+            if (nxt_slow_path(skcf->client_ip == NULL)) {
+                return NXT_ERROR;
+            }
+        }
+
+#if (NXT_TLS)
+        certificate = nxt_conf_get_path(listener, &certificate_path);
+
+        if (certificate != NULL) {
+            tls_init = nxt_mp_get(tmcf->mem_pool, sizeof(nxt_tls_init_t));
+            if (nxt_slow_path(tls_init == NULL)) {
+                return NXT_ERROR;
+            }
+
+            tls_init->cache_size = 0;
+            tls_init->timeout = 300;
+
+            value = nxt_conf_get_path(listener, &conf_cache_path);
+            if (value != NULL) {
+                tls_init->cache_size = nxt_conf_get_number(value);
+            }
+
+            value = nxt_conf_get_path(listener, &conf_timeout_path);
+            if (value != NULL) {
+                tls_init->timeout = nxt_conf_get_number(value);
+            }
+
+            tls_init->conf_cmds = nxt_conf_get_path(listener,
+                                                    &conf_commands_path);
+
+            tls_init->tickets_conf = nxt_conf_get_path(listener,
+                                                       &conf_tickets);
+
+            n = nxt_conf_array_elements_count_or_1(certificate);
+
+            for (i = 0; i < n; i++) {
+                value = nxt_conf_get_array_element_or_itself(certificate,
+                                                             i);
+                nxt_assert(value != NULL);
+
+                ret = nxt_router_conf_tls_insert(tmcf, value, skcf,
+                                                 tls_init, i == 0);
+                if (nxt_slow_path(ret != NXT_OK)) {
+                    goto fail;
+                }
+            }
+        }
+#endif
+
+        skcf->listen->handler = nxt_http_conn_init;
+        skcf->router_conf = rtcf;
+        skcf->router_conf->count++;
+
+        if (lscf.pass.length != 0) {
+            skcf->action = nxt_http_action_create(task, tmcf, &lscf.pass);
+
+        /* COMPATIBILITY: listener application. */
+        } else if (lscf.application.length > 0) {
+            skcf->action = nxt_http_pass_application(task, rtcf,
+                                                     &lscf.application);
+        }
+
+        if (nxt_slow_path(skcf->action == NULL)) {
+            goto fail;
+        }
+    }
+
+    nxt_unreachable();
 
 fail:
 

--- a/src/nxt_unit.c
+++ b/src/nxt_unit.c
@@ -6674,6 +6674,7 @@ static const char * nxt_unit_log_levels[] = {
     "warn",
     "notice",
     "info",
+    "diag",
     "debug",
 };
 


### PR DESCRIPTION
These patches do 3 things:

-  Move definition of `struct nxt_regex_s` to a header file (that's necessary for being able to log its contents in a different Translation Unit).

-  Add a parameter `task` to many functions, to pass it down to the function where I want to add the logging (`task` is needed for logging).

-  Add the actual logging for match trials (`nxt_debug()`).

EDIT:

And after modifications, a few more things:

- Add `-std=gnu11` to the compiler flags.
- Add warning about variable declaration after statement.
- Introduce (C99) loop variables in the project.
- Log the routes and actions that are chosen.
- Simplify some code after these changes allow it.