### PR TITLE
[WIP]: WASM

### DIFF
--- a/auto/help
+++ b/auto/help
@@ -75,4 +75,7 @@ cat << END
   java OPTIONS         configure Java module
                        run "./configure java --help" to see available options
 
+  wasm OPTIONS	       configure WebAssembly module
+		       run "./configure wasm --help" to see available options
+
 END

--- a/auto/modules/conf
+++ b/auto/modules/conf
@@ -33,6 +33,10 @@ case "$nxt_module" in
        . auto/modules/java
    ;;
 
+   wasm)
+       . auto/modules/wasm
+   ;;
+
    *)
        echo
        echo $0: error: invalid module \"$nxt_module\".

--- a/auto/modules/wasm
+++ b/auto/modules/wasm
@@ -1,0 +1,207 @@
+# Copyright (C) Andrew Clayton
+# Copyright (C) F5, Inc.
+
+
+NXT_WASM_RUNTIME=wasmtime
+
+shift
+
+for nxt_option; do
+
+    case "$nxt_option" in
+        -*=*) value=`echo "$nxt_option" | sed -e 's/[-_a-zA-Z0-9]*=//'`     ;;
+           *) value="" ;;
+    esac
+
+    case "$nxt_option" in
+
+        --runtime=*)		NXT_WASM_RUNTIME="$value"		    ;;
+        --module=*)		NXT_WASM_MODULE="$value"                    ;;
+        --include-path=*)	NXT_WASM_INCLUDE="$value"		    ;;
+        --lib-path=*)		NXT_WASM_LIB="$value"                       ;;
+        --rpath*)		NXT_WASM_RPATH="$value"			    ;;
+
+        --help)
+            cat << END
+
+    --runtime=RUNTIME		set the WASM runtime to use (default: wasmtime)
+    --module=NAME		set Unit WASM module name (default: wasm)
+    --include-path=DIRECTORY	set directory path to wasmtime includes
+    --lib-path=DIRECTORY 	set directory path to libwasmtime.so library
+    --rpath[=DIRECTORY]		set the rpath (default: --lib-path)
+
+END
+            exit 0
+        ;;
+
+        *)
+            echo
+            echo $0: error: invalid wasm option \"$nxt_option\"
+            echo
+            exit 1
+        ;;
+    esac
+
+done
+
+
+if [ ! -f $NXT_AUTOCONF_DATA ]; then
+   echo
+   echo Please run common $0 before configuring module \"$nxt_module\".
+   echo
+   exit 1
+fi
+
+. $NXT_AUTOCONF_DATA
+
+NXT_WASM=wasm
+NXT_WASM_MODULE=${NXT_WASM_MODULE=${NXT_WASM##*/}}
+
+NXT_WASM_INCLUDE=${NXT_WASM_INCLUDE=}
+NXT_WASM_LIB=${NXT_WASM_LIB=}
+NXT_WASM_LDFLAGS=
+if [ "$NXT_WASM_RUNTIME" = "wasmtime" ]; then
+    NXT_WASM_LDFLAGS=-lwasmtime
+fi
+NXT_WASM_ADDITIONAL_FLAGS="-fno-strict-aliasing \
+ -Wno-missing-field-initializers \
+ -DNXT_HAVE_WASM_$(echo ${NXT_WASM_RUNTIME} | tr 'a-z' 'A-Z')=1 \
+"
+
+# Set the RPATH/RUNPATH.
+#
+# We temporarily disable warning on unbound variables here as
+# NXT_WASM_RPATH may be legitimately unset, in which case we
+# don't set a RPATH.
+#
+# If NXT_WASM_RPATH is set but null then we set a RPATH of the
+# value of $NXT_WASM_LIB (--lib-path) otherwise use the value
+# provided.
+set +u
+if [ "${NXT_WASM_RPATH+set}" = set ]; then
+    if [ "$NXT_WASM_RPATH" = "" ]; then
+        NXT_WASM_RPATH=$NXT_WASM_LIB
+    fi
+
+    NXT_WASM_LDFLAGS="-Wl,-rpath,$NXT_WASM_RPATH $NXT_WASM_LDFLAGS"
+fi
+set -u
+
+$echo "configuring WASM module"
+$echo "configuring WASM module ..." >> $NXT_AUTOCONF_ERR
+
+nxt_found=no
+
+if [ "$NXT_WASM_RUNTIME" = "wasmtime" ]; then
+    nxt_feature="wasmtime"
+    nxt_feature_name=""
+    nxt_feature_run=no
+    nxt_feature_incs="-I${NXT_WASM_INCLUDE}"
+    nxt_feature_libs="-L${NXT_WASM_LIB} $NXT_WASM_LDFLAGS"
+    nxt_feature_test="
+        #include <wasm.h>
+        #include <wasi.h>
+        #include <wasmtime.h>
+
+        int main(void) {
+            wasm_config_t *c;
+
+            c = wasm_config_new();
+            wasm_config_delete(c);
+
+            return 0;
+        }"
+
+    . auto/feature
+fi
+
+if [ $nxt_found = no ]; then
+    $echo
+    $echo $0: error: no $NXT_WASM_RUNTIME found.
+    $echo
+    exit 1;
+fi
+
+
+if grep ^$NXT_WASM_MODULE: $NXT_MAKEFILE 2>&1 > /dev/null; then
+    $echo
+    $echo $0: error: duplicate \"$NXT_WASM_MODULE\" module configured.
+    $echo
+    exit 1;
+fi
+
+
+$echo " + WASM module: ${NXT_WASM_MODULE}.unit.so"
+
+. auto/cc/deps
+
+$echo >> $NXT_MAKEFILE
+
+NXT_WASM_MODULE_SRCS=" \
+    src/wasm/nxt_wasm.c \
+"
+
+if [ "$NXT_WASM_RUNTIME" = "wasmtime" ]; then
+    NXT_WASM_MODULE_SRCS="$NXT_WASM_MODULE_SRCS src/wasm/nxt_rt_wasmtime.c"
+fi
+
+
+# The wasm module object files.
+
+nxt_objs=$NXT_BUILD_DIR/src/nxt_unit.o
+
+for nxt_src in $NXT_WASM_MODULE_SRCS; do
+
+    nxt_obj=${nxt_src%.c}-$NXT_WASM_MODULE.o
+    nxt_dep=${nxt_src%.c}-$NXT_WASM_MODULE.dep
+    nxt_dep_flags=`nxt_gen_dep_flags`
+    nxt_dep_post=`nxt_gen_dep_post`
+    nxt_objs="$nxt_objs $NXT_BUILD_DIR/$nxt_obj"
+
+    cat << END >> $NXT_MAKEFILE
+
+$NXT_BUILD_DIR/$nxt_obj:	$nxt_src $NXT_VERSION_H
+	mkdir -p $NXT_BUILD_DIR/src/wasm
+	\$(CC) -c \$(CFLAGS) $NXT_WASM_ADDITIONAL_FLAGS \$(NXT_INCS) \\
+	-I$NXT_WASM_INCLUDE \\
+	$nxt_dep_flags \\
+	-o $NXT_BUILD_DIR/$nxt_obj $nxt_src
+	$nxt_dep_post
+
+-include $NXT_BUILD_DIR/$nxt_dep
+
+END
+
+done
+
+
+cat << END >> $NXT_MAKEFILE
+
+.PHONY: ${NXT_WASM_MODULE}
+.PHONY: ${NXT_WASM_MODULE}-install
+.PHONY: ${NXT_WASM_MODULE}-uninstall
+
+all: ${NXT_WASM_MODULE}
+
+${NXT_WASM_MODULE}:	$NXT_BUILD_DIR/lib/unit/modules/${NXT_WASM_MODULE}.unit.so
+
+$NXT_BUILD_DIR/lib/unit/modules/${NXT_WASM_MODULE}.unit.so:	$nxt_objs
+	\$(NXT_MODULE_LINK) -o \$@ \\
+	$nxt_objs -L${NXT_WASM_LIB} ${NXT_WASM_LDFLAGS} $NXT_LD_OPT
+
+
+install: ${NXT_WASM_MODULE}-install
+
+${NXT_WASM_MODULE}-install: ${NXT_WASM_MODULE} install-check
+	install -d \$(DESTDIR)$NXT_MODULESDIR
+	install -p $NXT_BUILD_DIR/lib/unit/modules/${NXT_WASM_MODULE}.unit.so \\
+		\$(DESTDIR)$NXT_MODULESDIR/
+
+
+uninstall: ${NXT_WASM_MODULE}-uninstall
+
+${NXT_WASM_MODULE}-uninstall:
+	rm -f \$(DESTDIR)$NXT_MODULESDIR/${NXT_WASM_MODULE}.unit.so
+	@rmdir -p \$(DESTDIR)$NXT_MODULESDIR 2>/dev/null || true
+
+END

--- a/src/nxt_application.c
+++ b/src/nxt_application.c
@@ -1099,6 +1099,9 @@ nxt_app_parse_type(u_char *p, size_t length)
 
     } else if (nxt_str_eq(&str, "java", 4)) {
         return NXT_APP_JAVA;
+
+    } else if (nxt_str_eq(&str, "wasm", 4)) {
+        return NXT_APP_WASM;
     }
 
     return NXT_APP_UNKNOWN;

--- a/src/nxt_application.h
+++ b/src/nxt_application.h
@@ -21,6 +21,7 @@ typedef enum {
     NXT_APP_PERL,
     NXT_APP_RUBY,
     NXT_APP_JAVA,
+    NXT_APP_WASM,
 
     NXT_APP_UNKNOWN,
 } nxt_app_type_t;
@@ -86,6 +87,23 @@ typedef struct {
 } nxt_java_app_conf_t;
 
 
+typedef struct {
+    const char        *module;
+
+    const char        *request_handler;
+    const char        *malloc_handler;
+    const char        *free_handler;
+
+    const char        *module_init_handler;
+    const char        *module_end_handler;
+    const char        *request_init_handler;
+    const char        *request_end_handler;
+    const char        *response_end_handler;
+
+    nxt_conf_value_t  *access;
+} nxt_wasm_app_conf_t;
+
+
 struct nxt_common_app_conf_s {
     nxt_str_t                  name;
     nxt_str_t                  type;
@@ -114,6 +132,7 @@ struct nxt_common_app_conf_s {
         nxt_perl_app_conf_t      perl;
         nxt_ruby_app_conf_t      ruby;
         nxt_java_app_conf_t      java;
+        nxt_wasm_app_conf_t      wasm;
     } u;
 
     nxt_conf_value_t           *self;

--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -250,6 +250,7 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_python_target_members[];
 static nxt_conf_vldt_object_t  nxt_conf_vldt_php_common_members[];
 static nxt_conf_vldt_object_t  nxt_conf_vldt_php_options_members[];
 static nxt_conf_vldt_object_t  nxt_conf_vldt_php_target_members[];
+static nxt_conf_vldt_object_t  nxt_conf_vldt_wasm_access_members[];
 static nxt_conf_vldt_object_t  nxt_conf_vldt_common_members[];
 static nxt_conf_vldt_object_t  nxt_conf_vldt_app_limits_members[];
 static nxt_conf_vldt_object_t  nxt_conf_vldt_app_processes_members[];
@@ -1035,6 +1036,58 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_java_members[] = {
         .name       = nxt_string("thread_stack_size"),
         .type       = NXT_CONF_VLDT_INTEGER,
         .validator  = nxt_conf_vldt_thread_stack_size,
+    },
+
+    NXT_CONF_VLDT_NEXT(nxt_conf_vldt_common_members)
+};
+
+
+static nxt_conf_vldt_object_t  nxt_conf_vldt_wasm_access_members[] = {
+    {
+        .name       = nxt_string("filesystem"),
+        .type       = NXT_CONF_VLDT_ARRAY,
+    },
+
+    NXT_CONF_VLDT_END
+};
+
+static nxt_conf_vldt_object_t  nxt_conf_vldt_wasm_members[] = {
+    {
+        .name       = nxt_string("module"),
+        .type       = NXT_CONF_VLDT_STRING,
+        .flags      = NXT_CONF_VLDT_REQUIRED,
+    }, {
+        .name       = nxt_string("request_handler"),
+        .type       = NXT_CONF_VLDT_STRING,
+        .flags      = NXT_CONF_VLDT_REQUIRED,
+    },{
+        .name       = nxt_string("malloc_handler"),
+        .type       = NXT_CONF_VLDT_STRING,
+        .flags      = NXT_CONF_VLDT_REQUIRED,
+    }, {
+        .name       = nxt_string("free_handler"),
+        .type       = NXT_CONF_VLDT_STRING,
+        .flags      = NXT_CONF_VLDT_REQUIRED,
+    }, {
+        .name       = nxt_string("module_init_handler"),
+        .type       = NXT_CONF_VLDT_STRING,
+    }, {
+        .name       = nxt_string("module_end_handler"),
+        .type       = NXT_CONF_VLDT_STRING,
+    }, {
+        .name       = nxt_string("request_init_handler"),
+        .type       = NXT_CONF_VLDT_STRING,
+    }, {
+        .name       = nxt_string("request_end_handler"),
+        .type       = NXT_CONF_VLDT_STRING,
+    }, {
+        .name       = nxt_string("response_end_handler"),
+        .type       = NXT_CONF_VLDT_STRING,
+    }, {
+        .name       = nxt_string("access"),
+        .type       = NXT_CONF_VLDT_OBJECT,
+        .validator  = nxt_conf_vldt_object,
+        .u.members  = nxt_conf_vldt_wasm_access_members,
     },
 
     NXT_CONF_VLDT_NEXT(nxt_conf_vldt_common_members)
@@ -2525,6 +2578,7 @@ nxt_conf_vldt_app(nxt_conf_validation_t *vldt, nxt_str_t *name,
         { nxt_conf_vldt_object, nxt_conf_vldt_perl_members },
         { nxt_conf_vldt_object, nxt_conf_vldt_ruby_members },
         { nxt_conf_vldt_object, nxt_conf_vldt_java_members },
+        { nxt_conf_vldt_object, nxt_conf_vldt_wasm_members },
     };
 
     ret = nxt_conf_vldt_type(vldt, name, value, NXT_CONF_VLDT_OBJECT);

--- a/src/nxt_main_process.c
+++ b/src/nxt_main_process.c
@@ -323,6 +323,70 @@ static nxt_conf_map_t  nxt_java_app_conf[] = {
 };
 
 
+static nxt_conf_map_t  nxt_wasm_app_conf[] = {
+    {
+        nxt_string("module"),
+        NXT_CONF_MAP_CSTRZ,
+        offsetof(nxt_common_app_conf_t, u.wasm.module),
+    },
+
+    {
+        nxt_string("request_handler"),
+        NXT_CONF_MAP_CSTRZ,
+        offsetof(nxt_common_app_conf_t, u.wasm.request_handler),
+    },
+
+    {
+        nxt_string("malloc_handler"),
+        NXT_CONF_MAP_CSTRZ,
+        offsetof(nxt_common_app_conf_t, u.wasm.malloc_handler),
+    },
+
+    {
+        nxt_string("free_handler"),
+        NXT_CONF_MAP_CSTRZ,
+        offsetof(nxt_common_app_conf_t, u.wasm.free_handler),
+    },
+
+    {
+        nxt_string("module_init_handler"),
+        NXT_CONF_MAP_CSTRZ,
+        offsetof(nxt_common_app_conf_t, u.wasm.module_init_handler),
+    },
+
+    {
+        nxt_string("module_end_handler"),
+        NXT_CONF_MAP_CSTRZ,
+        offsetof(nxt_common_app_conf_t, u.wasm.module_end_handler),
+    },
+
+    {
+        nxt_string("request_init_handler"),
+        NXT_CONF_MAP_CSTRZ,
+        offsetof(nxt_common_app_conf_t, u.wasm.request_init_handler),
+    },
+
+    {
+        nxt_string("request_end_handler"),
+        NXT_CONF_MAP_CSTRZ,
+        offsetof(nxt_common_app_conf_t, u.wasm.request_end_handler),
+    },
+
+    {
+        nxt_string("response_end_handler"),
+        NXT_CONF_MAP_CSTRZ,
+        offsetof(nxt_common_app_conf_t, u.wasm.response_end_handler),
+    },
+
+    {
+        nxt_string("access"),
+        NXT_CONF_MAP_PTR,
+        offsetof(nxt_common_app_conf_t, u.wasm.access),
+    },
+
+};
+
+
 static nxt_conf_app_map_t  nxt_app_maps[] = {
     { nxt_nitems(nxt_external_app_conf),  nxt_external_app_conf },
     { nxt_nitems(nxt_python_app_conf),    nxt_python_app_conf },
@@ -330,6 +394,7 @@ static nxt_conf_app_map_t  nxt_app_maps[] = {
     { nxt_nitems(nxt_perl_app_conf),      nxt_perl_app_conf },
     { nxt_nitems(nxt_ruby_app_conf),      nxt_ruby_app_conf },
     { nxt_nitems(nxt_java_app_conf),      nxt_java_app_conf },
+    { nxt_nitems(nxt_wasm_app_conf),      nxt_wasm_app_conf },
 };
 
 

--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -274,12 +274,13 @@ static const nxt_str_t http_prefix = nxt_string("HTTP_");
 static const nxt_str_t empty_prefix = nxt_string("");
 
 static const nxt_str_t  *nxt_app_msg_prefix[] = {
-    &empty_prefix,
-    &empty_prefix,
-    &http_prefix,
-    &http_prefix,
-    &http_prefix,
-    &empty_prefix,
+    [NXT_APP_EXTERNAL]  = &empty_prefix,
+    [NXT_APP_PYTHON]    = &empty_prefix,
+    [NXT_APP_PHP]       = &http_prefix,
+    [NXT_APP_PERL]      = &http_prefix,
+    [NXT_APP_RUBY]      = &http_prefix,
+    [NXT_APP_JAVA]      = &empty_prefix,
+    [NXT_APP_WASM]      = &empty_prefix,
 };
 
 

--- a/src/wasm/nxt_rt_wasmtime.c
+++ b/src/wasm/nxt_rt_wasmtime.c
@@ -1,0 +1,450 @@
+/*
+ * Copyright (C) Andrew Clayton
+ * Copyright (C) F5, Inc.
+ */
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdarg.h>
+
+#include <wasm.h>
+#include <wasi.h>
+#include <wasmtime.h>
+
+#include "nxt_wasm.h"
+
+typedef struct {
+    wasm_engine_t       *engine;
+    wasmtime_store_t    *store;
+    wasmtime_memory_t   memory;
+    wasmtime_module_t   *module;
+    wasmtime_linker_t   *linker;
+    wasmtime_context_t  *ctx;
+} nxt_wasmtime_ctx_t;
+
+static nxt_wasmtime_ctx_t  nxt_wasmtime_ctx;
+
+
+static void
+nxt_wasmtime_err_msg(wasmtime_error_t *error, wasm_trap_t *trap,
+                     const char *fmt, ...)
+{
+    va_list          args;
+    wasm_byte_vec_t  error_message;
+
+    fprintf(stderr, "WASMTIME ERROR: ");
+    va_start(args, fmt);
+    vfprintf(stderr, fmt, args);
+    va_end(args);
+    fprintf(stderr, "\n");
+
+    if (error == NULL && trap == NULL) {
+        return;
+    }
+
+    if (error != NULL) {
+        wasmtime_error_message(error, &error_message);
+        wasmtime_error_delete(error);
+    } else {
+        wasm_trap_message(trap, &error_message);
+        wasm_trap_delete(trap);
+    }
+    fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
+
+    wasm_byte_vec_delete(&error_message);
+}
+
+
+static void
+nxt_wasmtime_meminfo(const nxt_wasm_ctx_t *ctx)
+{
+    nxt_wasmtime_ctx_t  *rt_ctx = &nxt_wasmtime_ctx;
+
+    printf("==[MEMINFO] Linear memory @ %p is %" PRIu64 " pages totalling "
+           "%lu bytes\n",
+           ctx->baddr - ctx->baddr_offs,
+           wasmtime_memory_size(rt_ctx->ctx, &rt_ctx->memory),
+           wasmtime_memory_data_size(rt_ctx->ctx, &rt_ctx->memory));
+}
+
+
+static wasm_trap_t
+*nxt_wasm_get_init_mem_size(void *env, wasmtime_caller_t *caller,
+                            const wasmtime_val_t *args, size_t nargs,
+                            wasmtime_val_t *results, size_t nresults)
+{
+    results[0].of.i32 = NXT_WASM_MEM_SIZE;
+
+    return NULL;
+}
+
+
+static wasm_trap_t
+*nxt_wasm_response_end(void *env, wasmtime_caller_t *caller,
+                       const wasmtime_val_t *args, size_t nargs,
+                       wasmtime_val_t *results, size_t nresults)
+{
+    nxt_wasm_do_response_end(env);
+
+    return NULL;
+}
+
+
+static wasm_trap_t
+*nxt_wasm_send_response(void *env, wasmtime_caller_t *caller,
+                        const wasmtime_val_t *args, size_t nargs,
+                        wasmtime_val_t *results, size_t nresults)
+{
+    printf("\n# Got response @ [%u]\n", args[0].of.i32);
+    nxt_wasm_do_send_response(args[0].of.i32, env);
+
+    return NULL;
+}
+
+
+static wasm_trap_t
+*nxt_wasm_send_headers(void *env, wasmtime_caller_t *caller,
+                       const wasmtime_val_t *args, size_t nargs,
+                       wasmtime_val_t *results, size_t nresults)
+{
+    printf("\n# Got response headers @ [%u]\n", args[0].of.i32);
+    nxt_wasm_do_send_headers(args[0].of.i32, env);
+    printf("\n");
+
+    return NULL;
+}
+
+
+static void
+nxt_wasmtime_execute_hook(const nxt_wasm_ctx_t *ctx, nxt_wasm_fh_t hook)
+{
+    const char             *name = ctx->fh[hook].func_name;
+    wasm_trap_t            *trap = NULL;
+    wasmtime_error_t       *error;
+    nxt_wasmtime_ctx_t     *rt_ctx = &nxt_wasmtime_ctx;
+    const nxt_wasm_func_t  *func = &ctx->fh[hook].func;
+
+    if (name == NULL) {
+        return;
+    }
+
+    error = wasmtime_func_call(rt_ctx->ctx, func, NULL, 0, NULL, 0, &trap);
+    if (error != NULL || trap != NULL) {
+        nxt_wasmtime_err_msg(error, trap, "failed to call hook function [%s]",
+                             name);
+    }
+}
+
+
+static void
+nxt_wasmtime_execute_request(const nxt_wasm_ctx_t *ctx)
+{
+    int                    i = 0;
+    wasm_trap_t            *trap= NULL;
+    wasmtime_val_t         args[1] = { };
+    wasmtime_val_t         results[1] = { };
+    wasmtime_error_t       *error;
+    nxt_wasmtime_ctx_t     *rt_ctx = &nxt_wasmtime_ctx;
+    const nxt_wasm_func_t  *func = &ctx->fh[NXT_WASM_FH_REQUEST].func;
+
+    args[i].kind = WASMTIME_I32;
+    args[i++].of.i32 = ctx->baddr_offs;
+
+    { /* DEBUG */
+        nxt_wasm_request_t *wr;
+        nxt_wasm_http_hdr_field_t *f, *f_end;
+
+        wr = (nxt_wasm_request_t *)ctx->baddr;
+
+        printf("== Header data starts @ %lu bytes\n",
+               sizeof(nxt_wasm_request_t) +
+               (sizeof(nxt_wasm_http_hdr_field_t) * wr->nr_fields));
+
+        printf("-- Got [%u] headers\n", wr->nr_fields);
+
+        f_end = wr->fields + wr->nr_fields;
+        for (f = wr->fields; f < f_end; f++)
+            printf("== [%u/%.*s] = [%u/%u/%.*s]\n",
+                   f->name_offs, f->name_len,
+                   (unsigned char *)wr + f->name_offs,
+                   f->value_len, f->value_offs, f->value_len,
+                   (unsigned char *)wr + f->value_offs);
+    }
+    error = wasmtime_func_call(rt_ctx->ctx, func, args, i, results, 1, &trap);
+    if (error != NULL || trap != NULL) {
+        nxt_wasmtime_err_msg(error, trap,
+                             "failed to call function [->wasm_request_handler]"
+                             );
+    }
+}
+
+
+typedef enum {
+    NXT_WASM_FT_0_0,
+    NXT_WASM_FT_1_0,
+    NXT_WASM_FT_0_1,
+} nxt_wasm_func_type_t;
+
+typedef struct {
+    const char                *func_name;
+    wasmtime_func_callback_t  func;
+    wasm_valkind_t            params[1];
+    wasm_valkind_t            results[1];
+    nxt_wasm_func_type_t      ft;
+} nxt_wasm_function_import_t;
+
+static void
+nxt_wasmtime_set_function_imports(nxt_wasm_ctx_t *ctx)
+{
+    nxt_wasmtime_ctx_t                       *rt_ctx = &nxt_wasmtime_ctx;
+    static const nxt_wasm_function_import_t  *imf;
+    static const nxt_wasm_function_import_t  import_functions[] = {
+        {
+            .func_name = "nxt_wasm_get_init_mem_size",
+            .func      = nxt_wasm_get_init_mem_size,
+            .results   = { WASM_I32 },
+            .ft        = NXT_WASM_FT_0_1
+        }, {
+            .func_name = "nxt_wasm_response_end",
+            .func      = nxt_wasm_response_end,
+            .ft        = NXT_WASM_FT_0_0
+        }, {
+            .func_name = "nxt_wasm_send_response",
+            .func      = nxt_wasm_send_response,
+            .params    = { WASM_I32 },
+            .ft        = NXT_WASM_FT_1_0
+        }, {
+            .func_name = "nxt_wasm_send_headers",
+            .func      = nxt_wasm_send_headers,
+            .params    = { WASM_I32 },
+            .ft        = NXT_WASM_FT_1_0
+        },
+
+        { }
+    };
+
+    for (imf = import_functions; imf->func_name != NULL; imf++) {
+        wasm_functype_t  *func_ty;
+
+        switch (imf->ft) {
+        case NXT_WASM_FT_0_0:
+            func_ty = wasm_functype_new_0_0();
+            break;
+        case NXT_WASM_FT_1_0:
+            func_ty = wasm_functype_new_1_0(wasm_valtype_new(imf->params[0]));
+            break;
+        case NXT_WASM_FT_0_1:
+            func_ty = wasm_functype_new_0_1(wasm_valtype_new(imf->results[0]));
+            break;
+        default:
+            /* Stop GCC complaining about func_ty being used uninitialised */
+            func_ty = NULL;
+        }
+
+        wasmtime_linker_define_func(rt_ctx->linker, "env", 3,
+                                    imf->func_name, strlen(imf->func_name),
+                                    func_ty,  imf->func, ctx, NULL);
+        wasm_functype_delete(func_ty);
+    }
+}
+
+
+static int
+nxt_wasmtime_get_function_exports(nxt_wasm_ctx_t *ctx)
+{
+    int                 i;
+    nxt_wasmtime_ctx_t  *rt_ctx = &nxt_wasmtime_ctx;
+
+    for (i = 0; i < NXT_WASM_FH_NR; i++) {
+        bool               ok;
+        wasmtime_extern_t  item;
+
+        if (ctx->fh[i].func_name == NULL) {
+            continue;
+        }
+
+       ok = wasmtime_linker_get(rt_ctx->linker, rt_ctx->ctx, "", 0,
+                                ctx->fh[i].func_name,
+                                strlen(ctx->fh[i].func_name), &item);
+       if (!ok) {
+           nxt_wasmtime_err_msg(NULL, NULL,
+                                "couldn't get (%s) export from module",
+                                ctx->fh[i].func_name);
+           return -1;
+       }
+       ctx->fh[i].func = item.of.func;
+    }
+
+    return 0;
+}
+
+
+static int
+nxt_wasmtime_wasi_init(const nxt_wasm_ctx_t *ctx)
+{
+    char                **dir;
+    wasi_config_t       *wasi_config;
+    wasmtime_error_t    *error;
+    nxt_wasmtime_ctx_t  *rt_ctx = &nxt_wasmtime_ctx;
+
+    wasi_config = wasi_config_new();
+
+    wasi_config_inherit_env(wasi_config);
+    wasi_config_inherit_stdin(wasi_config);
+    wasi_config_inherit_stdout(wasi_config);
+    wasi_config_inherit_stderr(wasi_config);
+
+    for (dir = ctx->dirs; dir != NULL && *dir != NULL; dir++) {
+        printf("### wasmtime allowing guest access to (%s)\n", *dir);
+        wasi_config_preopen_dir(wasi_config, *dir, *dir);
+    }
+
+    error = wasmtime_context_set_wasi(rt_ctx->ctx, wasi_config);
+    if (error != NULL) {
+        nxt_wasmtime_err_msg(error, NULL, "failed to instantiate WASI");
+        return -1;
+    }
+
+    return 0;
+}
+
+
+static int
+nxt_wasmtime_init_memory(nxt_wasm_ctx_t *ctx)
+{
+    int                    i = 0;
+    bool                   ok;
+    wasm_trap_t            *trap = NULL;
+    wasmtime_val_t         args[1] = { };
+    wasmtime_val_t         results[1] = { };
+    wasmtime_error_t       *error;
+    wasmtime_extern_t      item;
+    nxt_wasmtime_ctx_t     *rt_ctx = &nxt_wasmtime_ctx;
+    const nxt_wasm_func_t  *func = &ctx->fh[NXT_WASM_FH_MALLOC].func;
+
+    args[i].kind = WASMTIME_I32;
+    args[i++].of.i32 = NXT_WASM_MEM_SIZE + NXT_WASM_PAGE_SIZE;
+
+    error = wasmtime_func_call(rt_ctx->ctx, func, args, i, results, 1, &trap);
+    if (error != NULL || trap != NULL) {
+        nxt_wasmtime_err_msg(error, trap,
+                             "failed to call function [->wasm_malloc_handler]"
+                             );
+        return -1;
+    }
+
+    ok = wasmtime_linker_get(rt_ctx->linker, rt_ctx->ctx, "", 0, "memory",
+                             strlen("memory"), &item);
+    if (!ok) {
+        nxt_wasmtime_err_msg(NULL, NULL, "couldn't get 'memory' from module\n");
+        return -1;
+    }
+    rt_ctx->memory = item.of.memory;
+
+    ctx->baddr_offs = results[0].of.i32;
+    ctx->baddr = wasmtime_memory_data(rt_ctx->ctx, &rt_ctx->memory);
+
+    printf("==[MEMINFO] Linear memory base addr : %p\n", ctx->baddr);
+    ctx->baddr += ctx->baddr_offs;
+    printf("==[MEMINFO] Linear memory WASM memory addr : %p\n", ctx->baddr);
+
+    nxt_wasmtime_meminfo(ctx);
+
+    return 0;
+}
+
+static int
+nxt_wasmtime_init(nxt_wasm_ctx_t *ctx)
+{
+    int                 err;
+    FILE                *fp;
+    size_t              file_size;
+    wasm_byte_vec_t     wasm;
+    wasmtime_error_t    *error;
+    nxt_wasmtime_ctx_t  *rt_ctx = &nxt_wasmtime_ctx;
+
+    rt_ctx->engine = wasm_engine_new();
+    rt_ctx->store = wasmtime_store_new(rt_ctx->engine, NULL, NULL);
+    rt_ctx->ctx = wasmtime_store_context(rt_ctx->store);
+
+    rt_ctx->linker = wasmtime_linker_new(rt_ctx->engine);
+    error = wasmtime_linker_define_wasi(rt_ctx->linker);
+    if (error != NULL) {
+        nxt_wasmtime_err_msg(error, NULL, "failed to link wasi");
+        return -1;
+    }
+
+    fp = fopen(ctx->module_path, "r");
+    if (!fp) {
+        nxt_wasmtime_err_msg(NULL, NULL,
+                             "error opening file (%s)", ctx->module_path);
+        return -1;
+    }
+    fseek(fp, 0L, SEEK_END);
+    file_size = ftell(fp);
+    wasm_byte_vec_new_uninitialized(&wasm, file_size);
+    fseek(fp, 0L, SEEK_SET);
+    if (fread(wasm.data, file_size, 1, fp) != 1) {
+        nxt_wasmtime_err_msg(NULL, NULL, "error loading module");
+        return -1;
+    }
+    fclose(fp);
+
+    error = wasmtime_module_new(rt_ctx->engine, (uint8_t *)wasm.data, wasm.size,
+                                &rt_ctx->module);
+    if (!rt_ctx->module) {
+        nxt_wasmtime_err_msg(error, NULL, "failed to compile module");
+        return -1;
+    }
+    wasm_byte_vec_delete(&wasm);
+
+    nxt_wasmtime_set_function_imports(ctx);
+
+    nxt_wasmtime_wasi_init(ctx);
+
+    printf("Instantiating module...\n");
+    error = wasmtime_linker_module(rt_ctx->linker, rt_ctx->ctx, "", 0,
+                                   rt_ctx->module);
+    if (error != NULL) {
+         nxt_wasmtime_err_msg(error, NULL, "failed to instantiate");
+         return -1;
+    }
+
+    err = nxt_wasmtime_get_function_exports(ctx);
+    if (err)
+        return -1;
+
+    err = nxt_wasmtime_init_memory(ctx);
+    if (err)
+        return -1;
+
+    return 0;
+}
+
+
+static void
+nxt_wasmtime_destroy(const nxt_wasm_ctx_t *ctx)
+{
+    int                    i = 0;
+    wasmtime_val_t         args[1] = { };
+    nxt_wasmtime_ctx_t     *rt_ctx = &nxt_wasmtime_ctx;
+    const nxt_wasm_func_t  *func = &ctx->fh[NXT_WASM_FH_FREE].func;
+
+    args[i].kind = WASMTIME_I32;
+    args[i++].of.i32 = ctx->baddr_offs;
+
+    (void)wasmtime_func_call(rt_ctx->ctx, func, args, i, NULL, 0, NULL);
+
+    wasmtime_module_delete(rt_ctx->module);
+    wasmtime_store_delete(rt_ctx->store);
+    wasm_engine_delete(rt_ctx->engine);
+}
+
+
+const nxt_wasm_operations_t  wasm_ops = {
+    .init               = nxt_wasmtime_init,
+    .destroy            = nxt_wasmtime_destroy,
+    .exec_request       = nxt_wasmtime_execute_request,
+    .exec_hook          = nxt_wasmtime_execute_hook,
+    .meminfo            = nxt_wasmtime_meminfo,
+};

--- a/src/wasm/nxt_wasm.c
+++ b/src/wasm/nxt_wasm.c
@@ -1,0 +1,326 @@
+/*
+ * Copyright (C) Andrew Clayton
+ * Copyright (C) F5, Inc.
+ */
+
+#include <nxt_main.h>
+#include <nxt_application.h>
+#include <nxt_unit.h>
+#include <nxt_unit_request.h>
+
+#include "nxt_wasm.h"
+
+#define NXT_WASM_VERSION    "0.1"
+
+static nxt_wasm_ctx_t               nxt_wasm_ctx;
+
+static const nxt_wasm_operations_t  *nxt_wops;
+
+#define NXT_WASM_DO_HOOK(hook)  nxt_wops->exec_hook(&nxt_wasm_ctx, hook);
+
+void
+nxt_wasm_do_response_end(nxt_wasm_ctx_t *ctx)
+{
+    nxt_unit_request_done(ctx->req, NXT_UNIT_OK);
+
+    NXT_WASM_DO_HOOK(NXT_WASM_FH_RESPONSE_END);
+}
+
+
+void
+nxt_wasm_do_send_headers(uint32_t offs, nxt_wasm_ctx_t *ctx)
+{
+    size_t                   fields_len;
+    unsigned int             i;
+    nxt_wasm_response_hdr_t  *rh;
+
+    rh = (nxt_wasm_response_hdr_t *)(ctx->baddr + offs);
+
+    fields_len = 0;
+    for (i = 0; i < rh->nr_fields; i++)
+        fields_len += rh->fields[i].name_len + rh->fields[i].value_len;
+
+    nxt_unit_response_init(ctx->req, 200, rh->nr_fields, fields_len);
+
+    for (i = 0; i < rh->nr_fields; i++) {
+        const char *name;
+        const char *val;
+
+        name = (const char *)(uint8_t *)rh + rh->fields[i].name_offs;
+        val = (const char *)(uint8_t *)rh + rh->fields[i].value_offs;
+
+        printf("# Got header field [%.*s: %.*s]\n",
+               rh->fields[i].name_len, name,
+               rh->fields[i].value_len, val);
+
+        nxt_unit_response_add_field(ctx->req, name, rh->fields[i].name_len,
+                                    val, rh->fields[i].value_len);
+    }
+
+    nxt_unit_response_send(ctx->req);
+}
+
+
+void
+nxt_wasm_do_send_response(uint32_t offs, nxt_wasm_ctx_t *ctx)
+{
+    nxt_wasm_response_t      *resp;
+    nxt_unit_request_info_t  *req = ctx->req;
+
+    if (!nxt_unit_response_is_init(req)) {
+        nxt_unit_response_init(req, 200, 0, 0);
+    }
+
+    resp = (nxt_wasm_response_t *)(nxt_wasm_ctx.baddr + offs);
+
+    nxt_unit_response_write(req, (const char *)resp->data, resp->size);
+    printf("== Sending %u bytes to unit\n", resp->size);
+}
+
+
+static void
+nxt_wasm_request_handler(nxt_unit_request_info_t *req)
+{
+    size_t                     offset, read_bytes, content_sent, content_len;
+    ssize_t                    bytes_read;
+    nxt_unit_field_t           *sf, *sf_end;
+    nxt_unit_request_t         *r;
+    nxt_wasm_request_t         *wr;
+    nxt_wasm_http_hdr_field_t  *df;
+
+    NXT_WASM_DO_HOOK(NXT_WASM_FH_REQUEST_INIT);
+
+    wr = (nxt_wasm_request_t *)nxt_wasm_ctx.baddr;
+
+#define SET_REQ_MEMBER(dmember, smember) \
+    do { \
+        const char *str = nxt_unit_sptr_get(&r->smember); \
+        wr->dmember##_offs = offset; \
+        wr->dmember##_len = strlen(str); \
+        memcpy((uint8_t *)wr + offset, str, wr->dmember##_len + 1); \
+        offset += wr->dmember##_len + 1; \
+    } while (0)
+
+    r = req->request;
+    offset = sizeof(nxt_wasm_request_t)
+             + (r->fields_count * sizeof(nxt_wasm_http_hdr_field_t));
+
+    SET_REQ_MEMBER(path, path);
+    SET_REQ_MEMBER(method, method);
+    SET_REQ_MEMBER(version, version);
+    SET_REQ_MEMBER(query, query);
+    SET_REQ_MEMBER(remote, remote);
+    SET_REQ_MEMBER(local_addr, local_addr);
+    SET_REQ_MEMBER(local_port, local_port);
+    SET_REQ_MEMBER(server_name, server_name);
+#undef SET_REQ_MEMBER
+
+    df = wr->fields;
+    sf_end = r->fields + r->fields_count;
+    for (sf = r->fields; sf < sf_end; sf++) {
+        const char *name = nxt_unit_sptr_get(&sf->name);
+        const char *value = nxt_unit_sptr_get(&sf->value);
+
+        df->name_offs = offset;
+        df->name_len = strlen(name);
+        memcpy((uint8_t *)wr + offset, name, df->name_len + 1);
+        offset += df->name_len + 1;
+
+        df->value_offs = offset;
+        df->value_len = strlen(value);
+        memcpy((uint8_t *)wr + offset, value, df->value_len + 1);
+        offset += df->value_len + 1;
+
+        df++;
+    }
+
+    wr->tls = r->tls;
+    wr->nr_fields = r->fields_count;
+    wr->content_offs = offset;
+    wr->content_len = content_len = r->content_length;
+
+    printf("%s: Got request for (%.*s)\n", __func__, wr->path_len,
+           (uint8_t *)wr + wr->path_offs);
+
+    read_bytes = wr->content_len;
+    if (read_bytes > NXT_WASM_MEM_SIZE - offset) {
+        read_bytes = NXT_WASM_MEM_SIZE - offset;
+    }
+
+    printf("**** Reading %lu bytes from nxt_unit_request_read()\n", read_bytes);
+    bytes_read = nxt_unit_request_read(req, (uint8_t *)wr + offset, read_bytes);
+    printf("**** Got %ld from nxt_unit_request_read()\n", bytes_read);
+    wr->content_sent = wr->total_content_sent = content_sent = bytes_read;
+
+    wr->request_size = offset + bytes_read;
+    printf("**** wr->request_size : %u\n", wr->request_size);
+
+    nxt_wasm_ctx.req = req;
+    nxt_wops->exec_request(&nxt_wasm_ctx);
+
+    printf("**** content_len : %lu, content_sent : %lu\n",
+           content_len, content_sent);
+    if (content_len == content_sent) {
+        printf("**** Going to request_done:\n");
+        goto request_done;
+    }
+
+    wr->nr_fields = 0;
+    wr->content_offs = offset = sizeof(nxt_wasm_request_t);
+    for ( ; ; ) {
+        read_bytes = nxt_min(content_len - content_sent,
+                             NXT_WASM_MEM_SIZE - offset);
+        printf("**** Reading %lu bytes from nxt_unit_request_read()\n",
+               read_bytes);
+        bytes_read = nxt_unit_request_read(req, (uint8_t *)wr + offset,
+                                           read_bytes);
+        printf("**** Got %ld from nxt_unit_request_read()\n", bytes_read);
+
+        content_sent += bytes_read;
+        wr->request_size = wr->content_sent = bytes_read;
+        wr->total_content_sent = content_sent;
+
+        printf("**** content_length : %lu, content_sent : %lu\n",
+               content_len, content_sent);
+
+        nxt_wops->exec_request(&nxt_wasm_ctx);
+
+        if (content_len == content_sent) {
+            break;
+        }
+    }
+
+request_done:
+    nxt_wops->meminfo(&nxt_wasm_ctx);
+
+    NXT_WASM_DO_HOOK(NXT_WASM_FH_REQUEST_END);
+}
+
+
+static nxt_int_t
+nxt_wasm_start(nxt_task_t *task, nxt_process_data_t *data)
+{
+    nxt_int_t              ret;
+    nxt_unit_ctx_t         *unit_ctx;
+    nxt_unit_init_t        wasm_init;
+    nxt_common_app_conf_t  *conf;
+
+    printf("%s: \n", __func__);
+
+    conf = data->app;
+
+    ret = nxt_unit_default_init(task, &wasm_init, conf);
+    if (nxt_slow_path(ret != NXT_OK)) {
+        nxt_alert(task, "nxt_unit_default_init() failed");
+        return ret;
+    }
+
+    wasm_init.callbacks.request_handler = nxt_wasm_request_handler;
+
+    unit_ctx = nxt_unit_init(&wasm_init);
+    if (nxt_slow_path(unit_ctx == NULL)) {
+        return NXT_ERROR;
+    }
+
+    NXT_WASM_DO_HOOK(NXT_WASM_FH_MODULE_INIT);
+    nxt_unit_run(unit_ctx);
+    nxt_unit_done(unit_ctx);
+    NXT_WASM_DO_HOOK(NXT_WASM_FH_MODULE_END);
+
+    if (nxt_wasm_ctx.dirs != NULL) {
+        char  **p;
+
+        for (p = nxt_wasm_ctx.dirs; *p != NULL; p++) {
+            nxt_free(*p);
+        }
+        nxt_free(nxt_wasm_ctx.dirs);
+    }
+
+    nxt_wops->destroy(&nxt_wasm_ctx);
+
+    exit(EXIT_SUCCESS);
+}
+
+
+static nxt_int_t
+nxt_wasm_setup(nxt_task_t *task, nxt_process_t *process,
+               nxt_common_app_conf_t *conf)
+{
+    int                      n, i, err;
+    nxt_conf_value_t         *dirs = NULL;
+    nxt_wasm_app_conf_t      *c;
+    nxt_wasm_func_handler_t  *fh;
+    static nxt_str_t         filesystem_str = nxt_string("filesystem");
+
+    c = &conf->u.wasm;
+
+    printf("%s: loading wasm module %s\n", __func__, c->module);
+
+    nxt_wops = &wasm_ops;
+
+    nxt_wasm_ctx.module_path = c->module;
+
+    fh = nxt_wasm_ctx.fh;
+
+    fh[NXT_WASM_FH_REQUEST].func_name = c->request_handler;
+    fh[NXT_WASM_FH_MALLOC].func_name = c->malloc_handler;
+    fh[NXT_WASM_FH_FREE].func_name = c->free_handler;
+
+    /* Optional function handlers (hooks) */
+    fh[NXT_WASM_FH_MODULE_INIT].func_name = c->module_init_handler;
+    fh[NXT_WASM_FH_MODULE_END].func_name = c->module_end_handler;
+    fh[NXT_WASM_FH_REQUEST_INIT].func_name = c->request_init_handler;
+    fh[NXT_WASM_FH_REQUEST_END].func_name = c->request_end_handler;
+    fh[NXT_WASM_FH_RESPONSE_END].func_name = c->response_end_handler;
+
+    /* Get any directories to pass through to the WASM module */
+    if (c->access != NULL) {
+        dirs = nxt_conf_get_object_member(c->access, &filesystem_str, NULL);
+    }
+
+    n = (dirs != NULL) ? nxt_conf_object_members_count(dirs) : 0;
+    if (n == 0) {
+        goto out_init;
+    }
+
+    nxt_wasm_ctx.dirs = nxt_zalloc((n + 1) * sizeof(char *));
+    if (nxt_slow_path(nxt_wasm_ctx.dirs == NULL)) {
+        return NXT_ERROR;
+    }
+
+    for (i = 0; i < n; i++) {
+        nxt_str_t         str;
+        nxt_conf_value_t  *value;
+
+        value = nxt_conf_get_array_element(dirs, i);
+        nxt_conf_get_string(value, &str);
+
+        nxt_wasm_ctx.dirs[i] = nxt_zalloc(str.length + 1);
+        nxt_cpymem(nxt_wasm_ctx.dirs[i], str.start, str.length);
+    }
+
+out_init:
+    err = nxt_wops->init(&nxt_wasm_ctx);
+    if (err) {
+        exit(EXIT_FAILURE);
+    }
+
+    return NXT_OK;
+}
+
+
+static uint32_t  compat[] = {
+    NXT_VERNUM, NXT_DEBUG,
+};
+
+
+NXT_EXPORT nxt_app_module_t  nxt_app_module = {
+    .compat_length  = sizeof(compat),
+    .compat         = compat,
+    .type           = nxt_string("wasm"),
+    .version        = NXT_WASM_VERSION,
+    .mounts         = NULL,
+    .nmounts        = 0,
+    .setup          = nxt_wasm_setup,
+    .start          = nxt_wasm_start,
+};

--- a/src/wasm/nxt_wasm.h
+++ b/src/wasm/nxt_wasm.h
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) Andrew Clayton
+ * Copyright (C) F5, Inc.
+ */
+
+#ifndef _NXT_WASM_H_INCLUDED_
+#define _NXT_WASM_H_INCLUDED_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <nxt_unit.h>
+
+#include <wasm.h>
+#if defined(NXT_HAVE_WASM_WASMTIME)
+#include <wasmtime.h>
+#endif
+
+#define NXT_WASM_PAGE_SIZE          (64 * 1024)
+
+#define NXT_WASM_MEM_PAGES          512UL       /* 32 MiB */
+
+#define NXT_WASM_MEM_SIZE           (NXT_WASM_PAGE_SIZE * NXT_WASM_MEM_PAGES)
+
+#if defined(NXT_HAVE_WASM_WASMTIME)
+typedef wasmtime_func_t  nxt_wasm_func_t;
+#endif
+
+typedef struct {
+    uint32_t  name_offs;
+    uint32_t  name_len;
+    uint32_t  value_offs;
+    uint32_t  value_len;
+} nxt_wasm_http_hdr_field_t;
+
+typedef struct {
+    uint32_t                   method_offs;
+    uint32_t                   method_len;
+    uint32_t                   version_offs;
+    uint32_t                   version_len;
+    uint32_t                   path_offs;
+    uint32_t                   path_len;
+    uint32_t                   query_offs;
+    uint32_t                   query_len;
+    uint32_t                   remote_offs;
+    uint32_t                   remote_len;
+    uint32_t                   local_addr_offs;
+    uint32_t                   local_addr_len;
+    uint32_t                   local_port_offs;
+    uint32_t                   local_port_len;
+    uint32_t                   server_name_offs;
+    uint32_t                   server_name_len;
+
+    uint32_t                   content_offs;
+    uint32_t                   content_len;
+    uint32_t                   content_sent;
+    uint32_t                   total_content_sent;
+
+    uint32_t                   request_size;
+
+    uint32_t                   nr_fields;
+
+    uint32_t                   tls;
+
+    nxt_wasm_http_hdr_field_t  fields[];
+} nxt_wasm_request_t;
+
+typedef struct {
+    uint32_t  size;
+
+    uint8_t   data[];
+} nxt_wasm_response_t;
+
+typedef struct {
+    uint32_t                   nr_fields;
+
+    nxt_wasm_http_hdr_field_t  fields[];
+} nxt_wasm_response_hdr_t;
+
+typedef enum {
+    NXT_WASM_FH_REQUEST = 0,
+    NXT_WASM_FH_MALLOC,
+    NXT_WASM_FH_FREE,
+
+    /* Optionsl handlers */
+    NXT_WASM_FH_MODULE_INIT,
+    NXT_WASM_FH_MODULE_END,
+    NXT_WASM_FH_REQUEST_INIT,
+    NXT_WASM_FH_REQUEST_END,
+    NXT_WASM_FH_RESPONSE_END,
+
+    NXT_WASM_FH_NR
+} nxt_wasm_fh_t;
+
+typedef struct {
+    const char       *func_name;
+    nxt_wasm_func_t  func;
+} nxt_wasm_func_handler_t;
+
+typedef struct {
+    const char               *module_path;
+
+    nxt_wasm_func_handler_t  fh[NXT_WASM_FH_NR];
+
+    char                     **dirs;
+
+    nxt_unit_request_info_t  *req;
+
+    uint8_t                  *baddr;
+    size_t                   baddr_offs;
+
+    size_t                   response_offs;
+} nxt_wasm_ctx_t;
+
+typedef struct {
+    int (*init)(nxt_wasm_ctx_t *);
+    void (*destroy)(const nxt_wasm_ctx_t *);
+    void (*exec_request)(const nxt_wasm_ctx_t *);
+    void (*exec_hook)(const nxt_wasm_ctx_t *, nxt_wasm_fh_t hook);
+    void (*meminfo)(const nxt_wasm_ctx_t *);
+} nxt_wasm_operations_t;
+
+extern const nxt_wasm_operations_t  wasm_ops;
+
+/* Exported to the WASM module */
+extern void nxt_wasm_do_response_end(nxt_wasm_ctx_t *ctx);
+extern void nxt_wasm_do_send_response(uint32_t offs, nxt_wasm_ctx_t *ctx);
+extern void nxt_wasm_do_send_headers(uint32_t offs, nxt_wasm_ctx_t *ctx);
+
+#endif  /* _NXT_WASM_H_INCLUDED_ */

--- a/wasm-demo/README.md
+++ b/wasm-demo/README.md
@@ -1,0 +1,30 @@
+Unit-Wasm demo
+==============
+## 1. Docker image unit:wasm
+Create a Docker image that includes the Wasm module for Unit based on
+[PR902](https://github.com/nginx/unit/pull/902).
+
+```
+docker build --no-cache -t unit:wasm -f unit-wasm.Dockerfile .
+```
+This image is based on the Docker Official Images for Unit 1.30 with a fresh
+build of unitd and the experimental Wasm module. Wasmtime is included as a
+shared object.
+
+## 2. Docker image unit:demo-wasm
+
+Create a second Docker image as a 'hello world' Wasm application.
+
+```
+docker build -t unit:demo-wasm -f demo-wasm.Dockerfile .
+```
+This image is based on the new `unit:wasm` image created above. It includes
+a demo application written in C and compiled to wasm.
+
+## 3. Run the demo
+
+```
+docker run -d -p 9000:80 unit:demo-wasm
+curl localhost:9000
+curl localhost:9000/wasm
+```

--- a/wasm-demo/demo-wasm.Dockerfile
+++ b/wasm-demo/demo-wasm.Dockerfile
@@ -1,0 +1,20 @@
+FROM unit:wasm AS build
+WORKDIR /demo
+
+# Get all the build tools we need
+#
+RUN apt update && apt install -y wget build-essential clang lld
+RUN cd /usr/lib/llvm-11/lib/clang/11.0.1 && wget -O- https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/libclang_rt.builtins-wasm32-wasi-20.0.tar.gz | tar zxvf -
+RUN wget -O- https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sysroot-20.0.tar.gz | tar zxfv -
+
+# Copy-in the demo application source code and build into a .wasm module
+#
+ADD src/ /demo/
+RUN make
+
+# Copy the .wasm modules and Unit configuration to the final Docker image
+# that will run the demo application.
+#
+FROM unit:wasm
+COPY --from=build /demo/*.wasm /demo/
+ADD wasm-conf.json /docker-entrypoint.d

--- a/wasm-demo/src/.gitignore
+++ b/wasm-demo/src/.gitignore
@@ -1,0 +1,5 @@
+*.o
+*.a
+*.wasm
+
+!Makefile

--- a/wasm-demo/src/Makefile
+++ b/wasm-demo/src/Makefile
@@ -1,0 +1,40 @@
+SYSROOT	= /demo/wasi-sysroot
+
+CC	= clang
+CFLAGS	= -Wall -Wextra -Wdeclaration-after-statement -Wvla -std=gnu11 \
+	  -fno-strict-aliasing --target=wasm32-wasi --sysroot=$(SYSROOT) \
+	  -Iinclude
+LDFLAGS	= -Wl,--no-entry,--export=__heap_base,--export=__data_end,--export=malloc,--export=free,--stack-first,-z,stack-size=$$((8*1024*1024)) \
+	  -mexec-model=reactor --rtlib=compiler-rt
+
+all: luw-echo-request luw-upload-reflector libunit-wasm.a
+
+libunit-wasm.o: libunit-wasm.c include/unit/unit-wasm.h
+	$(CC) $(CFLAGS) -fvisibility=hidden -c $<
+
+libunit-wasm.a: libunit-wasm.o
+	llvm-ar rcs $@ $<
+
+luw-echo-request: luw-echo-request.c libunit-wasm.o
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@.wasm $< libunit-wasm.o
+
+luw-upload-reflector: luw-upload-reflector.c libunit-wasm.o
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@.wasm $< libunit-wasm.o
+
+crate: libunit-wasm.a rust/libunit-wasm/build.rs rust/libunit-wasm/src/lib.rs rust/libunit-wasm/Cargo.toml
+	bindgen include/unit/unit-wasm.h -o rust/libunit-wasm/src/bindings.rs \
+	 --allowlist-function '^luw_.*' --allowlist-var '^luw_.*' \
+	 --allowlist-type '^luw_.*' -- --target=wasm32-wasi
+	cd rust/libunit-wasm; cargo build --target=wasm32-wasi
+
+unit-wasm-raw.o: unit-wasm-raw.c unit-wasm-raw.h
+	$(CC) $(CFLAGS) -c $<
+
+echo-request-raw: echo-request-raw.c unit-wasm-raw.o
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@.wasm $< unit-wasm-raw.o
+
+upload-reflector-raw: upload-reflector-raw.c unit-wasm-raw.o
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@.wasm $< unit-wasm-raw.o
+
+clean:
+	rm -f *.wasm *.o *.a *.gch

--- a/wasm-demo/src/echo-request-raw.c
+++ b/wasm-demo/src/echo-request-raw.c
@@ -1,0 +1,180 @@
+/*
+ * echo-request-raw.c - Raw example of writing a WASM module for use with Unit
+ *
+ * Download the wasi-sysroot tarball from https://github.com/WebAssembly/wasi-sdk/releases
+ */
+
+#define _GNU_SOURCE
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "unit-wasm-raw.h"
+
+static u8 *request_buf;
+
+__attribute__((import_module("env"), import_name("nxt_wasm_get_init_mem_size")))
+u32 nxt_wasm_get_init_mem_size(void);
+__attribute__((import_module("env"), import_name("nxt_wasm_response_end")))
+void nxt_wasm_response_end(void);
+__attribute__((import_module("env"), import_name("nxt_wasm_send_response")))
+void nxt_wasm_send_response(u32 offset);
+
+__attribute__((export_name("wasm_module_end_handler")))
+void wasm_module_end_handler(void)
+{
+	free(request_buf);
+}
+
+__attribute__((export_name("wasm_module_init_handler")))
+void wasm_module_init_handler(void)
+{
+	request_buf = malloc(nxt_wasm_get_init_mem_size());
+}
+
+__attribute__((export_name("wasm_free_handler")))
+void wasm_free_handler(u32 addr)
+{
+	free((void *)addr);
+}
+
+__attribute__((export_name("wasm_malloc_handler")))
+u32 wasm_malloc_handler(size_t size)
+{
+	return (u32)malloc(size);
+}
+
+static int echo_request(u8 *addr)
+{
+	u8 *p;
+	const char *method;
+	struct req *req;
+	struct resp *resp;
+	struct hdr_field *hf;
+	struct hdr_field *hf_end;
+	static const int resp_offs = 4096;
+
+	printf("==[WASM RESP]== %s:\n", __func__);
+
+	/*
+	 * For convenience, we will return our headers at the start
+	 * of the shared memory so leave a little space (resp_offs)
+	 * before storing the main response.
+	 *
+	 * send_headers() will return the start of the shared memory,
+	 * echo_request() will return the start of the shared memory
+	 * plus resp_offs.
+	 */
+	resp = (struct resp *)(addr + resp_offs);
+
+	req = (struct req *)request_buf;
+
+#define BUF_ADD(name, member) \
+	do { \
+		p = mempcpy(p, name, strlen(name)); \
+		p = mempcpy(p, (u8 *)req + req->member##_offs, req->member##_len); \
+		p = mempcpy(p, "\n", 1); \
+	} while (0)
+
+#define BUF_ADD_HF() \
+	do { \
+		p = mempcpy(p, (u8 *)req + hf->name_offs, hf->name_len); \
+		p = mempcpy(p, " = ", 3); \
+		p = mempcpy(p, (u8 *)req + hf->value_offs, hf->value_len); \
+		p = mempcpy(p, "\n", 1); \
+	} while (0)
+
+	p = resp->data;
+
+	p = mempcpy(p, "Welcome to WebAssembly on Unit!\n\n", 33);
+
+	p = mempcpy(p, "[Request Info]\n", 15);
+	BUF_ADD("REQUEST_PATH = ", path);
+	BUF_ADD("METHOD       = ", method);
+	BUF_ADD("VERSION      = ", version);
+	BUF_ADD("QUERY        = ", query);
+	BUF_ADD("REMOTE       = ", remote);
+	BUF_ADD("LOCAL_ADDR   = ", local_addr);
+	BUF_ADD("LOCAL_PORT   = ", local_port);
+	BUF_ADD("SERVER_NAME  = ", server_name);
+
+	p = mempcpy(p, "\n[Request Headers]\n", 19);
+	hf_end = req->fields + req->nr_fields;
+	for (hf = req->fields; hf < hf_end; hf++)
+		BUF_ADD_HF();
+
+	method = (char *)req + req->method_offs;
+	if (memcmp(method, "POST", req->method_len) == 0 ||
+	    memcmp(method, "PUT", req->method_len) == 0) {
+		p = mempcpy(p, "\n[", 2);
+		p = mempcpy(p, method, req->method_len);
+		p = mempcpy(p, " data]\n", 7);
+		p = mempcpy(p, (u8 *)req + req->content_offs, req->content_len);
+		p = mempcpy(p, "\n", 1);
+	}
+
+	p = memcpy(p, "\0", 1);
+
+	resp->size = p - resp->data;
+
+	send_headers(addr, "text/plain", resp->size);
+
+	nxt_wasm_send_response(resp_offs);
+	/* Tell Unit no more data to send */
+	nxt_wasm_response_end();
+
+	return 0;
+}
+
+__attribute__((export_name("wasm_request_handler")))
+int wasm_request_handler(u8 *addr)
+{
+	struct req *req = (struct req *)addr;
+	struct req *rb = (struct req *)request_buf;
+
+	printf("==[WASM REQ]== %s:\n", __func__);
+
+	/*
+	 * This function _may_ be called multiple times during a single
+	 * request if there is a large amount of data to transfer.
+	 *
+	 * In this simple demo, we are only expecting it to be called
+	 * once per request.
+	 *
+	 * Some useful request meta data:
+	 *
+	 * req->content_len contains the overall size of the POST/PUT
+	 * data.
+	 * req->content_sent shows how much of the body content has been
+	 * in _this_ request.
+	 * req->total_content_sent shows how much of it has been sent in
+	 * total.
+	 * req->content_offs is the offset in the passed in memory where
+	 * the body content starts.
+	 *
+	 * For new requests req->request_size shows the total size of
+	 * _this_ request, incl the req structure itself.
+	 * For continuation requests, req->request_size is just the amount
+	 * of new content, i.e req->content_sent
+	 *
+	 * When req->content_len == req->total_content_sent, that's the end
+	 * of that request.
+	 */
+
+	printf("==[WASM REQ]== req->request_size : %u\n", req->request_size);
+	memcpy(request_buf, addr, req->request_size);
+
+	rb = (struct req *)request_buf;
+	printf("==[WASM REQ]== rb@%p\n", rb);
+	printf("==[WASM REQ]== request_buf@%p\n", request_buf);
+	printf("==[WASM REQ]== rb->content_offs : %u\n", rb->content_offs);
+	printf("==[WASM REQ]== rb->content_len  : %u\n", rb->content_len);
+	printf("==[WASM REQ]== rb->content_sent : %u\n", rb->content_sent);
+	printf("==[WASM REQ]== rb->request_size : %u\n", rb->request_size);
+
+	echo_request(addr);
+
+	return 0;
+}

--- a/wasm-demo/src/include/unit/unit-wasm.h
+++ b/wasm-demo/src/include/unit/unit-wasm.h
@@ -1,0 +1,187 @@
+#ifndef _LIBUNIT_WASM_H_
+#define _LIBUNIT_WASM_H_
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define LUW_VERSION_MAJOR	0
+#define LUW_VERSION_MINOR	1
+#define LUW_VERSION_PATCH	0
+
+/* Version number in hex 0xMMmmpp00 */
+#define LUW_VERSION_NUMBER \
+	( (LUW_VERSION_MAJOR << 24) | \
+	  (LUW_VERSION_MINOR << 16) | \
+	  (LUW_VERSION_PATCH << 8) )
+
+#define __luw_export_name(name)	__attribute__((export_name(name)))
+
+typedef uint64_t u64;
+typedef int64_t  s64;
+typedef uint32_t u32;
+typedef int32_t  s32;
+typedef uint16_t u16;
+typedef int16_t  s16;
+typedef uint8_t   u8;
+typedef int8_t    s8;
+
+struct luw_hdr_field {
+	u32 name_offs;
+	u32 name_len;
+	u32 value_offs;
+	u32 value_len;
+};
+
+struct luw_req {
+	u32 method_offs;
+	u32 method_len;
+	u32 version_offs;
+	u32 version_len;
+	u32 path_offs;
+	u32 path_len;
+	u32 query_offs;
+	u32 query_len;
+	u32 remote_offs;
+	u32 remote_len;
+	u32 local_addr_offs;
+	u32 local_addr_len;
+	u32 local_port_offs;
+	u32 local_port_len;
+	u32 server_name_offs;
+	u32 server_name_len;
+
+	u32 content_offs;
+	u32 content_len;
+	u32 content_sent;
+	u32 total_content_sent;
+
+	u32 request_size;
+
+	u32 nr_fields;
+
+	u32 tls;
+
+	struct luw_hdr_field fields[];
+};
+
+struct luw_resp {
+	u32 size;
+
+	u8 data[];
+};
+
+struct luw_resp_hdr {
+	u32 nr_fields;
+
+	struct luw_hdr_field fields[];
+};
+
+typedef struct {
+	/* pointer to the shared memory */
+	u8 *addr;
+
+	/* points to the end of ctx->resp->data */
+	u8 *mem;
+
+	/* struct luw_req representation of the shared memory */
+	struct luw_req *req;
+
+	/* struct luw_resp representation of the shared memory */
+	struct luw_resp *resp;
+
+	/* struct luw_resp_hdr represnetation of the shared memory */
+	struct luw_resp_hdr *resp_hdr;
+
+	/* offset to where the struct resp starts in the shared memory */
+	size_t resp_offset;
+
+	/* points to the external buffer used for a copy of the request */
+	u8 *req_buf;
+
+	/* points to the end of the fields array in struct luw_resp_hdr */
+	u8 *hdrp;
+
+	/* points to the end of ctx->req_buf */
+	u8 *reqp;
+} luw_ctx_t;
+
+typedef enum {
+	LUW_SRB_NONE = 0x00,
+	LUW_SRB_APPEND = 0x01,
+	LUW_SRB_ALLOC = 0x02,
+	LUW_SRB_FULL_SIZE = 0x04,
+} luw_srb_flags_t;
+#define LUW_SRB_FLAGS_ALL \
+	(LUW_SRB_NONE|LUW_SRB_APPEND|LUW_SRB_ALLOC|LUW_SRB_FULL_SIZE)
+
+typedef struct luw_hdr_field luw_http_hdr_iter_t;
+
+#define luw_foreach_http_hdr(ctx, iter, name, value) \
+	for (iter = ctx->req->fields, \
+	     name = (const char *)(u8 *)ctx->req + iter->name_offs; \
+	     (iter < (ctx->req->fields + ctx->req->nr_fields)) && \
+	     (value = (const char *)(u8 *)ctx->req + iter->value_offs); \
+	     iter++, name = (const char *)(u8 *)ctx->req + iter->name_offs)
+
+/* Imported functions from the host/runtime */
+__attribute__((import_module("env"), import_name("nxt_wasm_get_init_mem_size")))
+u32 nxt_wasm_get_init_mem_size(void);
+__attribute__((import_module("env"), import_name("nxt_wasm_response_end")))
+void nxt_wasm_response_end(void);
+__attribute__((import_module("env"), import_name("nxt_wasm_send_headers")))
+void nxt_wasm_send_headers(u32 offset);
+__attribute__((import_module("env"), import_name("nxt_wasm_send_response")))
+void nxt_wasm_send_response(u32 offset);
+
+extern void luw_module_init_handler(void);
+extern void luw_module_end_handler(void);
+extern void luw_request_init_handler(void);
+extern void luw_request_end_handler(void);
+extern void luw_response_end_handler(void);
+extern int luw_request_handler(u8 *addr);
+extern void luw_free_handler(u32 addr);
+extern u32 luw_malloc_handler(size_t size);
+
+#pragma GCC visibility push(default)
+
+extern void luw_init_ctx(luw_ctx_t *ctx, u8 *addr, size_t offset);
+extern void luw_destroy_ctx(const luw_ctx_t *ctx);
+extern int luw_set_req_buf(luw_ctx_t *ctx, u8 **buf, unsigned long flags);
+extern const char *luw_get_http_path(const luw_ctx_t *ctx);
+extern const char *luw_get_http_method(const luw_ctx_t *ctx);
+extern const char *luw_get_http_version(const luw_ctx_t *ctx);
+extern const char *luw_get_http_query(const luw_ctx_t *ctx);
+extern const char *luw_get_http_remote(const luw_ctx_t *ctx);
+extern const char *luw_get_http_local_addr(const luw_ctx_t *ctx);
+extern const char *luw_get_http_local_port(const luw_ctx_t *ctx);
+extern const char *luw_get_http_server_name(const luw_ctx_t *ctx);
+extern const u8 *luw_get_http_content(const luw_ctx_t *ctx);
+extern size_t luw_get_http_content_len(const luw_ctx_t *ctx);
+extern size_t luw_get_http_content_sent(const luw_ctx_t *ctx);
+extern bool luw_http_is_tls(const luw_ctx_t *ctx);
+extern size_t luw_get_response_data_size(const luw_ctx_t *ctx);
+extern int luw_mem_writep(luw_ctx_t *ctx, const char *fmt, ...);
+extern size_t luw_mem_writep_data(luw_ctx_t *ctx, const u8 *src, size_t size);
+extern void luw_req_buf_append(luw_ctx_t *ctx, const u8 *src);
+extern size_t luw_mem_fill_buf_from_req(luw_ctx_t *ctx, size_t from);
+extern void luw_mem_reset(luw_ctx_t *ctx);
+extern void luw_http_send_response(const luw_ctx_t *ctx);
+extern void luw_http_init_headers(luw_ctx_t *ctx, size_t nr, size_t offset);
+extern void luw_http_add_header(luw_ctx_t *ctx, u16 idx, const char *name,
+				const char *value);
+extern void luw_http_send_headers(const luw_ctx_t *ctx);
+extern void luw_http_response_end(void);
+extern u32 luw_mem_get_init_size(void);
+
+#pragma GCC visibility pop
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* _LIBUNIT_WASM_H_ */

--- a/wasm-demo/src/libunit-wasm.c
+++ b/wasm-demo/src/libunit-wasm.c
@@ -1,0 +1,323 @@
+#define _GNU_SOURCE
+
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdarg.h>
+#include <string.h>
+#include <errno.h>
+
+#include "unit/unit-wasm.h"
+
+/*
+ * Some handlers are required some are optional.
+ *
+ * They are defined as _weak_ symbols so they can be overridden
+ * in the module.
+ */
+
+/* Optional Handlers */
+__attribute__((export_name("luw_module_init_handler"), __weak__))
+void luw_module_init_handler(void)
+{
+}
+
+__attribute__((export_name("luw_module_end_handler"), __weak__))
+void luw_module_end_handler(void)
+{
+}
+
+__attribute__((export_name("luw_request_init_handler"), __weak__))
+void luw_request_init_handler(void)
+{
+}
+
+__attribute__((export_name("luw_request_end_handler"), __weak__))
+void luw_request_end_handler(void)
+{
+}
+
+__attribute__((export_name("luw_response_end_handler"), __weak__))
+void luw_response_end_handler(void)
+{
+}
+
+/* Required Handlers */
+__attribute__((export_name("luw_request_handler"), __weak__))
+int luw_request_handler(u8 *addr)
+{
+	(void)addr;
+
+	return 0;
+}
+
+__attribute__((export_name("luw_free_handler"), __weak__))
+void luw_free_handler(u32 addr)
+{
+        free((void *)addr);
+}
+
+__attribute__((export_name("luw_malloc_handler"), __weak__))
+u32 luw_malloc_handler(size_t size)
+{
+        return (u32)malloc(size);
+}
+
+void luw_init_ctx(luw_ctx_t *ctx, u8 *addr, size_t offset)
+{
+	*ctx = (luw_ctx_t){ };
+
+	ctx->addr = addr;
+	ctx->req = (struct luw_req *)addr;
+	ctx->resp = (struct luw_resp *)(addr + offset);
+	ctx->mem = ctx->resp->data;
+	ctx->resp_offset = offset;
+}
+
+/*
+ * Allows to set an external buffer to be used as a copy for
+ * the request.
+ *
+ * The flags dictate a few behaviours
+ *
+ * LUW_SRB_NONE		- No specific action to be performed. It will
+ *			  simply copy the request data into the specified
+ *			  buffer.
+ *
+ * LUW_SRB_APPEND	- Sets up append mode whereby multiple successive
+ *			  requests will be appended to the specified buffer.
+ *
+ *			  The first request will have all it's netadata
+ *			  copied. Suvsequent requests will _only_ have the
+ *			  actual body data appended.
+ *
+ * LUW_SRB_ALLOC	- Allocate memory for the specified buffer.
+ *
+ * LUW_SRB_FULL_SIZE	- Used in conjunction with LUW_SRB_ALLOC. By
+ *			  default only ctx->req->request_size is
+ *			  allocated. If this flag is present it says to
+ *			  allocate memory for the _entire_ request that
+ *			  will eventually be sent.
+ */
+int luw_set_req_buf(luw_ctx_t *ctx, u8 **buf, unsigned long flags)
+{
+	size_t alloc_size;
+	size_t copy_bytes;
+
+	/* Check for unknown flags */
+	if (flags & ~LUW_SRB_FLAGS_ALL) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	/* Check for invalid combinations of flags */
+	if (flags & LUW_SRB_FULL_SIZE && !(flags & LUW_SRB_ALLOC)) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	alloc_size = copy_bytes = ctx->req->request_size;
+
+	if (flags & LUW_SRB_FULL_SIZE)
+		alloc_size = ctx->req->content_offs + ctx->req->content_len;
+
+	if (flags & LUW_SRB_ALLOC) {
+		*buf = malloc(alloc_size);
+		if (!*buf)
+			return -1;
+	}
+
+	memcpy(*buf, ctx->addr, copy_bytes);
+	ctx->req_buf = *buf;
+	ctx->req = (struct luw_req *)ctx->req_buf;
+	ctx->reqp = ctx->req_buf;
+
+	if (flags & LUW_SRB_APPEND)
+		ctx->reqp = ctx->req_buf + copy_bytes;
+
+	return 0;
+}
+
+const char *luw_get_http_path(const luw_ctx_t *ctx)
+{
+	return (const char *)(u8 *)ctx->req + ctx->req->path_offs;
+}
+
+const char *luw_get_http_method(const luw_ctx_t *ctx)
+{
+	return (const char *)(u8 *)ctx->req + ctx->req->method_offs;
+}
+
+const char *luw_get_http_version(const luw_ctx_t *ctx)
+{
+	return (const char *)(u8 *)ctx->req + ctx->req->version_offs;
+}
+
+const char *luw_get_http_query(const luw_ctx_t *ctx)
+{
+	return (const char *)(u8 *)ctx->req + ctx->req->query_offs;
+}
+
+const char *luw_get_http_remote(const luw_ctx_t *ctx)
+{
+	return (const char *)(u8 *)ctx->req + ctx->req->remote_offs;
+}
+
+const char *luw_get_http_local_addr(const luw_ctx_t *ctx)
+{
+	return (const char *)(u8 *)ctx->req + ctx->req->local_addr_offs;
+}
+
+const char *luw_get_http_local_port(const luw_ctx_t *ctx)
+{
+	return (const char *)(u8 *)ctx->req + ctx->req->local_port_offs;
+}
+
+const char *luw_get_http_server_name(const luw_ctx_t *ctx)
+{
+	return (const char *)(u8 *)ctx->req + ctx->req->server_name_offs;
+}
+
+const u8 *luw_get_http_content(const luw_ctx_t *ctx)
+{
+	return (u8 *)ctx->req + ctx->req->content_offs;
+}
+
+/* Returns the size of the overall content length */
+size_t luw_get_http_content_len(const luw_ctx_t *ctx)
+{
+	return ctx->req->content_len;
+}
+
+/* Returns the size of the content sent in _this_ request */
+size_t luw_get_http_content_sent(const luw_ctx_t *ctx)
+{
+	return ctx->req->content_sent;
+}
+
+bool luw_http_is_tls(const luw_ctx_t *ctx)
+{
+	return ctx->req->tls;
+}
+
+/* Returns the size of ctx->resp->data[] */
+size_t luw_get_response_data_size(const luw_ctx_t *ctx)
+{
+	return ctx->mem - ctx->resp->data;
+}
+
+/* Appends formatted nul terminated data to the response buffer */
+__attribute__((__format__(printf, 2, 3)))
+int luw_mem_writep(luw_ctx_t *ctx, const char *fmt, ...)
+{
+	int len;
+	char *logbuf;
+	va_list ap;
+
+	va_start(ap, fmt);
+	len = vasprintf(&logbuf, fmt, ap);
+	if (len == -1) {
+		va_end(ap);
+		return 1;
+	}
+	va_end(ap);
+
+	ctx->mem = mempcpy(ctx->mem, logbuf, len);
+	ctx->resp->size += len;
+
+	free(logbuf);
+
+	return 0;
+}
+
+/* Appends data of length size to the response buffer */
+size_t luw_mem_writep_data(luw_ctx_t *ctx, const u8 *src, size_t size)
+{
+	ctx->mem = mempcpy(ctx->mem, src, size);
+	ctx->resp->size += size;
+
+	return ctx->resp->size;
+}
+
+/* Append data from the request to the previously setup request_buffer. */
+void luw_req_buf_append(luw_ctx_t *ctx, const u8 *src)
+{
+	struct luw_req *req = (struct luw_req *)src;
+
+	ctx->reqp = mempcpy(ctx->reqp, src + req->content_offs,
+			    req->request_size);
+	ctx->req->content_sent = req->content_sent;
+	ctx->req->total_content_sent = req->total_content_sent;
+}
+
+/*
+ * Convenience function to fill the response buffer with data from
+ * the request buffer.
+ *
+ * The runtime allocates NXT_WASM_MEM_SIZE + NXT_WASM_PAGE_SIZE
+ * bytes so we don't need to worry about the size of the actual
+ * response structures.
+ */
+size_t luw_mem_fill_buf_from_req(luw_ctx_t *ctx, size_t from)
+{
+	size_t write_bytes;
+	size_t mem_size = nxt_wasm_get_init_mem_size();
+
+	write_bytes = ctx->req->content_sent;
+	if (write_bytes > mem_size)
+		write_bytes = mem_size;
+
+	memcpy(ctx->resp->data, ctx->req_buf + ctx->req->content_offs + from,
+	       write_bytes);
+	ctx->resp->size = write_bytes;
+
+	return write_bytes;
+}
+
+void luw_mem_reset(luw_ctx_t *ctx)
+{
+	ctx->mem = ctx->resp->data;
+	ctx->resp->size = 0;
+}
+
+void luw_http_send_response(const luw_ctx_t *ctx)
+{
+	nxt_wasm_send_response(ctx->resp_offset);
+}
+
+void luw_http_init_headers(luw_ctx_t *ctx, size_t nr, size_t offset)
+{
+	ctx->resp_hdr = (struct luw_resp_hdr *)(ctx->addr + offset);
+	ctx->hdrp = (u8 *)ctx->resp_hdr + sizeof(struct luw_resp_hdr) +
+		(nr * sizeof(struct luw_hdr_field));
+
+	ctx->resp_hdr->nr_fields = nr;
+}
+
+void luw_http_add_header(luw_ctx_t *ctx, u16 idx, const char *name,
+			 const char *value)
+{
+	ctx->resp_hdr->fields[idx].name_offs = ctx->hdrp - ctx->addr;
+	ctx->resp_hdr->fields[idx].name_len = strlen(name);
+	ctx->hdrp = mempcpy(ctx->hdrp, name, strlen(name));
+
+	ctx->resp_hdr->fields[idx].value_offs = ctx->hdrp - ctx->addr;
+	ctx->resp_hdr->fields[idx].value_len = strlen(value);
+	ctx->hdrp = mempcpy(ctx->hdrp, value, strlen(value));
+}
+
+void luw_http_send_headers(const luw_ctx_t *ctx)
+{
+	nxt_wasm_send_headers((u8 *)ctx->resp_hdr - ctx->addr);
+}
+
+void luw_http_response_end(void)
+{
+	nxt_wasm_response_end();
+}
+
+u32 luw_mem_get_init_size(void)
+{
+	return nxt_wasm_get_init_mem_size();
+}

--- a/wasm-demo/src/luw-echo-request.c
+++ b/wasm-demo/src/luw-echo-request.c
@@ -1,0 +1,92 @@
+/*
+ * luw-echo-request.c - Example of writing a WASM module for use with Unit
+ *			using libunit-wasm to make things nicer.
+ */
+
+#define _GNU_SOURCE
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "unit/unit-wasm.h"
+
+static u8 *request_buf;
+
+__luw_export_name("luw_module_end_handler")
+void luw_module_end_handler(void)
+{
+	free(request_buf);
+}
+
+__luw_export_name("luw_module_init_handler")
+void luw_module_init_handler(void)
+{
+	request_buf = malloc(luw_mem_get_init_size());
+}
+
+__luw_export_name("luw_request_handler")
+int luw_request_handler(u8 *addr)
+{
+	luw_ctx_t ctx_;
+	luw_ctx_t *ctx = &ctx_;
+	luw_http_hdr_iter_t *iter;
+	char clen[32];
+	const char *method;
+	const char *name;
+	const char *value;
+
+	luw_init_ctx(ctx, addr, 4096 /* Response offset */);
+	/* Take a copy of the request and use that */
+	luw_set_req_buf(ctx, &request_buf, LUW_SRB_NONE);
+
+#define BUF_ADD(fmt, member) \
+	luw_mem_writep(ctx, fmt, luw_get_http_##member(ctx));
+
+#define BUF_ADD_HF(fmt, name, value) \
+	luw_mem_writep(ctx, fmt, name, value);
+
+	luw_mem_writep(ctx,
+		       " *** Welcome to WebAssembly on Unit! "
+		       "[libunit-wasm (%d.%d.%d/%#0.8x)] ***\n\n",
+		       LUW_VERSION_MAJOR, LUW_VERSION_MINOR, LUW_VERSION_PATCH,
+		       LUW_VERSION_NUMBER);
+
+	luw_mem_writep(ctx, "[Request Info]\n");
+	BUF_ADD("REQUEST_PATH = %s\n", path);
+	BUF_ADD("METHOD       = %s\n", method);
+	BUF_ADD("VERSION      = %s\n", version);
+	BUF_ADD("QUERY        = %s\n", query);
+	BUF_ADD("REMOTE       = %s\n", remote);
+	BUF_ADD("LOCAL_ADDR   = %s\n", local_addr);
+	BUF_ADD("LOCAL_PORT   = %s\n", local_port);
+	BUF_ADD("SERVER_NAME  = %s\n", server_name);
+
+	luw_mem_writep(ctx, "\n[Request Headers]\n");
+
+	luw_foreach_http_hdr(ctx, iter, name, value)
+		BUF_ADD_HF("%s = %s\n", name, value);
+
+	method = luw_get_http_method(ctx);
+	if (memcmp(method, "POST", strlen(method)) == 0 ||
+	    memcmp(method, "PUT", strlen(method)) == 0) {
+		luw_mem_writep(ctx, "\n[%s data]\n", method);
+		luw_mem_writep_data(ctx, luw_get_http_content(ctx),
+				    luw_get_http_content_len(ctx));
+		luw_mem_writep(ctx, "\n");
+	}
+
+	luw_http_init_headers(ctx, 2, 0);
+
+	snprintf(clen, sizeof(clen), "%lu", luw_get_response_data_size(ctx));
+	luw_http_add_header(ctx, 0, "Content-Type", "text/plain");
+	luw_http_add_header(ctx, 1, "Content-Length", clen);
+
+	luw_http_send_headers(ctx);
+
+	luw_http_send_response(ctx);
+	/* Tell Unit no more data to send */
+	luw_http_response_end();
+
+	return 0;
+}

--- a/wasm-demo/src/luw-upload-reflector.c
+++ b/wasm-demo/src/luw-upload-reflector.c
@@ -1,0 +1,120 @@
+/*
+ * luw-upload-reflector.c - Example of writing a WASM module for use with Unit
+ *			    using libunit-wasm to make things nicer.
+*/
+
+#define _GNU_SOURCE
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "unit/unit-wasm.h"
+
+static luw_ctx_t ctx;
+
+static size_t total_response_sent;
+
+static u8 *request_buf;
+
+__luw_export_name("luw_response_end_handler")
+void luw_response_end_handler(void)
+{
+	total_response_sent = 0;
+}
+
+__luw_export_name("luw_request_end_handler")
+void luw_request_end_handler(void)
+{
+	if (!request_buf)
+		return;
+
+	free(request_buf);
+	request_buf = NULL;
+}
+
+__luw_export_name("luw_free_handler")
+void luw_free_handler(u32 addr)
+{
+	free((void *)addr);
+}
+
+__luw_export_name("luw_malloc_handler")
+u32 luw_malloc_handler(size_t size)
+{
+	return (u32)malloc(size);
+}
+
+static int upload_reflector(luw_ctx_t *ctx)
+{
+	size_t write_bytes;
+
+	/* Send headers */
+	if (total_response_sent == 0) {
+		luw_http_hdr_iter_t *iter;
+		const char *name;
+		const char *value;
+		char ct[256] = "application/octet-stream";
+		char clen[32];
+
+		/* Try to set the Content-Type */
+		luw_foreach_http_hdr(ctx, iter, name, value) {
+			if (strncasecmp(name, "Content-Type", 12) != 0)
+				continue;
+
+			snprintf(ct, sizeof(ct), "%s", value);
+			break;
+		}
+
+		luw_http_init_headers(ctx, 2, 0);
+
+		snprintf(clen, sizeof(clen), "%lu",
+			 luw_get_http_content_len(ctx));
+		luw_http_add_header(ctx, 0, "Content-Type", ct);
+		luw_http_add_header(ctx, 1, "Content-Length", clen);
+
+		luw_http_send_headers(ctx);
+	}
+
+	write_bytes = luw_mem_fill_buf_from_req(ctx, total_response_sent);
+	total_response_sent += write_bytes;
+
+	luw_http_send_response(ctx);
+
+	if (total_response_sent == ctx->req->content_len) {
+		total_response_sent = 0;
+
+		free(request_buf);
+		request_buf = NULL;
+
+		/* Tell Unit no more data to send */
+		luw_http_response_end();
+	}
+
+	return 0;
+}
+
+__luw_export_name("luw_request_handler")
+int luw_request_handler(u8 *addr)
+{
+	if (!request_buf) {
+		luw_init_ctx(&ctx, addr, 0 /* Response offset */);
+		/*
+		 * Take a copy of the request and use that, we do this
+		 * in APPEND mode so we can build up request_buf from
+		 * multiple requests.
+		 *
+		 * Just allocate memory for the total amount of data we
+		 * expect to get, this includes the request structure
+		 * itself as well as any body content.
+		 */
+		luw_set_req_buf(&ctx, &request_buf,
+				LUW_SRB_APPEND|LUW_SRB_ALLOC|LUW_SRB_FULL_SIZE);
+	} else {
+		luw_req_buf_append(&ctx, addr);
+	}
+
+	upload_reflector(&ctx);
+
+	return 0;
+}

--- a/wasm-demo/src/rust/.gitignore
+++ b/wasm-demo/src/rust/.gitignore
@@ -1,0 +1,3 @@
+Cargo.lock
+
+target/

--- a/wasm-demo/src/rust/echo-request/Cargo.toml
+++ b/wasm-demo/src/rust/echo-request/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "echo-test"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rust-unit-wasm = { path = "../libunit-wasm" }
+
+[lib]
+crate-type = ["cdylib"]

--- a/wasm-demo/src/rust/echo-request/src/lib.rs
+++ b/wasm-demo/src/rust/echo-request/src/lib.rs
@@ -1,0 +1,92 @@
+use rust_unit_wasm::*;
+
+// Buffer of some size to store the copy of the request
+const REQUEST_BUF: *mut *mut u8 = std::ptr::null_mut();
+
+#[no_mangle]
+pub extern "C" fn luw_module_end_handler() {
+    //free(REQUEST_BUF);
+}
+
+#[no_mangle]
+pub extern "C" fn luw_module_init_handler() {
+    //REQUEST_BUF = malloc(luw_mem_get_init_size());
+}
+
+#[no_mangle]
+pub extern "C" fn luw_request_handler(addr: *mut u8) -> i32 {
+    // Need a initalization
+    //
+    // It sucks that rust needs this, this is supposed to be
+    // an opaque structure and the structure is 0-initialised
+    // in luw_init_ctx();
+    let mut ctx_: luw_ctx_t = luw_ctx_t {
+        addr: std::ptr::null_mut(),
+        mem: std::ptr::null_mut(),
+        req: std::ptr::null_mut(),
+        resp: std::ptr::null_mut(),
+        resp_hdr: std::ptr::null_mut(),
+        resp_offset: 0,
+        req_buf: std::ptr::null_mut(),
+        hdrp: std::ptr::null_mut(),
+        reqp: std::ptr::null_mut(),
+    };
+    let ctx: *mut luw_ctx_t = &mut ctx_;
+
+    unsafe {
+        // Initialise the context structure.
+        //
+        // addr is the address of the previously allocated memory shared
+        // between the module and unit.
+        //
+        // The response data will be stored @ addr + offset (of 4096 bytes).
+        // This will leave some space for the response  headers.
+        luw_init_ctx(ctx, addr, 4096);
+
+        // Allocate memory to store the request and copy the request data.
+        luw_set_req_buf(
+            ctx,
+            REQUEST_BUF,
+            luw_srb_flags_t_LUW_SRB_ALLOC | luw_srb_flags_t_LUW_SRB_FULL_SIZE,
+        );
+
+        // Define the Response Body Text.
+        let response = "Hello World - From WebAssembly in Rust on Unit :) \n";
+        luw_mem_writep(ctx, response.as_ptr() as *const i8);
+
+        // Debgging: Print the response.len()
+        let content_len = format!("{}\0", response.len());
+
+        // Init Response Headers
+        //
+        // Needs the context, number of headers about to add as well as
+        // the offset where to store the headers. In this case we are
+        // storing the response headers at the beginning of our shared
+        // memory at offset 0.
+
+        luw_http_init_headers(ctx, 2, 0);
+        luw_http_add_header(
+            ctx,
+            0,
+            "Content-Type\0".as_ptr() as *const i8,
+            "text/plain\0".as_ptr() as *const i8,
+        );
+        luw_http_add_header(
+            ctx,
+            1,
+            "Content-Length\0".as_ptr() as *const i8,
+            content_len.as_ptr() as *const i8,
+        );
+
+        // This calls nxt_wasm_send_headers() in Unit
+        luw_http_send_headers(ctx);
+
+        // This calls nxt_wasm_send_response() in Unit
+        luw_http_send_response(ctx);
+
+        // This calls nxt_wasm_response_end() in Unit
+        luw_http_response_end();
+    }
+
+    return 0;
+}

--- a/wasm-demo/src/rust/libunit-wasm/Cargo.toml
+++ b/wasm-demo/src/rust/libunit-wasm/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "rust-unit-wasm"
+version = "0.0.1"
+build = "build.rs"
+links = "unit-wasm"
+
+[lib]
+crate-type = ["rlib"]
+path = "src/lib.rs"

--- a/wasm-demo/src/rust/libunit-wasm/build.rs
+++ b/wasm-demo/src/rust/libunit-wasm/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("cargo:rustc-link-search=native=../../");
+    println!("cargo:rustc-link-lib=static=unit-wasm");
+}

--- a/wasm-demo/src/rust/libunit-wasm/src/lib.rs
+++ b/wasm-demo/src/rust/libunit-wasm/src/lib.rs
@@ -1,0 +1,5 @@
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+
+include!("./bindings.rs");

--- a/wasm-demo/src/unit-wasm-raw.c
+++ b/wasm-demo/src/unit-wasm-raw.c
@@ -1,0 +1,39 @@
+#define _GNU_SOURCE
+
+#include <stdio.h>
+#include <string.h>
+
+#include "unit-wasm-raw.h"
+
+__attribute__((import_module("env"), import_name("nxt_wasm_send_headers")))
+void nxt_wasm_send_headers(u32 offset);
+
+void send_headers(u8 *addr, const char *ct, size_t len)
+{
+	struct resp_hdr *rh;
+	char clen[32];
+	u8 *p;
+	static const u32 hdr_offs = 0;
+
+	rh = (struct resp_hdr *)addr;
+
+#define SET_HDR_FIELD(idx, name, val) \
+	do { \
+		rh->fields[idx].name_offs = p - addr; \
+		rh->fields[idx].name_len = strlen(name); \
+		p = mempcpy(p, name, rh->fields[idx].name_len); \
+		rh->fields[idx].value_offs = p - addr; \
+		rh->fields[idx].value_len = strlen(val); \
+		p = mempcpy(p, val, rh->fields[idx].value_len); \
+	} while (0)
+
+	rh->nr_fields = 2;
+	p = addr + sizeof(struct resp_hdr) +
+	    (rh->nr_fields * sizeof(struct hdr_field));
+
+	SET_HDR_FIELD(0, "Content-Type", ct);
+	snprintf(clen, sizeof(clen), "%lu", len);
+	SET_HDR_FIELD(1, "Content-Length", clen);
+
+	nxt_wasm_send_headers(hdr_offs);
+}

--- a/wasm-demo/src/unit-wasm-raw.h
+++ b/wasm-demo/src/unit-wasm-raw.h
@@ -1,0 +1,79 @@
+#ifndef _UNIT_WASM_H_
+#define _UNIT_WASM_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+typedef uint64_t u64;
+typedef int64_t  s64;
+typedef uint32_t u32;
+typedef int32_t  s32;
+typedef uint16_t u16;
+typedef int16_t  s16;
+typedef uint8_t   u8;
+typedef int8_t    s8;
+
+#ifndef __unused
+#define __unused                __attribute__((unused))
+#endif
+#ifndef __maybe_unused
+#define __maybe_unused          __unused
+#endif
+#ifndef __always_unused
+#define __always_unused         __unused
+#endif
+
+struct hdr_field {
+	u32 name_offs;
+	u32 name_len;
+	u32 value_offs;
+	u32 value_len;
+};
+
+struct req {
+	u32 method_offs;
+	u32 method_len;
+	u32 version_offs;
+	u32 version_len;
+	u32 path_offs;
+	u32 path_len;
+	u32 query_offs;
+	u32 query_len;
+	u32 remote_offs;
+	u32 remote_len;
+	u32 local_addr_offs;
+	u32 local_addr_len;
+	u32 local_port_offs;
+	u32 local_port_len;
+	u32 server_name_offs;
+	u32 server_name_len;
+
+	u32 content_offs;
+	u32 content_len;
+	u32 content_sent;
+	u32 total_content_sent;
+
+	u32 request_size;
+
+	u32 nr_fields;
+
+	u32 tls;
+
+	struct hdr_field fields[];
+};
+
+struct resp {
+	u32 size;
+
+	u8 data[];
+};
+
+struct resp_hdr {
+	u32 nr_fields;
+
+	struct hdr_field fields[];
+};
+
+extern void send_headers(u8 *addr, const char *ct, size_t len);
+
+#endif /* _UNIT_WASM_H_ */

--- a/wasm-demo/src/upload-reflector-raw.c
+++ b/wasm-demo/src/upload-reflector-raw.c
@@ -1,0 +1,216 @@
+/*
+ * upload-reflector-raw.c - Raw example of writing a WASM module for use with
+ *			    Unit
+ *
+ * Download the wasi-sysroot tarball from https://github.com/WebAssembly/wasi-sdk/releases
+ */
+
+#define _GNU_SOURCE
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "unit-wasm-raw.h"
+
+static size_t total_response_sent;
+
+static u8 *request_buf;
+
+__attribute__((import_module("env"), import_name("nxt_wasm_get_init_mem_size")))
+u32 nxt_wasm_get_init_mem_size(void);
+__attribute__((import_module("env"), import_name("nxt_wasm_response_end")))
+void nxt_wasm_response_end(void);
+__attribute__((import_module("env"), import_name("nxt_wasm_send_response")))
+void nxt_wasm_send_response(u32 offset);
+
+__attribute__((export_name("wasm_response_end_handler")))
+void wasm_response_end_handler(void)
+{
+	total_response_sent = 0;
+}
+
+__attribute__((export_name("wasm_request_end_handler")))
+void wasm_request_end_handler(void)
+{
+	if (!request_buf)
+		return;
+
+	free(request_buf);
+	request_buf = NULL;
+}
+
+__attribute__((export_name("wasm_free_handler")))
+void wasm_free_handler(u32 addr)
+{
+	free((void *)addr);
+}
+
+__attribute__((export_name("wasm_malloc_handler")))
+u32 wasm_malloc_handler(size_t size)
+{
+	return (u32)malloc(size);
+}
+
+static int upload_reflector(u8 *addr)
+{
+	size_t mem_size = nxt_wasm_get_init_mem_size();
+	size_t rsize = sizeof(struct resp);
+	size_t write_bytes;
+	struct req *req;
+	struct resp *resp;
+
+	printf("==[WASM RESP]== %s:\n", __func__);
+
+	resp = (struct resp *)addr;
+	req = (struct req *)request_buf;
+
+	printf("==[WASM RESP]== resp@%p\n", resp);
+	printf("==[WASM RESP]== req@%p\n", req);
+	printf("==[WASM RESP]== req->content_len    : %u\n", req->content_len);
+
+	resp = (struct resp *)addr;
+
+	/* Send headers */
+	if (total_response_sent == 0) {
+		const char *field;
+		struct hdr_field *f;
+		struct hdr_field *f_end;
+		char ct[256];
+
+		/* Try to set the Content-Type */
+		f_end = req->fields + req->nr_fields;
+		for (f = req->fields; f < f_end; f++) {
+			field = (const char *)(u8 *)req + f->name_offs;
+
+			if (strncasecmp(field, "Content-Type", 12) == 0) {
+				snprintf(ct, sizeof(ct), "%.*s", f->value_len,
+					 (u8 *)req + f->value_offs);
+				break;
+			}
+
+			field = NULL;
+		}
+		if (!field)
+			sprintf(ct, "application/octet-stream");
+
+		send_headers(addr, ct, req->content_len);
+	}
+
+	write_bytes = req->content_sent;
+	if (write_bytes > mem_size - rsize)
+		write_bytes = mem_size - rsize;
+
+	printf("==[WASM RESP]== write_bytes         : %lu\n", write_bytes);
+	printf("==[WASM RESP]== req->content_len    : %u\n", req->content_len);
+	printf("==[WASM RESP]== total_response_sent : %lu\n",
+	       total_response_sent);
+
+	printf("==[WASM RESP]== Copying (%lu) bytes of data from [%p+%lx] to "
+	       "[%p]\n", write_bytes, req,
+	       req->content_offs + total_response_sent, resp->data);
+	memcpy(resp->data,
+	       (u8 *)req + req->content_offs + total_response_sent,
+	       write_bytes);
+
+	total_response_sent += write_bytes;
+	resp->size = write_bytes;
+	printf("==[WASM RESP]== resp->size          : %u\n", resp->size);
+
+	nxt_wasm_send_response(0);
+
+	if (total_response_sent == req->content_len) {
+		printf("==[WASM RESP]== All data sent. Cleaning up...\n");
+		total_response_sent = 0;
+
+		free(request_buf);
+		request_buf = NULL;
+
+		/* Tell Unit no more data to send */
+		nxt_wasm_response_end();
+	}
+
+	return 0;
+}
+
+__attribute__((export_name("wasm_request_handler")))
+int wasm_request_handler(u8 *addr)
+{
+	struct req *req = (struct req *)addr;
+	struct req *rb = (struct req *)request_buf;
+
+	printf("==[WASM REQ]== %s:\n", __func__);
+
+	/*
+	 * This function _may_ be called multiple times during a single
+	 * request if there is a large amount of data to transfer.
+	 *
+	 * Some useful request meta data:
+	 *
+	 * req->content_len contains the overall size of the POST/PUT
+	 * data.
+	 * req->content_sent shows how much of the body content has been
+	 * in _this_ request.
+	 * req->total_content_sent shows how much of it has been sent in
+	 * total.
+	 * req->content_offs is the offset in the passed in memory where
+	 * the body content starts.
+	 *
+	 * For new requests req->request_size shows the total size of
+	 * _this_ request, incl the req structure itself.
+	 * For continuation requests, req->request_size is just the amount
+	 * of new content, i.e req->content_sent
+	 *
+	 * When req->content_len == req->total_content_sent, that's the end
+	 * of that request.
+	 */
+
+	if (!request_buf) {
+		/*
+		 * Just allocate memory for the total amount of data we
+		 * expect to get, this includes the request structure
+		 * itself as well as any body content.
+		 */
+		printf("==[WASM REQ]== malloc(%u)\n",
+		       req->content_offs + req->content_len);
+		request_buf = malloc(req->content_offs + req->content_len);
+
+		/*
+		 * Regardless of how much memory we allocated above, here
+		 * we only want to copy the amount of data we actually
+		 * received in this request.
+		 */
+		printf("==[WASM REQ]== req->request_size : %u\n",
+		       req->request_size);
+		memcpy(request_buf, addr, req->request_size);
+
+		rb = (struct req *)request_buf;
+		printf("==[WASM REQ]== rb@%p\n", rb);
+		printf("==[WASM REQ]== request_buf@%p\n", request_buf);
+		printf("==[WASM REQ]== rb->content_offs : %u\n",
+		       rb->content_offs);
+		printf("==[WASM REQ]== rb->content_len  : %u\n",
+		       rb->content_len);
+		printf("==[WASM REQ]== rb->content_sent : %u\n",
+		       rb->content_sent);
+		printf("==[WASM REQ]== rb->request_size : %u\n",
+		       rb->request_size);
+	} else {
+		memcpy(request_buf + rb->request_size, addr + req->content_offs,
+		       req->request_size);
+
+		printf("==[WASM REQ +]== req->content_offs : %u\n",
+		       req->content_offs);
+		printf("==[WASM REQ +]== req->content_sent : %u\n",
+		       req->content_sent);
+		printf("==[WASM REQ +]== req->request_size : %u\n",
+		       req->request_size);
+
+		rb->content_sent = req->content_sent;
+		rb->total_content_sent = req->total_content_sent;
+	}
+
+	upload_reflector(addr);
+
+	return 0;
+}

--- a/wasm-demo/unit-wasm.Dockerfile
+++ b/wasm-demo/unit-wasm.Dockerfile
@@ -1,0 +1,40 @@
+# Start with the minimal Docker Official Image so we can use the same defaults
+#
+FROM unit:minimal AS build
+WORKDIR /src
+
+# Get all the build tools we need, including Wasmtime
+#
+#RUN apt update && apt install -y wget git build-essential clang lld libpcre2-dev libssl-dev
+RUN apt update && apt install -y wget git build-essential libpcre2-dev libssl-dev
+RUN wget -O- https://github.com/bytecodealliance/wasmtime/releases/download/v11.0.0/wasmtime-v11.0.0-$(arch)-linux-c-api.tar.xz \
+    | tar Jxfv - && \
+    mkdir /usr/lib/wasmtime && \
+    cp /src/wasmtime-v11.0.0-$(arch)-linux-c-api/lib/* /usr/lib/wasmtime
+
+# Build NGINX JavaScript (njs) so that we have a feature-complete Unit
+#
+RUN git clone https://github.com/nginx/njs.git && \
+    cd njs && \
+    ./configure --no-libxml2 --no-zlib && \
+    make
+
+# Build Unit with the Wasm module, copying the configure arguments from the
+# official image.
+#
+RUN git clone https://github.com/nginx/unit.git && \
+    cd unit && \
+    wget -O- https://github.com/nginx/unit/pull/902.patch | patch -p1 && \
+    ./configure $(unitd --version 2>&1 | tr ' ' '\n' | grep ^-- | grep -v opt=) \
+                --cc-opt="-I/src/njs/src -I/src/njs/build" --ld-opt=-L/src/njs/build && \
+    ./configure wasm --include-path=/src/wasmtime-v11.0.0-$(arch)-linux-c-api/include \
+                     --lib-path=/usr/lib/wasmtime --rpath && \
+    make
+
+# Create a clean final image by copying over only Wasmtime, the new unitd
+# binary, and the Wasm module.
+#
+FROM unit:minimal
+COPY --from=build /src/unit/build/sbin/unitd /usr/sbin
+COPY --from=build /src/unit/build/lib/unit/modules/wasm.unit.so /usr/lib/unit/modules
+COPY --from=build /usr/lib/wasmtime/*.so /usr/lib/wasmtime/

--- a/wasm-demo/wasm-conf.json
+++ b/wasm-demo/wasm-conf.json
@@ -1,0 +1,76 @@
+{
+    "access_log": "/dev/stdout",
+    "settings": {
+        "http": {
+            "log_route": true,
+            "max_body_size": 1073741824
+        }
+    },
+
+    "listeners": {
+        "*:80": {
+            "pass": "routes"
+        }
+    },
+
+    "routes": [
+        {
+            "match": {
+                "uri": "/echo*"
+            },
+            "action": {
+                "pass": "applications/luw-echo-request"
+            }
+        },
+        {
+            "match": {
+                "uri": "/upload*"
+            },
+            "action": {
+                "pass": "applications/luw-upload-reflector"
+            }
+        },
+        {
+            "match": {
+                "headers": {
+                    "accept": "*text/html*"
+                }
+            },
+            "action": {
+                "share": "/usr/share/unit/welcome/welcome.html"
+            }
+        },
+        {
+            "action": {
+                "share": "/usr/share/unit/welcome/welcome.md"
+            }
+        }
+    ],
+
+    "applications": {
+        "luw-echo-request": {
+            "type": "wasm",
+            "module": "/demo/luw-echo-request.wasm",
+            "request_handler": "luw_request_handler",
+            "malloc_handler": "luw_malloc_handler",
+            "free_handler": "luw_free_handler",
+            "module_init_handler": "luw_module_init_handler",
+            "module_end_handler": "luw_module_end_handler",
+            "access": {
+                "filesystem": [
+                    "/tmp",
+                    "/var/tmp"
+                ]
+            }
+        },
+        "luw-upload-reflector": {
+            "type": "wasm",
+            "module": "/demo/luw-upload-reflector.wasm",
+            "request_handler": "luw_request_handler",
+            "malloc_handler": "luw_malloc_handler",
+            "free_handler": "luw_free_handler",
+            "request_end_handler": "luw_request_end_handler",
+            "response_end_handler": "luw_response_end_handler"
+        }
+    }
+}


### PR DESCRIPTION
    *** EXPERIMENTAL *** WORK-IN-PROGRESS ***
    * Please try it out and share feedback! *


Introducing the WebAssembly Language Module
===========================================

This PR introduces a new Language Module that enables Unit to run WebAssembly ("Wasm") code as web applications. It includes the experimental `wasm` Language Module for Unit and a demo web application Wasm Module.

>  **NOTE:** The word 'module' has two meanings, so we use _Language Module_ to
> describe the extension to the Unit runtime, and _Wasm Module_ to describe the
> Wasm bytecode that executes within the WebAssembly sandbox.

Unit’s architecture is designed to have the HTTP server decoupled from application processes where the HTTP context flows in and out. It’s a very natural fit for WebAssembly’s sandboxed execution and linear memory byte-streams. We use [Wasmtime](https://wasmtime.dev/) to provide the WebAssembly runtime, and the Wasm Module runs in its own memory address space, separate from the Unit runtime.


Trying it out
=============

For a quick and simple 'hello world' experience, use the [Dockerfiles](https://github.com/nginx/unit/pull/902/files) in the **/wasm-demo** directory of this PR to create two images:

 1. `unit:wasm` (based on the Docker Official image, with Wasm Module)
 2. `unit:demo-wasm` (based on the Wasm image, with demo application)

Follow the README in the same directory to build/run the Docker-based demo.

Manual build instructions below.

## Prerequisites and Assumptions

You will need:
 * Modern Linux platform (might work on others, not yet tested).
 * Ability to build Unit from source.
   If you haven't done this before, please first run through the [Building From Source how-to guide](https://unit.nginx.org/howto/source/).
 * Additional build tools (required for the demo Wasm Module)
   - clang
   - lld

## Building the Wasm Language Module

0. Do a test build of Unit from source ([see docs](https://unit.nginx.org/howto/source/)) with this PR/patch applied. The following steps assume you're starting in the `unit` directory and used `./configure --prefix=$PWD/build`. 

2. Download and extract the Wasmtime C API (newer versions may or may not work). Notice that we use `$(arch)` to substitute-in the appropriate CPU architecture. This works for **x86_64** and **aarch64** (ARM) platforms.
```
wget -O- https://github.com/bytecodealliance/wasmtime/releases/download/v11.0.0/wasmtime-v11.0.0-$(arch)-linux-c-api.tar.xz | tar Jxfv -
```

3. Configure the Wasm Language Module for Unit
```
./configure wasm --include-path=$PWD/wasmtime-v11.0.0-$(arch)-linux-c-api/include \
                 --lib-path=$PWD/wasmtime-v11.0.0-$(arch)-linux-c-api/lib --rpath
```

4. Build the Wasm Language Module
```
make
```

5. Test that **unitd** Can Load the Language Module

Run `unitd` in the foreground (attached to the console) to check that Unit can discover and load the `wasm` Language Module at startup. You should see console output similar to this:
```
$ $PWD/build/sbin/unitd --no-daemon --log /dev/stderr
2023/06/15 11:29:31 [info] 1#1 unit 1.31.0 started
2023/06/15 11:29:31 [info] 43#43 discovery started
2023/06/15 11:29:31 [notice] 43#43 module: wasm 0.1 "/path/to/modules/wasm.unit.so"
```

## Building the demo application

0. Enter the **wasm-demo/src** directory. 

1. Download and extract the wasi-sysroot SDK
```
wget -O- https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sysroot-20.0.tar.gz | tar zxfv -
```

2. Compile the demo Wasm Modules to `.wasm` files. This requires lld and clang from LLVM 8.0+
```
make SYSROOT=wasi-sysroot/
```

If the above fails like
```
wasm-ld: error: cannot open /usr/lib/llvm-11/lib/clang/11.0.1/lib/wasi/libclang_rt.builtins-wasm32.a: No such file or directory
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
Then you need to download the WASI linker and copy it into your clang install.
```shell
cd /usr/libPATH/clang/VERSION
wget -O- https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/libclang_rt.builtins-wasm32-wasi-20.0.tar.gz | sudo tar zxfv -
```

3. Configure Unit to run the demo application

```json
  {
    "listeners": {
        "[::1]:8080": {
            "pass": "routes"
        }
    },

    "settings": {
        "http": {
            "max_body_size": 1073741824
        }
    },

    "routes": [
        {
            "match": {
                "uri": "/echo*"
            },
            "action": {
                "pass": "applications/luw-echo-request"
            }
        },
        {
            "match": {
                "uri": "/upload*"
            },
            "action": {
                "pass": "applications/luw-upload-reflector"
            }
        }
    ],

    "applications": {
        "luw-echo-request": {
            "type": "wasm",
            "module": "/path/to/unit/wasm-demo/src/luw-echo-request.wasm",
            "request_handler": "luw_request_handler",
            "malloc_handler": "luw_malloc_handler",
            "free_handler": "luw_free_handler",
            "module_init_handler": "luw_module_init_handler",
            "module_end_handler": "luw_module_end_handler",
            "access": {
                "filesystem": [
                    "/tmp",
                    "/foo/bar"
                ]
            }
        },
        "luw-upload-reflector": {
            "type": "wasm",
            "module": "/path/to/unit/wasm-demo/src/luw-upload-reflector.wasm",
            "request_handler": "luw_request_handler",
            "malloc_handler": "luw_malloc_handler",
            "free_handler": "luw_free_handler",
            "request_end_handler": "luw_request_end_handler",
            "response_end_handler": "luw_response_end_handler"
        }
    }
}

```

Apply the above configuration to the **/config** URI of Unit's Control API. With the JSON in a file, you can use the CLI to apply it.
```
cat conf.json | tools/unitc /config
```

The following messages should then appear in the Unit log file (or console if running with `--no-daemon`).
```
2023/07/26 13:28:14 [info] 182585#182585 "luw-echo-request" prototype started
2023/07/26 13:28:14 [info] 182590#182590 "luw-echo-request" application started
2023/07/26 13:28:14 [info] 182591#182591 "luw-upload-reflector" prototype started
2023/07/26 13:28:14 [info] 182596#182596 "luw-upload-reflector" application started
```

Now make a request to the demo application.
```
curl http://localhost:8080/echo
```