### PR TITLE
Java: fixed the calculation related to the response buffer.

### DIFF
--- a/src/java/nxt_jni_Response.c
+++ b/src/java/nxt_jni_Response.c
@@ -334,7 +334,8 @@ nxt_java_get_response_info(jlong req_info_ptr, uint32_t extra_fields,
                        - req->response->fields_count
         || extra_data > (uint32_t) (buf->end - buf->free))
     {
-        p = buf->start + req->response_max_fields * sizeof(nxt_unit_field_t);
+        p = buf->start + sizeof(nxt_unit_response_t)
+            + req->response_max_fields * sizeof(nxt_unit_field_t);
 
         max_size = 2 * (buf->end - p);
         if (max_size > nxt_unit_buf_max()) {
@@ -936,8 +937,8 @@ nxt_java_Response_reset(JNIEnv *env, jclass cls, jlong req_info_ptr)
 
         buf = req->response_buf;
 
-        buf->free = buf->start + req->response_max_fields
-                                  * sizeof(nxt_unit_field_t);
+        buf->free = buf->start + sizeof(nxt_unit_response_t)
+                    + req->response_max_fields * sizeof(nxt_unit_field_t);
     }
 }
 

--- a/src/nxt_unit.c
+++ b/src/nxt_unit.c
@@ -2148,7 +2148,8 @@ nxt_unit_response_realloc(nxt_unit_request_info_t *req,
     resp->status = req->response->status;
     resp->content_length = req->response->content_length;
 
-    p = buf->start + max_fields_count * sizeof(nxt_unit_field_t);
+    p = buf->start + sizeof(nxt_unit_response_t)
+        + max_fields_count * sizeof(nxt_unit_field_t);
     f = resp->fields;
 
     for (i = 0; i < req->response->fields_count; i++) {


### PR DESCRIPTION
We need to take into account the size of the nxt_unit_response_t structure itself when calculating where to start appending data to in memory.
