### PR TITLE
Tools: fixed portability of ps(1) calls.

### DIFF
--- a/tools/unitc
+++ b/tools/unitc
@@ -131,7 +131,7 @@ if [ $REMOTE -eq 0 ]; then
 
 		# Get control address
 		#
-		PARAMS=$(ps $PID | grep unitd | cut -f2- -dv | tr '[]' ' ' | cut -f3- -d ' ' | sed -e 's/ --/\n--/g')
+		PARAMS=$(ps ww $PID | grep 'unit[:d] ' | perl -p -e 's/.*?([^ ]*unit[:d])/\1/' | sed 's/ (.*//' | sed 's/.*\[//' | sed 's/].*//' | sed -e 's/ --/\n--/g')
 		CTRL_ADDR=$(echo "$PARAMS" | grep '\--control' | cut -f2 -d' ')
 		if [ "$CTRL_ADDR" = "" ]; then
 			CTRL_ADDR=$($(echo "$PARAMS" | grep unitd) --help | grep -A1 '\--control' | tail -1 | cut -f2 -d\")


### PR DESCRIPTION
```
ps(1) output is very different from system to system.  Use -ww to force
an unlimited width in the output (some implementations detect when the
output is being piped and do this automatically).  Use -o args=COMMAND
to show only the command line that was used to run the program.
However, that's not enough, since different implementation use different
conventions (and even some implementations use different conventions on
different scenarios), so we need to process them to get a consistent
output.  It seems that all implementations we tested do either (a) print
the original command line between brackets alongside other stuff that
goes outside of those brackets, or (b) print only the original command
line without brackets with no other stuff.  Since we want the command
line, we can remove everything outside the brackets (if any) to get it.
```

Closes: <https://github.com/nginx/unit/issues/875>
Reported-by: @mattxtaz
Cc: @lcrilly
Cc: @ac000
Signed-off-by: @alejandro-colomar
