### PR TITLE
Add WebAssembly language module support

### DIFF
--- a/auto/help
+++ b/auto/help
@@ -75,4 +75,7 @@ cat << END
   java OPTIONS         configure Java module
                        run "./configure java --help" to see available options
 
+  wasm OPTIONS	       configure WebAssembly module
+		       run "./configure wasm --help" to see available options
+
 END

--- a/auto/modules/conf
+++ b/auto/modules/conf
@@ -33,6 +33,10 @@ case "$nxt_module" in
        . auto/modules/java
    ;;
 
+   wasm)
+       . auto/modules/wasm
+   ;;
+
    *)
        echo
        echo $0: error: invalid module \"$nxt_module\".

--- a/auto/modules/wasm
+++ b/auto/modules/wasm
@@ -1,0 +1,207 @@
+# Copyright (C) Andrew Clayton
+# Copyright (C) F5, Inc.
+
+
+NXT_WASM_RUNTIME=wasmtime
+
+shift
+
+for nxt_option; do
+
+    case "$nxt_option" in
+        -*=*) value=`echo "$nxt_option" | sed -e 's/[-_a-zA-Z0-9]*=//'`     ;;
+           *) value="" ;;
+    esac
+
+    case "$nxt_option" in
+
+        --runtime=*)		NXT_WASM_RUNTIME="$value"		    ;;
+        --module=*)		NXT_WASM_MODULE="$value"                    ;;
+        --include-path=*)	NXT_WASM_INCLUDE_PATH="$value"		    ;;
+        --lib-path=*)		NXT_WASM_LIB_PATH="$value"		    ;;
+        --rpath*)		NXT_WASM_RPATH="$value"			    ;;
+
+        --help)
+            cat << END
+
+    --runtime=RUNTIME		set the WASM runtime to use (default: wasmtime)
+    --module=NAME		set Unit WASM module name (default: wasm)
+    --include-path=DIRECTORY	set directory path to wasmtime includes
+    --lib-path=DIRECTORY	set directory path to libwasmtime.so library
+    --rpath[=DIRECTORY]		set the rpath (default: --lib-path)
+
+END
+            exit 0
+        ;;
+
+        *)
+            echo
+            echo $0: error: invalid wasm option \"$nxt_option\"
+            echo
+            exit 1
+        ;;
+    esac
+
+done
+
+
+if [ ! -f $NXT_AUTOCONF_DATA ]; then
+   echo
+   echo Please run common $0 before configuring module \"$nxt_module\".
+   echo
+   exit 1
+fi
+
+. $NXT_AUTOCONF_DATA
+
+NXT_WASM=wasm
+NXT_WASM_MODULE=${NXT_WASM_MODULE=${NXT_WASM##*/}}
+
+NXT_WASM_INCLUDE_PATH=${NXT_WASM_INCLUDE_PATH=}
+NXT_WASM_LIB_PATH=${NXT_WASM_LIB_PATH=}
+NXT_WASM_LDFLAGS=
+if [ "$NXT_WASM_RUNTIME" = "wasmtime" ]; then
+    NXT_WASM_LDFLAGS=-lwasmtime
+fi
+NXT_WASM_ADDITIONAL_FLAGS="-fno-strict-aliasing \
+ -Wno-missing-field-initializers \
+ -DNXT_HAVE_WASM_$(echo ${NXT_WASM_RUNTIME} | tr 'a-z' 'A-Z') \
+"
+
+# Set the RPATH/RUNPATH.
+#
+# We temporarily disable warning on unbound variables here as
+# NXT_WASM_RPATH may be legitimately unset, in which case we
+# don't set a RPATH.
+#
+# If NXT_WASM_RPATH is set but null then we set a RPATH of the
+# value of $NXT_WASM_LIB (--lib-path) otherwise use the value
+# provided.
+set +u
+if [ "${NXT_WASM_RPATH+set}" = set ]; then
+    if [ "$NXT_WASM_RPATH" = "" ]; then
+        NXT_WASM_RPATH=$NXT_WASM_LIB_PATH
+    fi
+
+    NXT_WASM_LDFLAGS="-Wl,-rpath,$NXT_WASM_RPATH $NXT_WASM_LDFLAGS"
+fi
+set -u
+
+$echo "configuring WASM module"
+$echo "configuring WASM module ..." >> $NXT_AUTOCONF_ERR
+
+nxt_found=no
+
+if [ "$NXT_WASM_RUNTIME" = "wasmtime" ]; then
+    nxt_feature="wasmtime"
+    nxt_feature_name=""
+    nxt_feature_run=no
+    nxt_feature_incs="-I${NXT_WASM_INCLUDE_PATH}"
+    nxt_feature_libs="-L${NXT_WASM_LIB_PATH} $NXT_WASM_LDFLAGS"
+    nxt_feature_test="
+        #include <wasm.h>
+        #include <wasi.h>
+        #include <wasmtime.h>
+
+        int main(void) {
+            wasm_config_t *c;
+
+            c = wasm_config_new();
+            wasm_config_delete(c);
+
+            return 0;
+        }"
+
+    . auto/feature
+fi
+
+if [ $nxt_found = no ]; then
+    $echo
+    $echo $0: error: no $NXT_WASM_RUNTIME found.
+    $echo
+    exit 1;
+fi
+
+
+if grep ^$NXT_WASM_MODULE: $NXT_MAKEFILE 2>&1 > /dev/null; then
+    $echo
+    $echo $0: error: duplicate \"$NXT_WASM_MODULE\" module configured.
+    $echo
+    exit 1;
+fi
+
+
+$echo " + WASM module: ${NXT_WASM_MODULE}.unit.so"
+
+. auto/cc/deps
+
+$echo >> $NXT_MAKEFILE
+
+NXT_WASM_MODULE_SRCS=" \
+    src/wasm/nxt_wasm.c \
+"
+
+if [ "$NXT_WASM_RUNTIME" = "wasmtime" ]; then
+    NXT_WASM_MODULE_SRCS="$NXT_WASM_MODULE_SRCS src/wasm/nxt_rt_wasmtime.c"
+fi
+
+
+# The wasm module object files.
+
+nxt_objs=$NXT_BUILD_DIR/src/nxt_unit.o
+
+for nxt_src in $NXT_WASM_MODULE_SRCS; do
+
+    nxt_obj=${nxt_src%.c}-$NXT_WASM_MODULE.o
+    nxt_dep=${nxt_src%.c}-$NXT_WASM_MODULE.dep
+    nxt_dep_flags=`nxt_gen_dep_flags`
+    nxt_dep_post=`nxt_gen_dep_post`
+    nxt_objs="$nxt_objs $NXT_BUILD_DIR/$nxt_obj"
+
+    cat << END >> $NXT_MAKEFILE
+
+$NXT_BUILD_DIR/$nxt_obj:	$nxt_src $NXT_VERSION_H
+	mkdir -p $NXT_BUILD_DIR/src/wasm
+	\$(CC) -c \$(CFLAGS) $NXT_WASM_ADDITIONAL_FLAGS \$(NXT_INCS) \\
+	    -I$NXT_WASM_INCLUDE_PATH \\
+	    $nxt_dep_flags \\
+	    -o $NXT_BUILD_DIR/$nxt_obj $nxt_src
+	$nxt_dep_post
+
+-include $NXT_BUILD_DIR/$nxt_dep
+
+END
+
+done
+
+
+cat << END >> $NXT_MAKEFILE
+
+.PHONY: ${NXT_WASM_MODULE}
+.PHONY: ${NXT_WASM_MODULE}-install
+.PHONY: ${NXT_WASM_MODULE}-uninstall
+
+all: ${NXT_WASM_MODULE}
+
+${NXT_WASM_MODULE}:	$NXT_BUILD_DIR/lib/unit/modules/${NXT_WASM_MODULE}.unit.so
+
+$NXT_BUILD_DIR/lib/unit/modules/${NXT_WASM_MODULE}.unit.so:	$nxt_objs
+	\$(NXT_MODULE_LINK) -o \$@ \\
+	    $nxt_objs -L${NXT_WASM_LIB_PATH} ${NXT_WASM_LDFLAGS} $NXT_LD_OPT
+
+
+install: ${NXT_WASM_MODULE}-install
+
+${NXT_WASM_MODULE}-install: ${NXT_WASM_MODULE} install-check
+	install -d \$(DESTDIR)$NXT_MODULESDIR
+	install -p $NXT_BUILD_DIR/lib/unit/modules/${NXT_WASM_MODULE}.unit.so \\
+		\$(DESTDIR)$NXT_MODULESDIR/
+
+
+uninstall: ${NXT_WASM_MODULE}-uninstall
+
+${NXT_WASM_MODULE}-uninstall:
+	rm -f \$(DESTDIR)$NXT_MODULESDIR/${NXT_WASM_MODULE}.unit.so
+	@rmdir -p \$(DESTDIR)$NXT_MODULESDIR 2>/dev/null || true
+
+END

--- a/src/nxt_application.c
+++ b/src/nxt_application.c
@@ -1099,6 +1099,9 @@ nxt_app_parse_type(u_char *p, size_t length)
 
     } else if (nxt_str_eq(&str, "java", 4)) {
         return NXT_APP_JAVA;
+
+    } else if (nxt_str_eq(&str, "wasm", 4)) {
+        return NXT_APP_WASM;
     }
 
     return NXT_APP_UNKNOWN;

--- a/src/nxt_application.h
+++ b/src/nxt_application.h
@@ -21,6 +21,7 @@ typedef enum {
     NXT_APP_PERL,
     NXT_APP_RUBY,
     NXT_APP_JAVA,
+    NXT_APP_WASM,
 
     NXT_APP_UNKNOWN,
 } nxt_app_type_t;

--- a/src/nxt_application.h
+++ b/src/nxt_application.h
@@ -99,6 +99,8 @@ typedef struct {
     const char        *request_init_handler;
     const char        *request_end_handler;
     const char        *response_end_handler;
+
+    nxt_conf_value_t  *access;
 } nxt_wasm_app_conf_t;
 
 

--- a/src/nxt_application.h
+++ b/src/nxt_application.h
@@ -87,6 +87,21 @@ typedef struct {
 } nxt_java_app_conf_t;
 
 
+typedef struct {
+    const char        *module;
+
+    const char        *request_handler;
+    const char        *malloc_handler;
+    const char        *free_handler;
+
+    const char        *module_init_handler;
+    const char        *module_end_handler;
+    const char        *request_init_handler;
+    const char        *request_end_handler;
+    const char        *response_end_handler;
+} nxt_wasm_app_conf_t;
+
+
 struct nxt_common_app_conf_s {
     nxt_str_t                  name;
     nxt_str_t                  type;
@@ -115,6 +130,7 @@ struct nxt_common_app_conf_s {
         nxt_perl_app_conf_t      perl;
         nxt_ruby_app_conf_t      ruby;
         nxt_java_app_conf_t      java;
+        nxt_wasm_app_conf_t      wasm;
     } u;
 
     nxt_conf_value_t           *self;

--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -1049,6 +1049,44 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_java_members[] = {
 };
 
 
+static nxt_conf_vldt_object_t  nxt_conf_vldt_wasm_members[] = {
+    {
+        .name       = nxt_string("module"),
+        .type       = NXT_CONF_VLDT_STRING,
+        .flags      = NXT_CONF_VLDT_REQUIRED,
+    }, {
+        .name       = nxt_string("request_handler"),
+        .type       = NXT_CONF_VLDT_STRING,
+        .flags      = NXT_CONF_VLDT_REQUIRED,
+    },{
+        .name       = nxt_string("malloc_handler"),
+        .type       = NXT_CONF_VLDT_STRING,
+        .flags      = NXT_CONF_VLDT_REQUIRED,
+    }, {
+        .name       = nxt_string("free_handler"),
+        .type       = NXT_CONF_VLDT_STRING,
+        .flags      = NXT_CONF_VLDT_REQUIRED,
+    }, {
+        .name       = nxt_string("module_init_handler"),
+        .type       = NXT_CONF_VLDT_STRING,
+    }, {
+        .name       = nxt_string("module_end_handler"),
+        .type       = NXT_CONF_VLDT_STRING,
+    }, {
+        .name       = nxt_string("request_init_handler"),
+        .type       = NXT_CONF_VLDT_STRING,
+    }, {
+        .name       = nxt_string("request_end_handler"),
+        .type       = NXT_CONF_VLDT_STRING,
+    }, {
+        .name       = nxt_string("response_end_handler"),
+        .type       = NXT_CONF_VLDT_STRING,
+    },
+
+    NXT_CONF_VLDT_NEXT(nxt_conf_vldt_common_members)
+};
+
+
 static nxt_conf_vldt_object_t  nxt_conf_vldt_common_members[] = {
     {
         .name       = nxt_string("type"),
@@ -2562,6 +2600,7 @@ nxt_conf_vldt_app(nxt_conf_validation_t *vldt, nxt_str_t *name,
         { nxt_conf_vldt_object, nxt_conf_vldt_perl_members },
         { nxt_conf_vldt_object, nxt_conf_vldt_ruby_members },
         { nxt_conf_vldt_object, nxt_conf_vldt_java_members },
+        { nxt_conf_vldt_object, nxt_conf_vldt_wasm_members },
     };
 
     ret = nxt_conf_vldt_type(vldt, name, value, NXT_CONF_VLDT_OBJECT);

--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -252,6 +252,7 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_python_target_members[];
 static nxt_conf_vldt_object_t  nxt_conf_vldt_php_common_members[];
 static nxt_conf_vldt_object_t  nxt_conf_vldt_php_options_members[];
 static nxt_conf_vldt_object_t  nxt_conf_vldt_php_target_members[];
+static nxt_conf_vldt_object_t  nxt_conf_vldt_wasm_access_members[];
 static nxt_conf_vldt_object_t  nxt_conf_vldt_common_members[];
 static nxt_conf_vldt_object_t  nxt_conf_vldt_app_limits_members[];
 static nxt_conf_vldt_object_t  nxt_conf_vldt_app_processes_members[];
@@ -1081,9 +1082,24 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_wasm_members[] = {
     }, {
         .name       = nxt_string("response_end_handler"),
         .type       = NXT_CONF_VLDT_STRING,
+    }, {
+        .name       = nxt_string("access"),
+        .type       = NXT_CONF_VLDT_OBJECT,
+        .validator  = nxt_conf_vldt_object,
+        .u.members  = nxt_conf_vldt_wasm_access_members,
     },
 
     NXT_CONF_VLDT_NEXT(nxt_conf_vldt_common_members)
+};
+
+
+static nxt_conf_vldt_object_t  nxt_conf_vldt_wasm_access_members[] = {
+    {
+        .name       = nxt_string("filesystem"),
+        .type       = NXT_CONF_VLDT_ARRAY,
+    },
+
+    NXT_CONF_VLDT_END
 };
 
 

--- a/src/nxt_main_process.c
+++ b/src/nxt_main_process.c
@@ -323,6 +323,55 @@ static nxt_conf_map_t  nxt_java_app_conf[] = {
 };
 
 
+static nxt_conf_map_t  nxt_wasm_app_conf[] = {
+    {
+        nxt_string("module"),
+        NXT_CONF_MAP_CSTRZ,
+        offsetof(nxt_common_app_conf_t, u.wasm.module),
+    },
+    {
+        nxt_string("request_handler"),
+        NXT_CONF_MAP_CSTRZ,
+        offsetof(nxt_common_app_conf_t, u.wasm.request_handler),
+    },
+    {
+        nxt_string("malloc_handler"),
+        NXT_CONF_MAP_CSTRZ,
+        offsetof(nxt_common_app_conf_t, u.wasm.malloc_handler),
+    },
+    {
+        nxt_string("free_handler"),
+        NXT_CONF_MAP_CSTRZ,
+        offsetof(nxt_common_app_conf_t, u.wasm.free_handler),
+    },
+    {
+        nxt_string("module_init_handler"),
+        NXT_CONF_MAP_CSTRZ,
+        offsetof(nxt_common_app_conf_t, u.wasm.module_init_handler),
+    },
+    {
+        nxt_string("module_end_handler"),
+        NXT_CONF_MAP_CSTRZ,
+        offsetof(nxt_common_app_conf_t, u.wasm.module_end_handler),
+    },
+    {
+        nxt_string("request_init_handler"),
+        NXT_CONF_MAP_CSTRZ,
+        offsetof(nxt_common_app_conf_t, u.wasm.request_init_handler),
+    },
+    {
+        nxt_string("request_end_handler"),
+        NXT_CONF_MAP_CSTRZ,
+        offsetof(nxt_common_app_conf_t, u.wasm.request_end_handler),
+    },
+    {
+        nxt_string("response_end_handler"),
+        NXT_CONF_MAP_CSTRZ,
+        offsetof(nxt_common_app_conf_t, u.wasm.response_end_handler),
+    },
+};
+
+
 static nxt_conf_app_map_t  nxt_app_maps[] = {
     { nxt_nitems(nxt_external_app_conf),  nxt_external_app_conf },
     { nxt_nitems(nxt_python_app_conf),    nxt_python_app_conf },
@@ -330,6 +379,7 @@ static nxt_conf_app_map_t  nxt_app_maps[] = {
     { nxt_nitems(nxt_perl_app_conf),      nxt_perl_app_conf },
     { nxt_nitems(nxt_ruby_app_conf),      nxt_ruby_app_conf },
     { nxt_nitems(nxt_java_app_conf),      nxt_java_app_conf },
+    { nxt_nitems(nxt_wasm_app_conf),      nxt_wasm_app_conf },
 };
 
 

--- a/src/nxt_main_process.c
+++ b/src/nxt_main_process.c
@@ -369,6 +369,11 @@ static nxt_conf_map_t  nxt_wasm_app_conf[] = {
         NXT_CONF_MAP_CSTRZ,
         offsetof(nxt_common_app_conf_t, u.wasm.response_end_handler),
     },
+    {
+        nxt_string("access"),
+        NXT_CONF_MAP_PTR,
+        offsetof(nxt_common_app_conf_t, u.wasm.access),
+    },
 };
 
 

--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -274,12 +274,12 @@ static const nxt_str_t http_prefix = nxt_string("HTTP_");
 static const nxt_str_t empty_prefix = nxt_string("");
 
 static const nxt_str_t  *nxt_app_msg_prefix[] = {
-    &empty_prefix,
-    &empty_prefix,
-    &http_prefix,
-    &http_prefix,
-    &http_prefix,
-    &empty_prefix,
+    [NXT_APP_EXTERNAL]  = &empty_prefix,
+    [NXT_APP_PYTHON]    = &empty_prefix,
+    [NXT_APP_PHP]       = &http_prefix,
+    [NXT_APP_PERL]      = &http_prefix,
+    [NXT_APP_RUBY]      = &http_prefix,
+    [NXT_APP_JAVA]      = &empty_prefix,
 };
 
 

--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -280,6 +280,7 @@ static const nxt_str_t  *nxt_app_msg_prefix[] = {
     [NXT_APP_PERL]      = &http_prefix,
     [NXT_APP_RUBY]      = &http_prefix,
     [NXT_APP_JAVA]      = &empty_prefix,
+    [NXT_APP_WASM]      = &empty_prefix,
 };
 
 

--- a/src/wasm/nxt_rt_wasmtime.c
+++ b/src/wasm/nxt_rt_wasmtime.c
@@ -1,0 +1,407 @@
+/*
+ * Copyright (C) Andrew Clayton
+ * Copyright (C) F5, Inc.
+ */
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdarg.h>
+
+#include <wasm.h>
+#include <wasi.h>
+#include <wasmtime.h>
+
+#include "nxt_wasm.h"
+
+
+typedef struct nxt_wasmtime_ctx_s  nxt_wasmtime_ctx_t;
+
+struct nxt_wasmtime_ctx_s {
+    wasm_engine_t       *engine;
+    wasmtime_store_t    *store;
+    wasmtime_memory_t   memory;
+    wasmtime_module_t   *module;
+    wasmtime_linker_t   *linker;
+    wasmtime_context_t  *ctx;
+};
+
+static nxt_wasmtime_ctx_t  nxt_wasmtime_ctx;
+
+
+static void
+nxt_wasmtime_err_msg(wasmtime_error_t *error, wasm_trap_t *trap,
+                     const char *fmt, ...)
+{
+    va_list          args;
+    wasm_byte_vec_t  error_message;
+
+    fprintf(stderr, "WASMTIME ERROR: ");
+    va_start(args, fmt);
+    vfprintf(stderr, fmt, args);
+    va_end(args);
+    fprintf(stderr, "\n");
+
+    if (error == NULL && trap == NULL) {
+        return;
+    }
+
+    if (error != NULL) {
+        wasmtime_error_message(error, &error_message);
+        wasmtime_error_delete(error);
+    } else {
+        wasm_trap_message(trap, &error_message);
+        wasm_trap_delete(trap);
+    }
+    fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
+
+    wasm_byte_vec_delete(&error_message);
+}
+
+
+static wasm_trap_t *
+nxt_wasm_get_init_mem_size(void *env, wasmtime_caller_t *caller,
+                           const wasmtime_val_t *args, size_t nargs,
+                           wasmtime_val_t *results, size_t nresults)
+{
+    results[0].of.i32 = NXT_WASM_MEM_SIZE;
+
+    return NULL;
+}
+
+
+static wasm_trap_t *
+nxt_wasm_response_end(void *env, wasmtime_caller_t *caller,
+                      const wasmtime_val_t *args, size_t nargs,
+                      wasmtime_val_t *results, size_t nresults)
+{
+    nxt_wasm_do_response_end(env);
+
+    return NULL;
+}
+
+
+static wasm_trap_t *
+nxt_wasm_send_response(void *env, wasmtime_caller_t *caller,
+                       const wasmtime_val_t *args, size_t nargs,
+                       wasmtime_val_t *results, size_t nresults)
+{
+    nxt_wasm_do_send_response(env, args[0].of.i32);
+
+    return NULL;
+}
+
+
+static wasm_trap_t *
+nxt_wasm_send_headers(void *env, wasmtime_caller_t *caller,
+                      const wasmtime_val_t *args, size_t nargs,
+                      wasmtime_val_t *results, size_t nresults)
+{
+    nxt_wasm_do_send_headers(env, args[0].of.i32);
+
+    return NULL;
+}
+
+
+static void
+nxt_wasmtime_execute_hook(const nxt_wasm_ctx_t *ctx, nxt_wasm_fh_t hook)
+{
+    const char             *name = ctx->fh[hook].func_name;
+    wasm_trap_t            *trap = NULL;
+    wasmtime_error_t       *error;
+    nxt_wasmtime_ctx_t     *rt_ctx = &nxt_wasmtime_ctx;
+    const nxt_wasm_func_t  *func = &ctx->fh[hook].func;
+
+    if (name == NULL) {
+        return;
+    }
+
+    error = wasmtime_func_call(rt_ctx->ctx, func, NULL, 0, NULL, 0, &trap);
+    if (error != NULL || trap != NULL) {
+        nxt_wasmtime_err_msg(error, trap, "failed to call hook function [%s]",
+                             name);
+    }
+}
+
+
+static void
+nxt_wasmtime_execute_request(const nxt_wasm_ctx_t *ctx)
+{
+    int                    i = 0;
+    wasm_trap_t            *trap = NULL;
+    wasmtime_val_t         args[1] = { };
+    wasmtime_val_t         results[1] = { };
+    wasmtime_error_t       *error;
+    nxt_wasmtime_ctx_t     *rt_ctx = &nxt_wasmtime_ctx;
+    const nxt_wasm_func_t  *func = &ctx->fh[NXT_WASM_FH_REQUEST].func;
+
+    args[i].kind = WASMTIME_I32;
+    args[i++].of.i32 = ctx->baddr_off;
+
+    error = wasmtime_func_call(rt_ctx->ctx, func, args, i, results, 1, &trap);
+    if (error != NULL || trap != NULL) {
+        nxt_wasmtime_err_msg(error, trap,
+                             "failed to call function [->wasm_request_handler]"
+                            );
+    }
+}
+
+
+static void
+nxt_wasmtime_set_function_imports(nxt_wasm_ctx_t *ctx)
+{
+    nxt_wasmtime_ctx_t  *rt_ctx = &nxt_wasmtime_ctx;
+
+    static const struct {
+        const char                *func_name;
+
+        wasmtime_func_callback_t  func;
+        wasm_valkind_t            params[1];
+        wasm_valkind_t            results[1];
+
+        enum {
+            NXT_WASM_FT_0_0,
+            NXT_WASM_FT_1_0,
+            NXT_WASM_FT_0_1,
+        }                         ft;
+    } import_functions[] = {
+        {
+            .func_name = "nxt_wasm_get_init_mem_size",
+            .func      = nxt_wasm_get_init_mem_size,
+            .results   = { WASM_I32 },
+            .ft        = NXT_WASM_FT_0_1
+        }, {
+            .func_name = "nxt_wasm_response_end",
+            .func      = nxt_wasm_response_end,
+            .ft        = NXT_WASM_FT_0_0
+        }, {
+            .func_name = "nxt_wasm_send_response",
+            .func      = nxt_wasm_send_response,
+            .params    = { WASM_I32 },
+            .ft        = NXT_WASM_FT_1_0
+        }, {
+            .func_name = "nxt_wasm_send_headers",
+            .func      = nxt_wasm_send_headers,
+            .params    = { WASM_I32 },
+            .ft        = NXT_WASM_FT_1_0
+        },
+
+        { }
+    }, *imf;
+
+    for (imf = import_functions; imf->func_name != NULL; imf++) {
+        wasm_functype_t  *func_ty;
+
+        switch (imf->ft) {
+        case NXT_WASM_FT_0_0:
+            func_ty = wasm_functype_new_0_0();
+            break;
+        case NXT_WASM_FT_1_0:
+            func_ty = wasm_functype_new_1_0(wasm_valtype_new(imf->params[0]));
+            break;
+        case NXT_WASM_FT_0_1:
+            func_ty = wasm_functype_new_0_1(wasm_valtype_new(imf->results[0]));
+            break;
+        default:
+            /* Stop GCC complaining about func_ty being used uninitialised */
+            func_ty = NULL;
+        }
+
+        wasmtime_linker_define_func(rt_ctx->linker, "env", 3,
+                                    imf->func_name, strlen(imf->func_name),
+                                    func_ty,  imf->func, ctx, NULL);
+        wasm_functype_delete(func_ty);
+    }
+}
+
+
+static int
+nxt_wasmtime_get_function_exports(nxt_wasm_ctx_t *ctx)
+{
+    int                 i;
+    nxt_wasmtime_ctx_t  *rt_ctx = &nxt_wasmtime_ctx;
+
+    for (i = 0; i < NXT_WASM_FH_NR; i++) {
+        bool               ok;
+        wasmtime_extern_t  item;
+
+        if (ctx->fh[i].func_name == NULL) {
+            continue;
+        }
+
+        ok = wasmtime_linker_get(rt_ctx->linker, rt_ctx->ctx, "", 0,
+                                 ctx->fh[i].func_name,
+                                 strlen(ctx->fh[i].func_name), &item);
+        if (!ok) {
+            nxt_wasmtime_err_msg(NULL, NULL,
+                                 "couldn't get (%s) export from module",
+                                 ctx->fh[i].func_name);
+            return -1;
+        }
+        ctx->fh[i].func = item.of.func;
+    }
+
+    return 0;
+}
+
+
+static int
+nxt_wasmtime_wasi_init(const nxt_wasm_ctx_t *ctx)
+{
+    wasi_config_t       *wasi_config;
+    wasmtime_error_t    *error;
+    nxt_wasmtime_ctx_t  *rt_ctx = &nxt_wasmtime_ctx;
+
+    wasi_config = wasi_config_new();
+
+    wasi_config_inherit_env(wasi_config);
+    wasi_config_inherit_stdin(wasi_config);
+    wasi_config_inherit_stdout(wasi_config);
+    wasi_config_inherit_stderr(wasi_config);
+
+    error = wasmtime_context_set_wasi(rt_ctx->ctx, wasi_config);
+    if (error != NULL) {
+        nxt_wasmtime_err_msg(error, NULL, "failed to instantiate WASI");
+        return -1;
+    }
+
+    return 0;
+}
+
+
+static int
+nxt_wasmtime_init_memory(nxt_wasm_ctx_t *ctx)
+{
+    int                    i = 0;
+    bool                   ok;
+    wasm_trap_t            *trap = NULL;
+    wasmtime_val_t         args[1] = { };
+    wasmtime_val_t         results[1] = { };
+    wasmtime_error_t       *error;
+    wasmtime_extern_t      item;
+    nxt_wasmtime_ctx_t     *rt_ctx = &nxt_wasmtime_ctx;
+    const nxt_wasm_func_t  *func = &ctx->fh[NXT_WASM_FH_MALLOC].func;
+
+    args[i].kind = WASMTIME_I32;
+    args[i++].of.i32 = NXT_WASM_MEM_SIZE + NXT_WASM_PAGE_SIZE;
+
+    error = wasmtime_func_call(rt_ctx->ctx, func, args, i, results, 1, &trap);
+    if (error != NULL || trap != NULL) {
+        nxt_wasmtime_err_msg(error, trap,
+                             "failed to call function [->wasm_malloc_handler]"
+                            );
+        return -1;
+    }
+
+    ok = wasmtime_linker_get(rt_ctx->linker, rt_ctx->ctx, "", 0, "memory",
+                             strlen("memory"), &item);
+    if (!ok) {
+        nxt_wasmtime_err_msg(NULL, NULL, "couldn't get 'memory' from module\n");
+        return -1;
+    }
+    rt_ctx->memory = item.of.memory;
+
+    ctx->baddr_off = results[0].of.i32;
+    ctx->baddr = wasmtime_memory_data(rt_ctx->ctx, &rt_ctx->memory);
+
+    ctx->baddr += ctx->baddr_off;
+
+    return 0;
+}
+
+
+static int
+nxt_wasmtime_init(nxt_wasm_ctx_t *ctx)
+{
+    int                 err;
+    FILE                *fp;
+    size_t              file_size;
+    wasm_byte_vec_t     wasm;
+    wasmtime_error_t    *error;
+    nxt_wasmtime_ctx_t  *rt_ctx = &nxt_wasmtime_ctx;
+
+    rt_ctx->engine = wasm_engine_new();
+    rt_ctx->store = wasmtime_store_new(rt_ctx->engine, NULL, NULL);
+    rt_ctx->ctx = wasmtime_store_context(rt_ctx->store);
+
+    rt_ctx->linker = wasmtime_linker_new(rt_ctx->engine);
+    error = wasmtime_linker_define_wasi(rt_ctx->linker);
+    if (error != NULL) {
+        nxt_wasmtime_err_msg(error, NULL, "failed to link wasi");
+        return -1;
+    }
+
+    fp = fopen(ctx->module_path, "r");
+    if (!fp) {
+        nxt_wasmtime_err_msg(NULL, NULL,
+                             "error opening file (%s)", ctx->module_path);
+        return -1;
+    }
+    fseek(fp, 0L, SEEK_END);
+    file_size = ftell(fp);
+    wasm_byte_vec_new_uninitialized(&wasm, file_size);
+    fseek(fp, 0L, SEEK_SET);
+    if (fread(wasm.data, file_size, 1, fp) != 1) {
+        nxt_wasmtime_err_msg(NULL, NULL, "error loading module");
+        fclose(fp);
+        return -1;
+    }
+    fclose(fp);
+
+    error = wasmtime_module_new(rt_ctx->engine, (uint8_t *)wasm.data, wasm.size,
+                                &rt_ctx->module);
+    if (!rt_ctx->module) {
+        nxt_wasmtime_err_msg(error, NULL, "failed to compile module");
+        return -1;
+    }
+    wasm_byte_vec_delete(&wasm);
+
+    nxt_wasmtime_set_function_imports(ctx);
+
+    nxt_wasmtime_wasi_init(ctx);
+
+    error = wasmtime_linker_module(rt_ctx->linker, rt_ctx->ctx, "", 0,
+                                   rt_ctx->module);
+    if (error != NULL) {
+         nxt_wasmtime_err_msg(error, NULL, "failed to instantiate");
+         return -1;
+    }
+
+    err = nxt_wasmtime_get_function_exports(ctx);
+    if (err) {
+        return -1;
+    }
+
+    err = nxt_wasmtime_init_memory(ctx);
+    if (err) {
+        return -1;
+    }
+
+    return 0;
+}
+
+
+static void
+nxt_wasmtime_destroy(const nxt_wasm_ctx_t *ctx)
+{
+    int                    i = 0;
+    wasmtime_val_t         args[1] = { };
+    nxt_wasmtime_ctx_t     *rt_ctx = &nxt_wasmtime_ctx;
+    const nxt_wasm_func_t  *func = &ctx->fh[NXT_WASM_FH_FREE].func;
+
+    args[i].kind = WASMTIME_I32;
+    args[i++].of.i32 = ctx->baddr_off;
+
+    wasmtime_func_call(rt_ctx->ctx, func, args, i, NULL, 0, NULL);
+
+    wasmtime_module_delete(rt_ctx->module);
+    wasmtime_store_delete(rt_ctx->store);
+    wasm_engine_delete(rt_ctx->engine);
+}
+
+
+const nxt_wasm_operations_t  nxt_wasm_ops = {
+    .init               = nxt_wasmtime_init,
+    .destroy            = nxt_wasmtime_destroy,
+    .exec_request       = nxt_wasmtime_execute_request,
+    .exec_hook          = nxt_wasmtime_execute_hook,
+};

--- a/src/wasm/nxt_rt_wasmtime.c
+++ b/src/wasm/nxt_rt_wasmtime.c
@@ -247,6 +247,7 @@ nxt_wasmtime_get_function_exports(nxt_wasm_ctx_t *ctx)
 static int
 nxt_wasmtime_wasi_init(const nxt_wasm_ctx_t *ctx)
 {
+    char                **dir;
     wasi_config_t       *wasi_config;
     wasmtime_error_t    *error;
     nxt_wasmtime_ctx_t  *rt_ctx = &nxt_wasmtime_ctx;
@@ -257,6 +258,10 @@ nxt_wasmtime_wasi_init(const nxt_wasm_ctx_t *ctx)
     wasi_config_inherit_stdin(wasi_config);
     wasi_config_inherit_stdout(wasi_config);
     wasi_config_inherit_stderr(wasi_config);
+
+    for (dir = ctx->dirs; dir != NULL && *dir != NULL; dir++) {
+        wasi_config_preopen_dir(wasi_config, *dir, *dir);
+    }
 
     error = wasmtime_context_set_wasi(rt_ctx->ctx, wasi_config);
     if (error != NULL) {

--- a/src/wasm/nxt_wasm.c
+++ b/src/wasm/nxt_wasm.c
@@ -1,0 +1,258 @@
+/*
+ * Copyright (C) Andrew Clayton
+ * Copyright (C) F5, Inc.
+ */
+
+#include <nxt_main.h>
+#include <nxt_application.h>
+#include <nxt_unit.h>
+#include <nxt_unit_request.h>
+
+#include "nxt_wasm.h"
+
+
+#define NXT_WASM_VERSION        "0.1"
+
+#define NXT_WASM_DO_HOOK(hook)  nxt_wops->exec_hook(&nxt_wasm_ctx, hook);
+
+
+static uint32_t  compat[] = {
+    NXT_VERNUM, NXT_DEBUG,
+};
+
+static nxt_wasm_ctx_t               nxt_wasm_ctx;
+
+static const nxt_wasm_operations_t  *nxt_wops;
+
+
+void
+nxt_wasm_do_response_end(nxt_wasm_ctx_t *ctx)
+{
+    nxt_unit_request_done(ctx->req, NXT_UNIT_OK);
+
+    NXT_WASM_DO_HOOK(NXT_WASM_FH_RESPONSE_END);
+}
+
+
+void
+nxt_wasm_do_send_headers(nxt_wasm_ctx_t *ctx, uint32_t offset)
+{
+    size_t                      fields_len;
+    unsigned int                i;
+    nxt_wasm_response_fields_t  *rh;
+
+    rh = (nxt_wasm_response_fields_t *)(ctx->baddr + offset);
+
+    fields_len = 0;
+    for (i = 0; i < rh->nfields; i++) {
+        fields_len += rh->fields[i].name_len + rh->fields[i].value_len;
+    }
+
+    nxt_unit_response_init(ctx->req, 200, rh->nfields, fields_len);
+
+    for (i = 0; i < rh->nfields; i++) {
+        const char  *name;
+        const char  *val;
+
+        name = (const char *)rh + rh->fields[i].name_off;
+        val = (const char *)rh + rh->fields[i].value_off;
+
+        nxt_unit_response_add_field(ctx->req, name, rh->fields[i].name_len,
+                                    val, rh->fields[i].value_len);
+    }
+
+    nxt_unit_response_send(ctx->req);
+}
+
+
+void
+nxt_wasm_do_send_response(nxt_wasm_ctx_t *ctx, uint32_t offset)
+{
+    nxt_wasm_response_t      *resp;
+    nxt_unit_request_info_t  *req = ctx->req;
+
+    if (!nxt_unit_response_is_init(req)) {
+        nxt_unit_response_init(req, 200, 0, 0);
+    }
+
+    resp = (nxt_wasm_response_t *)(nxt_wasm_ctx.baddr + offset);
+
+    nxt_unit_response_write(req, (const char *)resp->data, resp->size);
+}
+
+
+static void
+nxt_wasm_request_handler(nxt_unit_request_info_t *req)
+{
+    size_t                 offset, read_bytes, content_sent, content_len;
+    ssize_t                bytes_read;
+    nxt_unit_field_t       *sf, *sf_end;
+    nxt_unit_request_t     *r;
+    nxt_wasm_request_t     *wr;
+    nxt_wasm_http_field_t  *df;
+
+    NXT_WASM_DO_HOOK(NXT_WASM_FH_REQUEST_INIT);
+
+    wr = (nxt_wasm_request_t *)nxt_wasm_ctx.baddr;
+
+#define SET_REQ_MEMBER(dmember, smember) \
+    do { \
+        const char *str = nxt_unit_sptr_get(&r->smember); \
+        wr->dmember##_off = offset; \
+        wr->dmember##_len = strlen(str); \
+        memcpy((uint8_t *)wr + offset, str, wr->dmember##_len + 1); \
+        offset += wr->dmember##_len + 1; \
+    } while (0)
+
+    r = req->request;
+    offset = sizeof(nxt_wasm_request_t)
+             + (r->fields_count * sizeof(nxt_wasm_http_field_t));
+
+    SET_REQ_MEMBER(path, path);
+    SET_REQ_MEMBER(method, method);
+    SET_REQ_MEMBER(version, version);
+    SET_REQ_MEMBER(query, query);
+    SET_REQ_MEMBER(remote, remote);
+    SET_REQ_MEMBER(local_addr, local_addr);
+    SET_REQ_MEMBER(local_port, local_port);
+    SET_REQ_MEMBER(server_name, server_name);
+#undef SET_REQ_MEMBER
+
+    df = wr->fields;
+    sf_end = r->fields + r->fields_count;
+    for (sf = r->fields; sf < sf_end; sf++) {
+        const char  *name = nxt_unit_sptr_get(&sf->name);
+        const char  *value = nxt_unit_sptr_get(&sf->value);
+
+        df->name_off = offset;
+        df->name_len = strlen(name);
+        memcpy((uint8_t *)wr + offset, name, df->name_len + 1);
+        offset += df->name_len + 1;
+
+        df->value_off = offset;
+        df->value_len = strlen(value);
+        memcpy((uint8_t *)wr + offset, value, df->value_len + 1);
+        offset += df->value_len + 1;
+
+        df++;
+    }
+
+    wr->tls = r->tls;
+    wr->nfields = r->fields_count;
+    wr->content_off = offset;
+    wr->content_len = content_len = r->content_length;
+
+    read_bytes = nxt_min(wr->content_len, NXT_WASM_MEM_SIZE - offset);
+
+    bytes_read = nxt_unit_request_read(req, (uint8_t *)wr + offset, read_bytes);
+    wr->content_sent = wr->total_content_sent = content_sent = bytes_read;
+
+    wr->request_size = offset + bytes_read;
+
+    nxt_wasm_ctx.req = req;
+    nxt_wops->exec_request(&nxt_wasm_ctx);
+
+    if (content_len == content_sent) {
+        goto request_done;
+    }
+
+    wr->nfields = 0;
+    wr->content_off = offset = sizeof(nxt_wasm_request_t);
+    do {
+        read_bytes = nxt_min(content_len - content_sent,
+                             NXT_WASM_MEM_SIZE - offset);
+        bytes_read = nxt_unit_request_read(req, (uint8_t *)wr + offset,
+                                           read_bytes);
+
+        content_sent += bytes_read;
+        wr->request_size = wr->content_sent = bytes_read;
+        wr->total_content_sent = content_sent;
+
+        nxt_wops->exec_request(&nxt_wasm_ctx);
+    } while (content_sent < content_len);
+
+request_done:
+    NXT_WASM_DO_HOOK(NXT_WASM_FH_REQUEST_END);
+}
+
+
+static nxt_int_t
+nxt_wasm_start(nxt_task_t *task, nxt_process_data_t *data)
+{
+    nxt_int_t              ret;
+    nxt_unit_ctx_t         *unit_ctx;
+    nxt_unit_init_t        wasm_init;
+    nxt_common_app_conf_t  *conf;
+
+    conf = data->app;
+
+    ret = nxt_unit_default_init(task, &wasm_init, conf);
+    if (nxt_slow_path(ret != NXT_OK)) {
+        nxt_alert(task, "nxt_unit_default_init() failed");
+        return ret;
+    }
+
+    wasm_init.callbacks.request_handler = nxt_wasm_request_handler;
+
+    unit_ctx = nxt_unit_init(&wasm_init);
+    if (nxt_slow_path(unit_ctx == NULL)) {
+        return NXT_ERROR;
+    }
+
+    NXT_WASM_DO_HOOK(NXT_WASM_FH_MODULE_INIT);
+    nxt_unit_run(unit_ctx);
+    nxt_unit_done(unit_ctx);
+    NXT_WASM_DO_HOOK(NXT_WASM_FH_MODULE_END);
+
+    nxt_wops->destroy(&nxt_wasm_ctx);
+
+    exit(EXIT_SUCCESS);
+}
+
+
+static nxt_int_t
+nxt_wasm_setup(nxt_task_t *task, nxt_process_t *process,
+               nxt_common_app_conf_t *conf)
+{
+    int                      err;
+    nxt_wasm_app_conf_t      *c;
+    nxt_wasm_func_handler_t  *fh;
+
+    c = &conf->u.wasm;
+
+    nxt_wops = &nxt_wasm_ops;
+
+    nxt_wasm_ctx.module_path = c->module;
+
+    fh = nxt_wasm_ctx.fh;
+
+    fh[NXT_WASM_FH_REQUEST].func_name = c->request_handler;
+    fh[NXT_WASM_FH_MALLOC].func_name = c->malloc_handler;
+    fh[NXT_WASM_FH_FREE].func_name = c->free_handler;
+
+    /* Optional function handlers (hooks) */
+    fh[NXT_WASM_FH_MODULE_INIT].func_name = c->module_init_handler;
+    fh[NXT_WASM_FH_MODULE_END].func_name = c->module_end_handler;
+    fh[NXT_WASM_FH_REQUEST_INIT].func_name = c->request_init_handler;
+    fh[NXT_WASM_FH_REQUEST_END].func_name = c->request_end_handler;
+    fh[NXT_WASM_FH_RESPONSE_END].func_name = c->response_end_handler;
+
+    err = nxt_wops->init(&nxt_wasm_ctx);
+    if (err) {
+        exit(EXIT_FAILURE);
+    }
+
+    return NXT_OK;
+}
+
+
+NXT_EXPORT nxt_app_module_t  nxt_app_module = {
+    .compat_length  = sizeof(compat),
+    .compat         = compat,
+    .type           = nxt_string("wasm"),
+    .version        = NXT_WASM_VERSION,
+    .mounts         = NULL,
+    .nmounts        = 0,
+    .setup          = nxt_wasm_setup,
+    .start          = nxt_wasm_start,
+};

--- a/src/wasm/nxt_wasm.h
+++ b/src/wasm/nxt_wasm.h
@@ -125,6 +125,7 @@ struct nxt_wasm_operations_s {
     void  (*destroy)(const nxt_wasm_ctx_t *ctx);
     void  (*exec_request)(const nxt_wasm_ctx_t *ctx);
     void  (*exec_hook)(const nxt_wasm_ctx_t *ctx, nxt_wasm_fh_t hook);
+    void  (*meminfo)(const nxt_wasm_ctx_t *ctx);
 };
 
 extern const nxt_wasm_operations_t  nxt_wasm_ops;

--- a/src/wasm/nxt_wasm.h
+++ b/src/wasm/nxt_wasm.h
@@ -110,6 +110,8 @@ struct nxt_wasm_ctx_s {
 
     nxt_wasm_func_handler_t  fh[NXT_WASM_FH_NR];
 
+    char                     **dirs;
+
     nxt_unit_request_info_t  *req;
 
     uint8_t                  *baddr;

--- a/src/wasm/nxt_wasm.h
+++ b/src/wasm/nxt_wasm.h
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) Andrew Clayton
+ * Copyright (C) F5, Inc.
+ */
+
+#ifndef _NXT_WASM_H_INCLUDED_
+#define _NXT_WASM_H_INCLUDED_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <nxt_unit.h>
+
+#include <wasm.h>
+#if defined(NXT_HAVE_WASM_WASMTIME)
+#include <wasmtime.h>
+#endif
+
+
+#define NXT_WASM_PAGE_SIZE          (64 * 1024)
+#define NXT_WASM_MEM_SIZE           (32UL * 1024 * 1024)
+
+#if defined(NXT_HAVE_WASM_WASMTIME)
+typedef wasmtime_func_t  nxt_wasm_func_t;
+#endif
+
+
+typedef struct nxt_wasm_http_field_s       nxt_wasm_http_field_t;
+typedef struct nxt_wasm_request_s          nxt_wasm_request_t;
+typedef struct nxt_wasm_response_s         nxt_wasm_response_t;
+typedef struct nxt_wasm_response_fields_s  nxt_wasm_response_fields_t;
+typedef enum nxt_wasm_fh_e                 nxt_wasm_fh_t;
+typedef struct nxt_wasm_func_handler_s     nxt_wasm_func_handler_t;
+typedef struct nxt_wasm_ctx_s              nxt_wasm_ctx_t;
+typedef struct nxt_wasm_operations_s       nxt_wasm_operations_t;
+
+struct nxt_wasm_http_field_s {
+    uint32_t  name_off;
+    uint32_t  name_len;
+    uint32_t  value_off;
+    uint32_t  value_len;
+};
+
+struct nxt_wasm_request_s {
+    uint32_t               method_off;
+    uint32_t               method_len;
+    uint32_t               version_off;
+    uint32_t               version_len;
+    uint32_t               path_off;
+    uint32_t               path_len;
+    uint32_t               query_off;
+    uint32_t               query_len;
+    uint32_t               remote_off;
+    uint32_t               remote_len;
+    uint32_t               local_addr_off;
+    uint32_t               local_addr_len;
+    uint32_t               local_port_off;
+    uint32_t               local_port_len;
+    uint32_t               server_name_off;
+    uint32_t               server_name_len;
+
+    uint32_t               content_off;
+    uint32_t               content_len;
+    uint32_t               content_sent;
+    uint32_t               total_content_sent;
+
+    uint32_t               request_size;
+
+    uint32_t               nfields;
+
+    uint32_t               tls;
+
+    nxt_wasm_http_field_t  fields[];
+};
+
+struct nxt_wasm_response_s {
+    uint32_t  size;
+
+    uint8_t   data[];
+};
+
+struct nxt_wasm_response_fields_s {
+    uint32_t               nfields;
+
+    nxt_wasm_http_field_t  fields[];
+};
+
+enum nxt_wasm_fh_e {
+    NXT_WASM_FH_REQUEST = 0,
+    NXT_WASM_FH_MALLOC,
+    NXT_WASM_FH_FREE,
+
+    /* Optional handlers */
+    NXT_WASM_FH_MODULE_INIT,
+    NXT_WASM_FH_MODULE_END,
+    NXT_WASM_FH_REQUEST_INIT,
+    NXT_WASM_FH_REQUEST_END,
+    NXT_WASM_FH_RESPONSE_END,
+
+    NXT_WASM_FH_NR
+};
+
+struct nxt_wasm_func_handler_s {
+    const char       *func_name;
+    nxt_wasm_func_t  func;
+};
+
+struct nxt_wasm_ctx_s {
+    const char               *module_path;
+
+    nxt_wasm_func_handler_t  fh[NXT_WASM_FH_NR];
+
+    nxt_unit_request_info_t  *req;
+
+    uint8_t                  *baddr;
+    size_t                   baddr_off;
+
+    size_t                   response_off;
+};
+
+struct nxt_wasm_operations_s {
+    int   (*init)(nxt_wasm_ctx_t *ctx);
+    void  (*destroy)(const nxt_wasm_ctx_t *ctx);
+    void  (*exec_request)(const nxt_wasm_ctx_t *ctx);
+    void  (*exec_hook)(const nxt_wasm_ctx_t *ctx, nxt_wasm_fh_t hook);
+};
+
+extern const nxt_wasm_operations_t  nxt_wasm_ops;
+
+
+/* Exported to the WASM module */
+extern void nxt_wasm_do_response_end(nxt_wasm_ctx_t *ctx);
+extern void nxt_wasm_do_send_response(nxt_wasm_ctx_t *ctx, uint32_t offset);
+extern void nxt_wasm_do_send_headers(nxt_wasm_ctx_t *ctx, uint32_t offset);
+
+#endif  /* _NXT_WASM_H_INCLUDED_ */


### PR DESCRIPTION
This adds support to Unit for running WebAssembly (Wasm) modules.

It should be noted that this is being classed as a **Technology Preview**.

Wasm provides a secure sandboxed environment for running code. Code runs in a virtual machine with limited access to outside resources and any attempt to access memory not allocated to the module will result in a trap and the immediate termination of execution of the module.

While Wasm originated on the web browser side of things, influenced by asm.js, there are server side runtimes available and with the combination of WebAssembly System Interface (WASI) you can have a POSIX like environment to develop in.

This initial Wasm support makes use of [Wasmtime](https://wasmtime.dev/), however it has been designed with the ability to support different runtimes in mind (initially at build time, but perhaps eventually also at runtime).

There are actually sort of two parts of this (different sides of the same coin if you will).

This pull request deals solely with the Unit language module (runtime) side of things, what runs Wasm modules.

Then there is the Wasm modules side of things. There is a parallel project, [libunit-wasm](https://github.com/nginx/unit-wasm), this is done as a separate project as it is likely to be a rapidly evolving entity, to help with developing Wasm modules for Unit in C and Rust.

This pull request consists of the following commits

- Index initialise the nxt_app_msg_prefix array.

A preparatory patch that makes a structure array initialisation much clearer.

- Wasm: Register a new WebAssembly language module type.

This registers a new module type of 'NXT_APP_WASM'

- Wasm: Add core configuration data structure.

This adds the core Wasm configuration structure which is required by subsequent commits.

- Wasm: Add the core of initial WebAssembly language module support.

This adds the core of WebAssembly language module support under a new src/wasm directory.

- Wasm: Wire the Wasm language module up to the build system.

Allow the Wasm language module to be configured and built.

- Wasm: Wire up Wasm language module support to the config system.

Allow the Wasm language module to be configured via the Unit configuration.

- Wasm: Add support for directory access.

Allow to specify directories that can be made available for access by the Wasm modules.

- [WASM DEBUG] NOT TO BE COMMITTED.

**Ignore this patch**. It's still useful while we work on the Rust unit-wasm support.

As always, see individual commit messages for more details...

Each successive commit has been build tested.