### PR TITLE
Docker: avoided error if docker-entrypoint.d already exists

### DIFF
--- a/pkg/docker/template.Dockerfile
+++ b/pkg/docker/template.Dockerfile
@@ -57,7 +57,7 @@ RUN set -ex \
     && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \
     && @@RUN@@ \
     && mkdir -p /var/lib/unit/ \
-    && mkdir /docker-entrypoint.d/ \
+    && mkdir -p /docker-entrypoint.d/ \
     && groupadd --gid 999 unit \
     && useradd \
          --uid 999 \


### PR DESCRIPTION
We are using `make build-python` with custom python images where the folder `/docker-entrypoint.d/` already exists. Without the `-p`, mkdir failed. Could we add it to avoid this issue?