### PR TITLE
Python: Add ASGI lifespan_state support.

### DIFF
--- a/src/python/nxt_python_asgi_str.c
+++ b/src/python/nxt_python_asgi_str.c
@@ -55,6 +55,7 @@ PyObject  *nxt_py_subprotocol_str;
 PyObject  *nxt_py_subprotocols_str;
 PyObject  *nxt_py_text_str;
 PyObject  *nxt_py_type_str;
+PyObject  *nxt_py_state_str;
 PyObject  *nxt_py_version_str;
 PyObject  *nxt_py_websocket_str;
 PyObject  *nxt_py_websocket_accept_str;
@@ -110,6 +111,7 @@ static nxt_python_string_t nxt_py_asgi_strings[] = {
     { nxt_string("subprotocols"), &nxt_py_subprotocols_str },
     { nxt_string("text"), &nxt_py_text_str },
     { nxt_string("type"), &nxt_py_type_str },
+    { nxt_string("state"), &nxt_py_state_str },
     { nxt_string("version"), &nxt_py_version_str },
     { nxt_string("websocket"), &nxt_py_websocket_str },
     { nxt_string("websocket.accept"), &nxt_py_websocket_accept_str },

--- a/src/python/nxt_python_asgi_str.h
+++ b/src/python/nxt_python_asgi_str.h
@@ -50,6 +50,7 @@ extern PyObject  *nxt_py_subprotocol_str;
 extern PyObject  *nxt_py_subprotocols_str;
 extern PyObject  *nxt_py_text_str;
 extern PyObject  *nxt_py_type_str;
+extern PyObject  *nxt_py_state_str;
 extern PyObject  *nxt_py_version_str;
 extern PyObject  *nxt_py_websocket_str;
 extern PyObject  *nxt_py_websocket_accept_str;


### PR DESCRIPTION
fix https://github.com/nginx/unit/issues/864

The test script
```
import contextlib
from fastapi import FastAPI, Request


@contextlib.asynccontextmanager
async def lifespan(app):
    yield {"queue": []}


app = FastAPI(lifespan=lifespan)


@app.get("/")
async def _(request: Request):
    # print(request.scope["state"]["queue"])
    request.state.queue.append(1)
    return {"queue": request.state.queue}
```
