### PR TITLE
Fix WASM module caveats (post 1.31)

### DIFF
--- a/auto/modules/go
+++ b/auto/modules/go
@@ -115,14 +115,16 @@ ${NXT_GO}-install: ${NXT_GO}-install-src ${NXT_GO}-install-env
     GOPATH=\$(DESTDIR)\$(GOPATH) ${NXT_GO} build ${NXT_GO_PKG}
 
 ${NXT_GO}-install-src:
-	install -d \$(DESTDIR)\$(NXT_GO_DST)/src/${NXT_GO_PKG}
+	test -d \$(DESTDIR)\$(NXT_GO_DST)/src/${NXT_GO_PKG} \
+		|| install -d \$(DESTDIR)\$(NXT_GO_DST)/src/${NXT_GO_PKG}
 	install -p -m644 ./go/* \$(DESTDIR)\$(NXT_GO_DST)/src/${NXT_GO_PKG}/
 
 ${NXT_GO}-install-env: \$(DESTDIR)\$(NXT_GO_DST)/src/${NXT_GO_PKG}/env.go \
     ${NXT_VERSION_H} ${NXT_BUILD_DIR}/lib/${NXT_LIB_UNIT_STATIC}
 
 \$(DESTDIR)\$(NXT_GO_DST)/src/${NXT_GO_PKG}/env.go:
-	install -d \$(DESTDIR)\$(NXT_GO_DST)/src/${NXT_GO_PKG}
+	test -d \$(DESTDIR)\$(NXT_GO_DST)/src/${NXT_GO_PKG} \
+		|| install -d \$(DESTDIR)\$(NXT_GO_DST)/src/${NXT_GO_PKG}
 	$echo "package unit" > \$@
 	$echo "/*" >> \$@
 	$echo "#cgo CFLAGS: ${CFLAGS} ${NXT_CC_OPT}" >> \$@

--- a/auto/modules/java
+++ b/auto/modules/java
@@ -535,10 +535,12 @@ ${NXT_JAVA_MODULE}-install: \\
     $NXT_BUILD_DIR/$NXT_UNIT_JAR \\
     $NXT_BUILD_DIR/$NXT_WS_API_JAR \\
     java-shared-install
-	install -d \$(DESTDIR)$NXT_MODULESDIR
+	test -d \$(DESTDIR)$NXT_MODULESDIR \
+		|| install -d \$(DESTDIR)$NXT_MODULESDIR
 	install -p $NXT_BUILD_DIR/lib/unit/modules/${NXT_JAVA_MODULE}.unit.so \\
 		\$(DESTDIR)$NXT_MODULESDIR/
-	install -d \$(DESTDIR)$NXT_JARS
+	test -d \$(DESTDIR)$NXT_JARS \
+		|| install -d \$(DESTDIR)$NXT_JARS
 	install -p -m 0644 $NXT_BUILD_DIR/$NXT_UNIT_JAR \$(DESTDIR)$NXT_JARS/
 	install -p -m 0644 $NXT_BUILD_DIR/$NXT_WS_API_JAR \$(DESTDIR)$NXT_JARS/
 
@@ -629,7 +631,8 @@ if ! grep ^java-shared-install: $NXT_MAKEFILE 2>&1 > /dev/null; then
 .PHONY: java-shared-uninstall
 
 java-shared-install: $NXT_JAVA_INSTALL_JARS
-	install -d \$(DESTDIR)$NXT_JARS
+	test -d \$(DESTDIR)$NXT_JARS \
+		|| install -d \$(DESTDIR)$NXT_JARS
 	install -p -m 0644 $NXT_JAVA_INSTALL_JARS \$(DESTDIR)$NXT_JARS/
 
 java-shared-uninstall:

--- a/auto/modules/perl
+++ b/auto/modules/perl
@@ -194,7 +194,8 @@ $NXT_BUILD_DIR/lib/unit/modules/${NXT_PERL_MODULE}.unit.so:	$nxt_objs
 install: ${NXT_PERL_MODULE}-install
 
 ${NXT_PERL_MODULE}-install: ${NXT_PERL_MODULE} install-check
-	install -d \$(DESTDIR)$NXT_MODULESDIR
+	test -d \$(DESTDIR)$NXT_MODULESDIR \
+		|| install -d \$(DESTDIR)$NXT_MODULESDIR
 	install -p $NXT_BUILD_DIR/lib/unit/modules/${NXT_PERL_MODULE}.unit.so \\
 		\$(DESTDIR)$NXT_MODULESDIR/
 

--- a/auto/modules/php
+++ b/auto/modules/php
@@ -275,7 +275,8 @@ $NXT_BUILD_DIR/lib/unit/modules/${NXT_PHP_MODULE}.unit.so:	$nxt_objs
 install: ${NXT_PHP_MODULE}-install
 
 ${NXT_PHP_MODULE}-install: ${NXT_PHP_MODULE} install-check
-	install -d \$(DESTDIR)$NXT_MODULESDIR
+	test -d \$(DESTDIR)$NXT_MODULESDIR \
+		|| install -d \$(DESTDIR)$NXT_MODULESDIR
 	install -p $NXT_BUILD_DIR/lib/unit/modules/${NXT_PHP_MODULE}.unit.so \\
 		\$(DESTDIR)$NXT_MODULESDIR/
 

--- a/auto/modules/python
+++ b/auto/modules/python
@@ -223,7 +223,8 @@ $NXT_BUILD_DIR/lib/unit/modules/${NXT_PYTHON_MODULE}.unit.so:	$nxt_objs
 install: ${NXT_PYTHON_MODULE}-install
 
 ${NXT_PYTHON_MODULE}-install: ${NXT_PYTHON_MODULE} install-check
-	install -d \$(DESTDIR)$NXT_MODULESDIR
+	test -d \$(DESTDIR)$NXT_MODULESDIR \
+		|| install -d \$(DESTDIR)$NXT_MODULESDIR
 	install -p $NXT_BUILD_DIR/lib/unit/modules/${NXT_PYTHON_MODULE}.unit.so \\
 		\$(DESTDIR)$NXT_MODULESDIR/
 

--- a/auto/modules/ruby
+++ b/auto/modules/ruby
@@ -260,7 +260,8 @@ $NXT_BUILD_DIR/lib/unit/modules/${NXT_RUBY_MODULE}.unit.so:	$nxt_objs
 install: ${NXT_RUBY_MODULE}-install
 
 ${NXT_RUBY_MODULE}-install: ${NXT_RUBY_MODULE} install-check
-	install -d \$(DESTDIR)$NXT_MODULESDIR
+	test -d \$(DESTDIR)$NXT_MODULESDIR \
+		|| install -d \$(DESTDIR)$NXT_MODULESDIR
 	install -p $NXT_BUILD_DIR/lib/unit/modules/${NXT_RUBY_MODULE}.unit.so \\
 		\$(DESTDIR)$NXT_MODULESDIR/
 

--- a/auto/modules/wasm
+++ b/auto/modules/wasm
@@ -193,7 +193,8 @@ $NXT_BUILD_DIR/lib/unit/modules/${NXT_WASM_MODULE}.unit.so:	$nxt_objs
 install: ${NXT_WASM_MODULE}-install
 
 ${NXT_WASM_MODULE}-install: ${NXT_WASM_MODULE} install-check
-	install -d \$(DESTDIR)$NXT_MODULESDIR
+	test -d \$(DESTDIR)$NXT_MODULESDIR \
+		|| install -d \$(DESTDIR)$NXT_MODULESDIR
 	install -p $NXT_BUILD_DIR/lib/unit/modules/${NXT_WASM_MODULE}.unit.so \\
 		\$(DESTDIR)$NXT_MODULESDIR/
 

--- a/src/nxt_clang.h
+++ b/src/nxt_clang.h
@@ -260,7 +260,7 @@ nxt_popcount(unsigned int x)
 
 
 #define nxt_sizeof_struct(s, flex, n)                                         \
-    (sizeof(s) + nxt_sizeof_flex_array(s, flex, n))
+    (nxt_max(sizeof(s), offsetof(s, flex) + nxt_sizeof_flex_array(s, flex, n)))
 
 
 #endif /* _NXT_CLANG_H_INCLUDED_ */

