### PR TITLE
Debug router

### DIFF
--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -344,6 +344,9 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_http_members[] = {
         .type       = NXT_CONF_VLDT_OBJECT,
         .validator  = nxt_conf_vldt_object,
         .u.members  = nxt_conf_vldt_static_members,
+    }, {
+        .name       = nxt_string("log_route_selection"),
+        .type       = NXT_CONF_VLDT_BOOLEAN,
     },
 
     NXT_CONF_VLDT_END

--- a/src/nxt_h1proto.c
+++ b/src/nxt_h1proto.c
@@ -654,6 +654,10 @@ nxt_h1p_header_process(nxt_task_t *task, nxt_h1proto_t *h1p,
     r->path = &h1p->parser.path;
     r->args = &h1p->parser.args;
 
+    nxt_log_http(task, r, NXT_LOG_NOTICE, NXT_LOG_HTTP_ROUTE_SELECTION,
+                 "http request line: \"%V %V %V\"",
+                 r->method, &r->target, &r->version);
+
     r->fields = h1p->parser.fields;
 
     ret = nxt_http_fields_process(r->fields, &nxt_h1p_fields_hash, r);

--- a/src/nxt_h1proto.c
+++ b/src/nxt_h1proto.c
@@ -507,6 +507,7 @@ nxt_h1p_conn_request_init(nxt_task_t *task, void *obj, void *data)
 
             r->conf = joint;
             skcf = joint->socket_conf;
+            r->log_ft = skcf->log_ft;
 
             if (c->local == NULL) {
                 c->local = skcf->sockaddr;

--- a/src/nxt_http.h
+++ b/src/nxt_http.h
@@ -7,6 +7,8 @@
 #ifndef _NXT_HTTP_H_INCLUDED_
 #define _NXT_HTTP_H_INCLUDED_
 
+
+#include <nxt_log_http.h>
 #include <nxt_regex.h>
 
 
@@ -165,6 +167,7 @@ struct nxt_http_request_s {
     nxt_sockaddr_t                  *remote;
     nxt_sockaddr_t                  *local;
     nxt_task_t                      task;
+    nxt_log_http_features_t         log_ft;
 
     nxt_timer_t                     timer;
     void                            *timer_data;

--- a/src/nxt_http.h
+++ b/src/nxt_http.h
@@ -365,7 +365,7 @@ nxt_int_t nxt_http_route_addr_rule(nxt_http_request_t *r,
     nxt_http_route_addr_rule_t *addr_rule, nxt_sockaddr_t *sockaddr);
 nxt_http_route_rule_t *nxt_http_route_types_rule_create(nxt_task_t *task,
     nxt_mp_t *mp, nxt_conf_value_t *types);
-nxt_int_t nxt_http_route_test_rule(nxt_http_request_t *r,
+nxt_int_t nxt_http_route_test_rule(nxt_task_t *task, nxt_http_request_t *r,
     nxt_http_route_rule_t *rule, u_char *start, size_t length);
 
 nxt_int_t nxt_http_action_init(nxt_task_t *task, nxt_router_temp_conf_t *tmcf,

--- a/src/nxt_http_request.c
+++ b/src/nxt_http_request.c
@@ -579,7 +579,14 @@ nxt_http_action_t *
 nxt_http_application_handler(nxt_task_t *task, nxt_http_request_t *r,
     nxt_http_action_t *action)
 {
-    nxt_debug(task, "http application handler");
+#if (NXT_DEBUG)
+    nxt_http_app_conf_t  *conf;
+
+    conf = action->u.conf;
+#endif
+
+    nxt_debug(task, "http application handler: \"applications/%V\"",
+              &conf->app->name);
 
     /*
      * TODO: need an application flag to get local address

--- a/src/nxt_http_return.c
+++ b/src/nxt_http_return.c
@@ -92,7 +92,7 @@ nxt_http_return(nxt_task_t *task, nxt_http_request_t *r,
         nxt_tstr_str(conf->location, &loc);
     }
 
-    nxt_debug(task, "http return: %d (loc: \"%V\")", conf->status, &loc);
+    nxt_debug(task, "http return: %d (location: \"%V\")", conf->status, &loc);
 #endif
 
     if (conf->status >= NXT_HTTP_BAD_REQUEST

--- a/src/nxt_http_route.c
+++ b/src/nxt_http_route.c
@@ -1555,6 +1555,14 @@ nxt_http_route_handler(nxt_task_t *task, nxt_http_request_t *r,
     route = start->u.route;
 
     for (i = 0; i < route->items; i++) {
+        if (start->u.pass->start == NULL) {
+            nxt_log_http(task, r, NXT_LOG_INFO, NXT_LOG_HTTP_ROUTE_SELECTION,
+                         "evaluating: \"routes/%z\"", i);
+        } else {
+            nxt_log_http(task, r, NXT_LOG_INFO, NXT_LOG_HTTP_ROUTE_SELECTION,
+                         "evaluating: \"routes/%V/%z\"", start->u.pass, i);
+        }
+
         action = nxt_http_route_match(task, r, route->match[i]);
         if (action != NULL) {
             if (start->u.pass->start == NULL) {

--- a/src/nxt_http_route.c
+++ b/src/nxt_http_route.c
@@ -1549,6 +1549,17 @@ nxt_http_route_handler(nxt_task_t *task, nxt_http_request_t *r,
     for (i = 0; i < route->items; i++) {
         action = nxt_http_route_match(task, r, route->match[i]);
         if (action != NULL) {
+            if (start->u.pass->start == NULL) {
+                nxt_log_http(task, r, NXT_LOG_NOTICE,
+                             NXT_LOG_HTTP_ROUTE_SELECTION,
+                             "selected: \"routes/%z/action\"", i);
+            } else {
+                nxt_log_http(task, r, NXT_LOG_NOTICE,
+                             NXT_LOG_HTTP_ROUTE_SELECTION,
+                             "selected: \"routes/%V/%z/action\"",
+                             start->u.pass, i);
+            }
+
             return action;
         }
     }

--- a/src/nxt_http_route.c
+++ b/src/nxt_http_route.c
@@ -1540,21 +1540,17 @@ static nxt_http_action_t *
 nxt_http_route_handler(nxt_task_t *task, nxt_http_request_t *r,
     nxt_http_action_t *start)
 {
+    size_t                  i;
     nxt_http_route_t        *route;
     nxt_http_action_t       *action;
-    nxt_http_route_match_t  **match, **end;
 
     route = start->u.route;
-    match = &route->match[0];
-    end = match + route->items;
 
-    while (match < end) {
-        action = nxt_http_route_match(task, r, *match);
+    for (i = 0; i < route->items; i++) {
+        action = nxt_http_route_match(task, r, route->match[i]);
         if (action != NULL) {
             return action;
         }
-
-        match++;
     }
 
     nxt_http_request_error(task, r, NXT_HTTP_NOT_FOUND);

--- a/src/nxt_http_route.c
+++ b/src/nxt_http_route.c
@@ -2165,11 +2165,18 @@ nxt_http_route_pattern(nxt_task_t *task, nxt_http_request_t *r,
 
         match = nxt_regex_match(pattern->u.regex, start, length,
                                 r->regex_match);
+        nxt_debug_http(task, r, NXT_LOG_HTTP_ROUTE_SELECTION,
+                       "match try (string) regex: \"%V\", string: \"%*s\", match: %i",
+                       &pattern->u.regex->pattern, length, start, match);
+
         return match;
     }
 #endif
 
     if (length < pattern->min_length) {
+        nxt_debug_http(task, r, NXT_LOG_HTTP_ROUTE_SELECTION,
+                       "match try (string): \"%*s\", string is short",
+                       length, start);
         return 0;
     }
 
@@ -2182,17 +2189,25 @@ nxt_http_route_pattern(nxt_task_t *task, nxt_http_request_t *r,
     for (i = 0; i < pattern_slices->nelts; i++, pattern_slice++) {
         test = pattern_slice->start;
         test_length = pattern_slice->length;
+        length = end - start;
 
         switch (pattern_slice->type) {
         case NXT_HTTP_ROUTE_PATTERN_EXACT:
             match = ((length == pattern->min_length) &&
                      nxt_http_route_memcmp(start, test, test_length,
                                            pattern->case_sensitive));
+            nxt_debug_http(task, r, NXT_LOG_HTTP_ROUTE_SELECTION,
+                           "match try (string) exact: \"%*s\", string: \"%*s\", match: %b",
+                           test_length, test, length, start, match);
+
             return match;
 
         case NXT_HTTP_ROUTE_PATTERN_BEGIN:
             match = nxt_http_route_memcmp(start, test, test_length,
                                           pattern->case_sensitive);
+            nxt_debug_http(task, r, NXT_LOG_HTTP_ROUTE_SELECTION,
+                           "match try (string) begin: \"%*s\", string: \"%*s\", match: %b",
+                           test_length, test, length, start, match);
 
             if (match) {
                 start += test_length;
@@ -2206,6 +2221,10 @@ nxt_http_route_pattern(nxt_task_t *task, nxt_http_request_t *r,
 
             match = nxt_http_route_memcmp(p, test, test_length,
                                           pattern->case_sensitive);
+            nxt_debug_http(task, r, NXT_LOG_HTTP_ROUTE_SELECTION,
+                           "match try (string) end: \"%*s\", string: \"%*s\", match: %b",
+                           test_length, test, length, start, match);
+
             if (match) {
                 end = p;
                 break;
@@ -2222,6 +2241,10 @@ nxt_http_route_pattern(nxt_task_t *task, nxt_http_request_t *r,
             }
 
             match = (p != NULL);
+
+            nxt_debug_http(task, r, NXT_LOG_HTTP_ROUTE_SELECTION,
+                           "match try (string) substring: \"%*s\", string: \"%*s\", match: %b",
+                           test_length, test, length, start, match);
 
             if (match) {
                 start = p + test_length;

--- a/src/nxt_http_route.c
+++ b/src/nxt_http_route.c
@@ -1544,6 +1544,14 @@ nxt_http_route_handler(nxt_task_t *task, nxt_http_request_t *r,
     nxt_http_route_t        *route;
     nxt_http_action_t       *action;
 
+    if (start->u.pass->start == NULL) {
+        nxt_debug_http(task, r, NXT_LOG_HTTP_ROUTE_SELECTION,
+                       "http route handler: \"routes\"");
+    } else {
+        nxt_debug_http(task, r, NXT_LOG_HTTP_ROUTE_SELECTION,
+                       "http route handler: \"routes/%V\"", start->u.pass);
+    }
+
     route = start->u.route;
 
     for (i = 0; i < route->items; i++) {

--- a/src/nxt_http_route.c
+++ b/src/nxt_http_route.c
@@ -1601,16 +1601,25 @@ nxt_http_route_match(nxt_task_t *task, nxt_http_request_t *r,
         case NXT_HTTP_ROUTE_TABLE:
             ret = nxt_http_route_table(task, r, test->table);
             break;
+
         case NXT_HTTP_ROUTE_SOURCE:
+            nxt_debug_http(task, r, NXT_LOG_HTTP_ROUTE_SELECTION,
+                           "match try: \"source\"");
+
             ret = nxt_http_route_addr_rule(r, test->addr_rule, r->remote);
             break;
+
         case NXT_HTTP_ROUTE_DESTINATION:
+            nxt_debug_http(task, r, NXT_LOG_HTTP_ROUTE_SELECTION,
+                           "match try: \"destination\"");
+
             if (r->local == NULL && nxt_fast_path(r->proto.any != NULL)) {
                 nxt_http_proto[r->protocol].local_addr(task, r);
             }
 
             ret = nxt_http_route_addr_rule(r, test->addr_rule, r->local);
             break;
+
         default:
             ret = nxt_http_route_rule(task, r, test->rule);
             break;
@@ -1684,17 +1693,26 @@ nxt_http_route_rule(nxt_task_t *task, nxt_http_request_t *r,
     void       *p, **pp;
     u_char     *start;
     size_t     length;
-    nxt_str_t  *s;
+    nxt_str_t  *s, rule_name;
 
     switch (rule->object) {
 
     case NXT_HTTP_ROUTE_HEADER:
+        nxt_debug_http(task, r, NXT_LOG_HTTP_ROUTE_SELECTION,
+                       "match try: \"headers/%*s\"",
+                       rule->u.name.length, rule->u.name.start);
         return nxt_http_route_header(task, r, rule);
 
     case NXT_HTTP_ROUTE_ARGUMENT:
+        nxt_debug_http(task, r, NXT_LOG_HTTP_ROUTE_SELECTION,
+                       "match try: \"arguments/%*s\"",
+                       rule->u.name.length, rule->u.name.start);
         return nxt_http_route_arguments(task, r, rule);
 
     case NXT_HTTP_ROUTE_COOKIE:
+        nxt_debug_http(task, r, NXT_LOG_HTTP_ROUTE_SELECTION,
+                       "match try: \"cookies/%*s\"",
+                       rule->u.name.length, rule->u.name.start);
         return nxt_http_route_cookies(task, r, rule);
 
     case NXT_HTTP_ROUTE_SCHEME:
@@ -1724,6 +1742,24 @@ nxt_http_route_rule(nxt_task_t *task, nxt_http_request_t *r,
 
     length = s->length;
     start = s->start;
+
+    switch (rule->u.offset) {
+
+    case offsetof(nxt_http_request_t, host):
+        nxt_str_set(&rule_name, "host");
+        break;
+
+    case offsetof(nxt_http_request_t, path):
+        nxt_str_set(&rule_name, "uri");
+        break;
+
+    case offsetof(nxt_http_request_t, method):
+        nxt_str_set(&rule_name, "method");
+        break;
+    }
+
+    nxt_debug_http(task, r, NXT_LOG_HTTP_ROUTE_SELECTION,
+                   "match try: \"%V\"", &rule_name);
 
     return nxt_http_route_test_rule(task, r, rule, start, length);
 }
@@ -2001,6 +2037,9 @@ nxt_http_route_scheme(nxt_task_t *task, nxt_http_request_t *r,
     https = (pattern_slice->length == nxt_length("https"));
 
     match = (r->tls == https);
+    nxt_debug_http(task, r, NXT_LOG_HTTP_ROUTE_SELECTION,
+                   "match try: \"scheme\": \"%*s\"; match: %b",
+                   pattern_slice->length, pattern_slice->start, match);
 
     return match;
 }

--- a/src/nxt_http_static.c
+++ b/src/nxt_http_static.c
@@ -192,6 +192,8 @@ nxt_http_static(nxt_task_t *task, nxt_http_request_t *r,
     nxt_bool_t             need_body;
     nxt_http_static_ctx_t  *ctx;
 
+    nxt_debug(task, "http static handler");
+
     if (nxt_slow_path(!nxt_str_eq(r->method, "GET", 3))) {
 
         if (!nxt_str_eq(r->method, "HEAD", 4)) {

--- a/src/nxt_http_static.c
+++ b/src/nxt_http_static.c
@@ -353,7 +353,7 @@ nxt_http_static_send_ready(nxt_task_t *task, void *obj, void *data)
             nxt_http_static_extract_extension(shr, &exten);
             mtype = nxt_http_static_mtype_get(&rtcf->mtypes_hash, &exten);
 
-            ret = nxt_http_route_test_rule(r, conf->types, mtype->start,
+            ret = nxt_http_route_test_rule(task, r, conf->types, mtype->start,
                                            mtype->length);
             if (nxt_slow_path(ret == NXT_ERROR)) {
                 goto fail;

--- a/src/nxt_http_static.c
+++ b/src/nxt_http_static.c
@@ -198,6 +198,7 @@ nxt_http_static(nxt_task_t *task, nxt_http_request_t *r,
 
         if (!nxt_str_eq(r->method, "HEAD", 4)) {
             if (action->fallback != NULL) {
+                nxt_debug(task, "http static handler: fallback");
                 return action->fallback;
             }
 
@@ -692,6 +693,7 @@ nxt_http_static_next(nxt_task_t *task, nxt_http_request_t *r,
     }
 
     if (action->fallback != NULL) {
+        nxt_debug(task, "http static handler: fallback");
         nxt_http_request_action(task, r, action->fallback);
         return;
     }

--- a/src/nxt_log_http.h
+++ b/src/nxt_log_http.h
@@ -1,0 +1,41 @@
+
+/*
+ * Copyright (C) Alejandro Colomar <alx@nginx.com>
+ * Copyright (C) NGINX, Inc.
+ */
+
+#ifndef _NXT_LOG_HTTP_H_INCLUDED_
+#define _NXT_LOG_HTTP_H_INCLUDED_
+
+
+#include "nxt_main.h"
+
+#include "nxt_clang.h"
+#include "nxt_log.h"
+
+
+typedef enum nxt_log_http_features_e  nxt_log_http_features_t;
+
+
+#define nxt_log_http(task, r, level, cond, ...)                               \
+    do {                                                                      \
+        if (nxt_slow_path((cond) & (r)->log_ft)) {                            \
+            nxt_log(task, level, __VA_ARGS__);                                \
+        }                                                                     \
+    } while (0)
+
+
+#define nxt_debug_http(task, r, cond, ...)                                    \
+    do {                                                                      \
+        if (nxt_slow_path((cond) & (r)->log_ft)) {                            \
+            nxt_debug(task, level, __VA_ARGS__);                              \
+        }                                                                     \
+    } while (0)
+
+
+enum nxt_log_http_features_e {
+    NXT_LOG_HTTP_ROUTE_SELECTION = 0x01,
+};
+
+
+#endif  /* _NXT_LOG_HTTP_H_INCLUDED_ */

--- a/src/nxt_pcre.c
+++ b/src/nxt_pcre.c
@@ -8,12 +8,6 @@
 #include <pcre.h>
 
 
-struct nxt_regex_s {
-    pcre        *code;
-    pcre_extra  *extra;
-    nxt_str_t   pattern;
-};
-
 struct nxt_regex_match_s {
     int  ovecsize;
     int  ovec[];

--- a/src/nxt_pcre2.c
+++ b/src/nxt_pcre2.c
@@ -14,12 +14,6 @@ static void *nxt_pcre2_malloc(PCRE2_SIZE size, void *memory_data);
 static void nxt_pcre2_free(void *p, void *memory_data);
 
 
-struct nxt_regex_s {
-    pcre2_code  *code;
-    nxt_str_t   pattern;
-};
-
-
 nxt_regex_t *
 nxt_regex_compile(nxt_mp_t *mp, nxt_str_t *source, nxt_regex_err_t *err)
 {

--- a/src/nxt_regex.h
+++ b/src/nxt_regex.h
@@ -7,11 +7,20 @@
 #ifndef _NXT_REGEX_H_INCLUDED_
 #define _NXT_REGEX_H_INCLUDED_
 
+
 #if (NXT_HAVE_REGEX)
+
+#if (NXT_HAVE_PCRE2)
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
+#else
+#include <pcre.h>
+#endif
+
 
 typedef struct nxt_regex_s        nxt_regex_t;
 
- #if (NXT_HAVE_PCRE2)
+#if (NXT_HAVE_PCRE2)
 typedef void                      nxt_regex_match_t;
 #else
 typedef struct nxt_regex_match_s  nxt_regex_match_t;
@@ -27,6 +36,17 @@ typedef struct {
     const char  *msg;
 #endif
 } nxt_regex_err_t;
+
+
+struct nxt_regex_s {
+#if (NXT_HAVE_PCRE2)
+    pcre2_code  *code;
+#else
+    pcre        *code;
+    pcre_extra  *extra;
+#endif
+    nxt_str_t   pattern;
+};
 
 
 NXT_EXPORT void nxt_regex_init(void);

--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -2465,12 +2465,6 @@ nxt_router_apps_hash_use(nxt_task_t *task, nxt_router_conf_t *rtcf, int i)
 }
 
 
-typedef struct {
-    nxt_app_t  *app;
-    nxt_int_t  target;
-} nxt_http_app_conf_t;
-
-
 nxt_int_t
 nxt_router_application_init(nxt_router_conf_t *rtcf, nxt_str_t *name,
     nxt_str_t *target, nxt_http_action_t *action)

--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -104,6 +104,8 @@ static void nxt_router_conf_send(nxt_task_t *task,
 
 static nxt_int_t nxt_router_conf_create(nxt_task_t *task,
     nxt_router_temp_conf_t *tmcf, u_char *start, u_char *end);
+static nxt_int_t nxt_router_conf_create_applications(nxt_task_t *task,
+    nxt_router_temp_conf_t *tmcf, nxt_conf_value_t *applications);
 static nxt_int_t nxt_router_conf_process_static(nxt_task_t *task,
     nxt_router_conf_t *rtcf, nxt_conf_value_t *conf);
 static nxt_http_forward_t *nxt_router_conf_forward(nxt_task_t *task,
@@ -1542,31 +1544,24 @@ static nxt_int_t
 nxt_router_conf_create(nxt_task_t *task, nxt_router_temp_conf_t *tmcf,
     u_char *start, u_char *end)
 {
-    u_char                      *p;
-    size_t                      size;
-    nxt_mp_t                    *mp, *app_mp;
-    uint32_t                    next, next_target;
+    nxt_mp_t                    *mp;
+    uint32_t                    next;
     nxt_int_t                   ret;
-    nxt_str_t                   name, target;
-    nxt_app_t                   *app, *prev;
-    nxt_str_t                   *t, *s, *targets;
-    nxt_uint_t                  n, i;
-    nxt_port_t                  *port;
+    nxt_str_t                   name;
+    nxt_app_t                   *app;
+    nxt_str_t                   *t;
     nxt_router_t                *router;
-    nxt_app_joint_t             *app_joint;
 #if (NXT_TLS)
+    nxt_uint_t                  n, i;
     nxt_tls_init_t              *tls_init;
     nxt_conf_value_t            *certificate;
 #endif
     nxt_conf_value_t            *root, *conf, *http, *value, *websocket;
-    nxt_conf_value_t            *applications, *application;
+    nxt_conf_value_t            *applications;
     nxt_conf_value_t            *listeners, *listener;
     nxt_socket_conf_t           *skcf;
     nxt_router_conf_t           *rtcf;
     nxt_http_routes_t           *routes;
-    nxt_event_engine_t          *engine;
-    nxt_app_lang_module_t       *lang;
-    nxt_router_app_conf_t       apcf;
     nxt_router_listener_conf_t  lscf;
 
     static nxt_str_t  http_path = nxt_string("/settings/http");
@@ -1618,235 +1613,9 @@ nxt_router_conf_create(nxt_task_t *task, nxt_router_temp_conf_t *tmcf,
     applications = nxt_conf_get_path(root, &applications_path);
 
     if (applications != NULL) {
-        next = 0;
-
-        for ( ;; ) {
-            application = nxt_conf_next_object_member(applications,
-                                                      &name, &next);
-            if (application == NULL) {
-                break;
-            }
-
-            nxt_debug(task, "application \"%V\"", &name);
-
-            size = nxt_conf_json_length(application, NULL);
-
-            app_mp = nxt_mp_create(4096, 128, 1024, 64);
-            if (nxt_slow_path(app_mp == NULL)) {
-                goto fail;
-            }
-
-            app = nxt_mp_get(app_mp, sizeof(nxt_app_t) + name.length + size);
-            if (app == NULL) {
-                goto app_fail;
-            }
-
-            nxt_memzero(app, sizeof(nxt_app_t));
-
-            app->mem_pool = app_mp;
-
-            app->name.start = nxt_pointer_to(app, sizeof(nxt_app_t));
-            app->conf.start = nxt_pointer_to(app, sizeof(nxt_app_t)
-                                                  + name.length);
-
-            p = nxt_conf_json_print(app->conf.start, application, NULL);
-            app->conf.length = p - app->conf.start;
-
-            nxt_assert(app->conf.length <= size);
-
-            nxt_debug(task, "application conf \"%V\"", &app->conf);
-
-            prev = nxt_router_app_find(&router->apps, &name);
-
-            if (prev != NULL && nxt_strstr_eq(&app->conf, &prev->conf)) {
-                nxt_mp_destroy(app_mp);
-
-                nxt_queue_remove(&prev->link);
-                nxt_queue_insert_tail(&tmcf->previous, &prev->link);
-
-                ret = nxt_router_apps_hash_add(rtcf, prev);
-                if (nxt_slow_path(ret != NXT_OK)) {
-                    goto fail;
-                }
-
-                continue;
-            }
-
-            apcf.processes = 1;
-            apcf.max_processes = 1;
-            apcf.spare_processes = 0;
-            apcf.timeout = 0;
-            apcf.idle_timeout = 15000;
-            apcf.limits_value = NULL;
-            apcf.processes_value = NULL;
-            apcf.targets_value = NULL;
-
-            app_joint = nxt_malloc(sizeof(nxt_app_joint_t));
-            if (nxt_slow_path(app_joint == NULL)) {
-                goto app_fail;
-            }
-
-            nxt_memzero(app_joint, sizeof(nxt_app_joint_t));
-
-            ret = nxt_conf_map_object(mp, application, nxt_router_app_conf,
-                                      nxt_nitems(nxt_router_app_conf), &apcf);
-            if (ret != NXT_OK) {
-                nxt_alert(task, "application map error");
-                goto app_fail;
-            }
-
-            if (apcf.limits_value != NULL) {
-
-                if (nxt_conf_type(apcf.limits_value) != NXT_CONF_OBJECT) {
-                    nxt_alert(task, "application limits is not object");
-                    goto app_fail;
-                }
-
-                ret = nxt_conf_map_object(mp, apcf.limits_value,
-                                        nxt_router_app_limits_conf,
-                                        nxt_nitems(nxt_router_app_limits_conf),
-                                        &apcf);
-                if (ret != NXT_OK) {
-                    nxt_alert(task, "application limits map error");
-                    goto app_fail;
-                }
-            }
-
-            if (apcf.processes_value != NULL
-                && nxt_conf_type(apcf.processes_value) == NXT_CONF_OBJECT)
-            {
-                ret = nxt_conf_map_object(mp, apcf.processes_value,
-                                     nxt_router_app_processes_conf,
-                                     nxt_nitems(nxt_router_app_processes_conf),
-                                     &apcf);
-                if (ret != NXT_OK) {
-                    nxt_alert(task, "application processes map error");
-                    goto app_fail;
-                }
-
-            } else {
-                apcf.max_processes = apcf.processes;
-                apcf.spare_processes = apcf.processes;
-            }
-
-            if (apcf.targets_value != NULL) {
-                n = nxt_conf_object_members_count(apcf.targets_value);
-
-                targets = nxt_mp_get(app_mp, sizeof(nxt_str_t) * n);
-                if (nxt_slow_path(targets == NULL)) {
-                    goto app_fail;
-                }
-
-                next_target = 0;
-
-                for (i = 0; i < n; i++) {
-                    (void) nxt_conf_next_object_member(apcf.targets_value,
-                                                       &target, &next_target);
-
-                    s = nxt_str_dup(app_mp, &targets[i], &target);
-                    if (nxt_slow_path(s == NULL)) {
-                        goto app_fail;
-                    }
-                }
-
-            } else {
-                targets = NULL;
-            }
-
-            nxt_debug(task, "application type: %V", &apcf.type);
-            nxt_debug(task, "application processes: %D", apcf.processes);
-            nxt_debug(task, "application request timeout: %M", apcf.timeout);
-
-            lang = nxt_app_lang_module(task->thread->runtime, &apcf.type);
-
-            if (lang == NULL) {
-                nxt_alert(task, "unknown application type: \"%V\"", &apcf.type);
-                goto app_fail;
-            }
-
-            nxt_debug(task, "application language module: \"%s\"", lang->file);
-
-            ret = nxt_thread_mutex_create(&app->mutex);
-            if (ret != NXT_OK) {
-                goto app_fail;
-            }
-
-            nxt_queue_init(&app->ports);
-            nxt_queue_init(&app->spare_ports);
-            nxt_queue_init(&app->idle_ports);
-            nxt_queue_init(&app->ack_waiting_req);
-
-            app->name.length = name.length;
-            nxt_memcpy(app->name.start, name.start, name.length);
-
-            app->type = lang->type;
-            app->max_processes = apcf.max_processes;
-            app->spare_processes = apcf.spare_processes;
-            app->max_pending_processes = apcf.spare_processes
-                                         ? apcf.spare_processes : 1;
-            app->timeout = apcf.timeout;
-            app->idle_timeout = apcf.idle_timeout;
-
-            app->targets = targets;
-
-            engine = task->thread->engine;
-
-            app->engine = engine;
-
-            app->adjust_idle_work.handler = nxt_router_adjust_idle_timer;
-            app->adjust_idle_work.task = &engine->task;
-            app->adjust_idle_work.obj = app;
-
-            nxt_queue_insert_tail(&tmcf->apps, &app->link);
-
-            ret = nxt_router_apps_hash_add(rtcf, app);
-            if (nxt_slow_path(ret != NXT_OK)) {
-                goto app_fail;
-            }
-
-            nxt_router_app_use(task, app, 1);
-
-            app->joint = app_joint;
-
-            app_joint->use_count = 1;
-            app_joint->app = app;
-
-            app_joint->idle_timer.bias = NXT_TIMER_DEFAULT_BIAS;
-            app_joint->idle_timer.work_queue = &engine->fast_work_queue;
-            app_joint->idle_timer.handler = nxt_router_app_idle_timeout;
-            app_joint->idle_timer.task = &engine->task;
-            app_joint->idle_timer.log = app_joint->idle_timer.task->log;
-
-            app_joint->free_app_work.handler = nxt_router_free_app;
-            app_joint->free_app_work.task = &engine->task;
-            app_joint->free_app_work.obj = app_joint;
-
-            port = nxt_port_new(task, NXT_SHARED_PORT_ID, nxt_pid,
-                                NXT_PROCESS_APP);
-            if (nxt_slow_path(port == NULL)) {
-                return NXT_ERROR;
-            }
-
-            ret = nxt_port_socket_init(task, port, 0);
-            if (nxt_slow_path(ret != NXT_OK)) {
-                nxt_port_use(task, port, -1);
-                return NXT_ERROR;
-            }
-
-            ret = nxt_router_app_queue_init(task, port);
-            if (nxt_slow_path(ret != NXT_OK)) {
-                nxt_port_write_close(port);
-                nxt_port_read_close(port);
-                nxt_port_use(task, port, -1);
-                return NXT_ERROR;
-            }
-
-            nxt_port_write_enable(task, port);
-            port->app = app;
-
-            app->shared_port = port;
-
-            nxt_thread_mutex_create(&app->outgoing.mutex);
+        ret = nxt_router_conf_create_applications(task, tmcf, applications);
+        if (nxt_slow_path(ret == NXT_ERROR)) {
+            return NXT_ERROR;
         }
     }
 
@@ -2059,6 +1828,277 @@ nxt_router_conf_create(nxt_task_t *task, nxt_router_temp_conf_t *tmcf,
     nxt_queue_init(&router->sockets);
 
     return NXT_OK;
+
+fail:
+
+    nxt_queue_each(app, &tmcf->apps, nxt_app_t, link) {
+
+        nxt_queue_remove(&app->link);
+        nxt_thread_mutex_destroy(&app->mutex);
+        nxt_mp_destroy(app->mem_pool);
+
+    } nxt_queue_loop;
+
+    return NXT_ERROR;
+}
+
+
+static nxt_int_t
+nxt_router_conf_create_applications(nxt_task_t *task,
+    nxt_router_temp_conf_t *tmcf, nxt_conf_value_t *applications)
+{
+    u_char                      *p;
+    size_t                      size;
+    nxt_mp_t                    *mp, *app_mp;
+    uint32_t                    next, next_target;
+    nxt_int_t                   ret;
+    nxt_str_t                   name, target;
+    nxt_app_t                   *app, *prev;
+    nxt_str_t                   *s, *targets;
+    nxt_uint_t                  n, i;
+    nxt_port_t                  *port;
+    nxt_router_t                *router;
+    nxt_app_joint_t             *app_joint;
+    nxt_conf_value_t            *application;
+    nxt_router_conf_t           *rtcf;
+    nxt_event_engine_t          *engine;
+    nxt_app_lang_module_t       *lang;
+    nxt_router_app_conf_t       apcf;
+
+    rtcf = tmcf->router_conf;
+    mp = rtcf->mem_pool;
+    router = rtcf->router;
+
+    next = 0;
+
+    for ( ;; ) {
+        application = nxt_conf_next_object_member(applications, &name, &next);
+        if (application == NULL) {
+            return NXT_OK;
+        }
+
+        nxt_debug(task, "application \"%V\"", &name);
+
+        size = nxt_conf_json_length(application, NULL);
+
+        app_mp = nxt_mp_create(4096, 128, 1024, 64);
+        if (nxt_slow_path(app_mp == NULL)) {
+            goto fail;
+        }
+
+        app = nxt_mp_get(app_mp, sizeof(nxt_app_t) + name.length + size);
+        if (app == NULL) {
+            goto app_fail;
+        }
+
+        nxt_memzero(app, sizeof(nxt_app_t));
+
+        app->mem_pool = app_mp;
+
+        app->name.start = nxt_pointer_to(app, sizeof(nxt_app_t));
+        app->conf.start = nxt_pointer_to(app, sizeof(nxt_app_t) + name.length);
+
+        p = nxt_conf_json_print(app->conf.start, application, NULL);
+        app->conf.length = p - app->conf.start;
+
+        nxt_assert(app->conf.length <= size);
+
+        nxt_debug(task, "application conf \"%V\"", &app->conf);
+
+        prev = nxt_router_app_find(&router->apps, &name);
+
+        if (prev != NULL && nxt_strstr_eq(&app->conf, &prev->conf)) {
+            nxt_mp_destroy(app_mp);
+
+            nxt_queue_remove(&prev->link);
+            nxt_queue_insert_tail(&tmcf->previous, &prev->link);
+
+            ret = nxt_router_apps_hash_add(rtcf, prev);
+            if (nxt_slow_path(ret != NXT_OK)) {
+                goto fail;
+            }
+
+            continue;
+        }
+
+        apcf.processes = 1;
+        apcf.max_processes = 1;
+        apcf.spare_processes = 0;
+        apcf.timeout = 0;
+        apcf.idle_timeout = 15000;
+        apcf.limits_value = NULL;
+        apcf.processes_value = NULL;
+        apcf.targets_value = NULL;
+
+        app_joint = nxt_malloc(sizeof(nxt_app_joint_t));
+        if (nxt_slow_path(app_joint == NULL)) {
+            goto app_fail;
+        }
+
+        nxt_memzero(app_joint, sizeof(nxt_app_joint_t));
+
+        ret = nxt_conf_map_object(mp, application, nxt_router_app_conf,
+                                  nxt_nitems(nxt_router_app_conf), &apcf);
+        if (ret != NXT_OK) {
+            nxt_alert(task, "application map error");
+            goto app_fail;
+        }
+
+        if (apcf.limits_value != NULL) {
+
+            if (nxt_conf_type(apcf.limits_value) != NXT_CONF_OBJECT) {
+                nxt_alert(task, "application limits is not object");
+                goto app_fail;
+            }
+
+            ret = nxt_conf_map_object(mp, apcf.limits_value,
+                                      nxt_router_app_limits_conf,
+                                      nxt_nitems(nxt_router_app_limits_conf),
+                                      &apcf);
+            if (ret != NXT_OK) {
+                nxt_alert(task, "application limits map error");
+                goto app_fail;
+            }
+        }
+
+        if (apcf.processes_value != NULL
+            && nxt_conf_type(apcf.processes_value) == NXT_CONF_OBJECT)
+        {
+            ret = nxt_conf_map_object(mp, apcf.processes_value,
+                                      nxt_router_app_processes_conf,
+                                      nxt_nitems(nxt_router_app_processes_conf),
+                                      &apcf);
+            if (ret != NXT_OK) {
+                nxt_alert(task, "application processes map error");
+                goto app_fail;
+            }
+
+        } else {
+            apcf.max_processes = apcf.processes;
+            apcf.spare_processes = apcf.processes;
+        }
+
+        if (apcf.targets_value != NULL) {
+            n = nxt_conf_object_members_count(apcf.targets_value);
+
+            targets = nxt_mp_get(app_mp, sizeof(nxt_str_t) * n);
+            if (nxt_slow_path(targets == NULL)) {
+                goto app_fail;
+            }
+
+            next_target = 0;
+
+            for (i = 0; i < n; i++) {
+                (void) nxt_conf_next_object_member(apcf.targets_value,
+                                                   &target, &next_target);
+
+                s = nxt_str_dup(app_mp, &targets[i], &target);
+                if (nxt_slow_path(s == NULL)) {
+                    goto app_fail;
+                }
+            }
+
+        } else {
+            targets = NULL;
+        }
+
+        nxt_debug(task, "application type: %V", &apcf.type);
+        nxt_debug(task, "application processes: %D", apcf.processes);
+        nxt_debug(task, "application request timeout: %M", apcf.timeout);
+
+        lang = nxt_app_lang_module(task->thread->runtime, &apcf.type);
+
+        if (lang == NULL) {
+            nxt_alert(task, "unknown application type: \"%V\"", &apcf.type);
+            goto app_fail;
+        }
+
+        nxt_debug(task, "application language module: \"%s\"", lang->file);
+
+        ret = nxt_thread_mutex_create(&app->mutex);
+        if (ret != NXT_OK) {
+            goto app_fail;
+        }
+
+        nxt_queue_init(&app->ports);
+        nxt_queue_init(&app->spare_ports);
+        nxt_queue_init(&app->idle_ports);
+        nxt_queue_init(&app->ack_waiting_req);
+
+        app->name.length = name.length;
+        nxt_memcpy(app->name.start, name.start, name.length);
+
+        app->type = lang->type;
+        app->max_processes = apcf.max_processes;
+        app->spare_processes = apcf.spare_processes;
+        app->max_pending_processes = apcf.spare_processes
+                                     ? apcf.spare_processes : 1;
+        app->timeout = apcf.timeout;
+        app->idle_timeout = apcf.idle_timeout;
+
+        app->targets = targets;
+
+        engine = task->thread->engine;
+
+        app->engine = engine;
+
+        app->adjust_idle_work.handler = nxt_router_adjust_idle_timer;
+        app->adjust_idle_work.task = &engine->task;
+        app->adjust_idle_work.obj = app;
+
+        nxt_queue_insert_tail(&tmcf->apps, &app->link);
+
+        ret = nxt_router_apps_hash_add(rtcf, app);
+        if (nxt_slow_path(ret != NXT_OK)) {
+            goto app_fail;
+        }
+
+        nxt_router_app_use(task, app, 1);
+
+        app->joint = app_joint;
+
+        app_joint->use_count = 1;
+        app_joint->app = app;
+
+        app_joint->idle_timer.bias = NXT_TIMER_DEFAULT_BIAS;
+        app_joint->idle_timer.work_queue = &engine->fast_work_queue;
+        app_joint->idle_timer.handler = nxt_router_app_idle_timeout;
+        app_joint->idle_timer.task = &engine->task;
+        app_joint->idle_timer.log = app_joint->idle_timer.task->log;
+
+        app_joint->free_app_work.handler = nxt_router_free_app;
+        app_joint->free_app_work.task = &engine->task;
+        app_joint->free_app_work.obj = app_joint;
+
+        port = nxt_port_new(task, NXT_SHARED_PORT_ID, nxt_pid,
+                            NXT_PROCESS_APP);
+        if (nxt_slow_path(port == NULL)) {
+            return NXT_ERROR;
+        }
+
+        ret = nxt_port_socket_init(task, port, 0);
+        if (nxt_slow_path(ret != NXT_OK)) {
+            nxt_port_use(task, port, -1);
+            return NXT_ERROR;
+        }
+
+        ret = nxt_router_app_queue_init(task, port);
+        if (nxt_slow_path(ret != NXT_OK)) {
+            nxt_port_write_close(port);
+            nxt_port_read_close(port);
+            nxt_port_use(task, port, -1);
+            return NXT_ERROR;
+        }
+
+        nxt_port_write_enable(task, port);
+        port->app = app;
+
+        app->shared_port = port;
+
+        nxt_thread_mutex_create(&app->outgoing.mutex);
+    }
+
+    nxt_unreachable();
 
 app_fail:
 

--- a/src/nxt_router.h
+++ b/src/nxt_router.h
@@ -59,98 +59,98 @@ typedef struct {
 
 
 typedef struct {
-    nxt_event_engine_t     *engine;
-    nxt_work_t             *jobs;
+    nxt_event_engine_t       *engine;
+    nxt_work_t               *jobs;
 
     enum {
         NXT_ROUTER_ENGINE_KEEP = 0,
         NXT_ROUTER_ENGINE_ADD,
         NXT_ROUTER_ENGINE_DELETE,
-    }                      action;
+    }                        action;
 } nxt_router_engine_conf_t;
 
 
 typedef struct {
 #if (NXT_TLS)
-    nxt_queue_t            tls;        /* of nxt_router_tlssock_t */
+    nxt_queue_t              tls;        /* of nxt_router_tlssock_t */
 #endif
 
-    nxt_queue_t            apps;       /* of nxt_app_t */
-    nxt_queue_t            previous;   /* of nxt_app_t */
+    nxt_queue_t              apps;       /* of nxt_app_t */
+    nxt_queue_t              previous;   /* of nxt_app_t */
 
-    uint32_t               new_threads;
-    uint32_t               stream;
-    uint32_t               count;
+    uint32_t                 new_threads;
+    uint32_t                 stream;
+    uint32_t                 count;
 
-    nxt_event_engine_t     *engine;
-    nxt_port_t             *port;
-    nxt_array_t            *engines;
-    nxt_router_conf_t      *router_conf;
-    nxt_mp_t               *mem_pool;
+    nxt_event_engine_t       *engine;
+    nxt_port_t               *port;
+    nxt_array_t              *engines;
+    nxt_router_conf_t        *router_conf;
+    nxt_mp_t                 *mem_pool;
 } nxt_router_temp_conf_t;
 
 
 typedef struct {
-    nxt_task_t              task;
-    nxt_work_t              work;
-    nxt_router_temp_conf_t  *tmcf;
+    nxt_task_t               task;
+    nxt_work_t               work;
+    nxt_router_temp_conf_t   *tmcf;
 } nxt_joint_job_t;
 
 
 typedef struct {
-    uint32_t               use_count;
-    nxt_app_t              *app;
-    nxt_timer_t            idle_timer;
-    nxt_work_t             free_app_work;
+    uint32_t                 use_count;
+    nxt_app_t                *app;
+    nxt_timer_t              idle_timer;
+    nxt_work_t               free_app_work;
 } nxt_app_joint_t;
 
 
 struct nxt_app_s {
-    nxt_thread_mutex_t     mutex;       /* Protects ports queue. */
-    nxt_queue_t            ports;       /* of nxt_port_t.app_link */
-    nxt_lvlhsh_t           port_hash;   /* of nxt_port_t */
+    nxt_thread_mutex_t       mutex;       /* Protects ports queue. */
+    nxt_queue_t              ports;       /* of nxt_port_t.app_link */
+    nxt_lvlhsh_t             port_hash;   /* of nxt_port_t */
 
-    nxt_queue_t            spare_ports; /* of nxt_port_t.idle_link */
-    nxt_queue_t            idle_ports;  /* of nxt_port_t.idle_link */
-    nxt_work_t             adjust_idle_work;
-    nxt_event_engine_t     *engine;
+    nxt_queue_t              spare_ports; /* of nxt_port_t.idle_link */
+    nxt_queue_t              idle_ports;  /* of nxt_port_t.idle_link */
+    nxt_work_t               adjust_idle_work;
+    nxt_event_engine_t       *engine;
 
-    nxt_str_t              name;
+    nxt_str_t                name;
 
-    uint32_t               port_hash_count;
+    uint32_t                 port_hash_count;
 
-    uint32_t               active_requests;
-    uint32_t               pending_processes;
-    uint32_t               processes;
-    uint32_t               idle_processes;
+    uint32_t                 active_requests;
+    uint32_t                 pending_processes;
+    uint32_t                 processes;
+    uint32_t                 idle_processes;
 
-    uint32_t               max_processes;
-    uint32_t               spare_processes;
-    uint32_t               max_pending_processes;
+    uint32_t                 max_processes;
+    uint32_t                 spare_processes;
+    uint32_t                 max_pending_processes;
 
-    uint32_t               generation;
-    uint32_t               proto_port_requests;
+    uint32_t                 generation;
+    uint32_t                 proto_port_requests;
 
-    nxt_msec_t             timeout;
-    nxt_msec_t             idle_timeout;
+    nxt_msec_t               timeout;
+    nxt_msec_t               idle_timeout;
 
-    nxt_str_t              *targets;
+    nxt_str_t                *targets;
 
-    nxt_app_type_t         type:8;
+    nxt_app_type_t           type:8;
 
-    nxt_mp_t               *mem_pool;
-    nxt_queue_link_t       link;
+    nxt_mp_t                 *mem_pool;
+    nxt_queue_link_t         link;
 
-    nxt_str_t              conf;
+    nxt_str_t                conf;
 
-    nxt_atomic_t           use_count;
-    nxt_queue_t            ack_waiting_req; /* of nxt_http_request_t.app_link */
+    nxt_atomic_t             use_count;
+    nxt_queue_t              ack_waiting_req; /* of nxt_http_request_t.app_link */
 
-    nxt_app_joint_t        *joint;
-    nxt_port_t             *shared_port;
-    nxt_port_t             *proto_port;
+    nxt_app_joint_t          *joint;
+    nxt_port_t               *shared_port;
+    nxt_port_t               *proto_port;
 
-    nxt_port_mmaps_t       outgoing;
+    nxt_port_mmaps_t         outgoing;
 };
 
 
@@ -168,74 +168,74 @@ typedef struct {
 
 
 typedef struct {
-    uint32_t               count;
-    nxt_queue_link_t       link;
-    nxt_router_conf_t      *router_conf;
+    uint32_t                 count;
+    nxt_queue_link_t         link;
+    nxt_router_conf_t        *router_conf;
 
-    nxt_http_action_t      *action;
+    nxt_http_action_t        *action;
 
     /*
      * A listen socket time can be shorter than socket configuration life
      * time, so a copy of the non-wildcard socket sockaddr is stored here
      * to be used as a local sockaddr in connections.
      */
-    nxt_sockaddr_t         *sockaddr;
+    nxt_sockaddr_t           *sockaddr;
 
-    nxt_listen_socket_t    *listen;
+    nxt_listen_socket_t      *listen;
 
-    size_t                 header_buffer_size;
-    size_t                 large_header_buffer_size;
-    size_t                 large_header_buffers;
-    size_t                 body_buffer_size;
-    size_t                 max_body_size;
-    size_t                 proxy_header_buffer_size;
-    size_t                 proxy_buffer_size;
-    size_t                 proxy_buffers;
+    size_t                   header_buffer_size;
+    size_t                   large_header_buffer_size;
+    size_t                   large_header_buffers;
+    size_t                   body_buffer_size;
+    size_t                   max_body_size;
+    size_t                   proxy_header_buffer_size;
+    size_t                   proxy_buffer_size;
+    size_t                   proxy_buffers;
 
-    nxt_msec_t             idle_timeout;
-    nxt_msec_t             header_read_timeout;
-    nxt_msec_t             body_read_timeout;
-    nxt_msec_t             send_timeout;
-    nxt_msec_t             proxy_timeout;
-    nxt_msec_t             proxy_send_timeout;
-    nxt_msec_t             proxy_read_timeout;
+    nxt_msec_t               idle_timeout;
+    nxt_msec_t               header_read_timeout;
+    nxt_msec_t               body_read_timeout;
+    nxt_msec_t               send_timeout;
+    nxt_msec_t               proxy_timeout;
+    nxt_msec_t               proxy_send_timeout;
+    nxt_msec_t               proxy_read_timeout;
 
-    nxt_websocket_conf_t   websocket_conf;
+    nxt_websocket_conf_t     websocket_conf;
 
-    nxt_str_t              body_temp_path;
+    nxt_str_t                body_temp_path;
 
-    uint8_t                discard_unsafe_fields;  /* 1 bit */
+    uint8_t                  discard_unsafe_fields;  /* 1 bit */
 
-    nxt_http_forward_t     *forwarded;
-    nxt_http_forward_t     *client_ip;
+    nxt_http_forward_t       *forwarded;
+    nxt_http_forward_t       *client_ip;
 
 #if (NXT_TLS)
-    nxt_tls_conf_t         *tls;
+    nxt_tls_conf_t           *tls;
 #endif
 } nxt_socket_conf_t;
 
 
 typedef struct {
-    uint32_t               count;
-    nxt_queue_link_t       link;
-    nxt_event_engine_t     *engine;
-    nxt_socket_conf_t      *socket_conf;
+    uint32_t                 count;
+    nxt_queue_link_t         link;
+    nxt_event_engine_t       *engine;
+    nxt_socket_conf_t        *socket_conf;
 
-    nxt_joint_job_t        *close_job;
+    nxt_joint_job_t          *close_job;
 
-    nxt_upstream_t         **upstreams;
+    nxt_upstream_t           **upstreams;
 
     /* Modules configuraitons. */
 } nxt_socket_conf_joint_t;
 
 
 struct nxt_router_access_log_s {
-    void                   (*handler)(nxt_task_t *task, nxt_http_request_t *r,
-                                      nxt_router_access_log_t *access_log,
-                                      nxt_tstr_t *format);
-    nxt_fd_t               fd;
-    nxt_str_t              path;
-    uint32_t               count;
+    void                     (*handler)(nxt_task_t *task, nxt_http_request_t *r,
+                                        nxt_router_access_log_t *access_log,
+                                        nxt_tstr_t *format);
+    nxt_fd_t                 fd;
+    nxt_str_t                path;
+    uint32_t                 count;
 };
 
 

--- a/src/nxt_router.h
+++ b/src/nxt_router.h
@@ -16,6 +16,7 @@ typedef struct nxt_http_request_s  nxt_http_request_t;
 #include <nxt_application.h>
 
 
+typedef struct nxt_http_app_conf_s      nxt_http_app_conf_t;
 typedef struct nxt_http_action_s        nxt_http_action_t;
 typedef struct nxt_http_routes_s        nxt_http_routes_t;
 typedef struct nxt_http_forward_s       nxt_http_forward_t;
@@ -150,6 +151,12 @@ struct nxt_app_s {
     nxt_port_t             *proto_port;
 
     nxt_port_mmaps_t       outgoing;
+};
+
+
+struct nxt_http_app_conf_s {
+    nxt_app_t  *app;
+    nxt_int_t  target;
 };
 
 

--- a/src/nxt_router.h
+++ b/src/nxt_router.h
@@ -12,6 +12,8 @@
 #include <nxt_runtime.h>
 #include <nxt_main_process.h>
 
+#include <nxt_log_http.h>
+
 typedef struct nxt_http_request_s  nxt_http_request_t;
 #include <nxt_application.h>
 
@@ -208,6 +210,8 @@ typedef struct {
 
     nxt_http_forward_t       *forwarded;
     nxt_http_forward_t       *client_ip;
+
+    nxt_log_http_features_t  log_ft;
 
 #if (NXT_TLS)
     nxt_tls_conf_t           *tls;


### PR DESCRIPTION
    Router: logging request line.
    
        The request line is essential to understand which logs correspond to
        which request when reading the logs.

    Router: logging the kind of element tried for a match.
    Router: logging when a "share" takes the "fallback" action.
    Router: logging when control is passed to a "share".
    Router: expanded location abbreviation in log message.
    
        "loc" is good for source code, but in the debug log it's better
        expanded.

    Router: printing the application name in the debug log.
    Router: logging route array elements being evaluated.
    
        Log when a route array element is evaluated, even if it is later
        discarded due to not meeting the requirements, or any error condition
        that may make it not be suitable, to have more continuity in the
        understanding of all of the steps the router takes to run an action.

    Router: logging when control is passed to a route.
    Router: logging route whose action is selected.
    Router: logging pattern matching decissions.
    
Closes: <https://github.com/nginx/unit/issues/758>
Link: <https://github.com/nginx/unit/pull/824>
Reported-by: @mwoodpatrick
Suggested-by: @lcrilly 
Suggested-by: @tippexs 
Reviewed-by: @ac000 
Cc: @artemkonev 
Cc: @hongzhidao 
Signed-off-by: @alejandro-colomar 

---

This PR is limited in scope compared to #824.  This PR only adds logging lines (all in [debug]), to let developers debug and in general better understand what the router does.  We plan to make those log lines optionally visible in non-debug builds, but that will be implemented separately, outside of this PR.