--- a/src/nxt_clang.h
+++ b/src/nxt_clang.h
@@ -255,4 +255,12 @@ nxt_popcount(unsigned int x)
     (sizeof(s) - 1)
 
 
+#define nxt_sizeof_flex_array(s, flex, n)                                     \
+    (n * sizeof((s){0}.flex[0]))
+
+
+#define nxt_sizeof_struct(s, flex, n)                                         \
+    (sizeof(s) + nxt_sizeof_flex_array(s, flex, n))
+
+
 #endif /* _NXT_CLANG_H_INCLUDED_ */

--- a/src/wasm/nxt_rt_wasmtime.c
+++ b/src/wasm/nxt_rt_wasmtime.c
@@ -3,12 +3,12 @@
  * Copyright (C) F5, Inc.
  */
 
-#include <stdio.h>
-#include <stdbool.h>
 #include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
 
-#include <wasm.h>
 #include <wasi.h>
+#include <wasm.h>
 #include <wasmtime.h>
 
 #include "nxt_wasm.h"

--- a/src/wasm/nxt_wasm.c
+++ b/src/wasm/nxt_wasm.c
@@ -156,7 +156,7 @@ nxt_wasm_request_handler(nxt_unit_request_info_t *req)
     }
 
     wr->nfields = 0;
-    wr->content_off = offset = sizeof(nxt_wasm_request_t);
+    wr->content_off = offset = offsetof(nxt_wasm_request_t, fields);
     do {
         read_bytes = nxt_min(content_len - content_sent,
                              NXT_WASM_MEM_SIZE - offset);

--- a/src/wasm/nxt_wasm.c
+++ b/src/wasm/nxt_wasm.c
@@ -105,8 +105,7 @@ nxt_wasm_request_handler(nxt_unit_request_info_t *req)
     } while (0)
 
     r = req->request;
-    offset = sizeof(nxt_wasm_request_t)
-             + (r->fields_count * sizeof(nxt_wasm_http_field_t));
+    offset = nxt_sizeof_struct(nxt_wasm_request_t, fields, r->fields_count);
 
     SET_REQ_MEMBER(path, path);
     SET_REQ_MEMBER(method, method);


### PR DESCRIPTION
This is a set of fixes for the caveats noted in the review in <https://github.com/nginx/unit/pull/917>, which we agreed to fix after the release.

I prepared the PR already, but please ignore it until we release 1.31.