### PR TITLE
Fixes an error in memory copying when increasing the size of nxt_vector_t

### DIFF
--- a/src/nxt_vector.c
+++ b/src/nxt_vector.c
@@ -75,12 +75,13 @@ void *
 nxt_vector_add(nxt_vector_t *vector, const nxt_mem_proto_t *proto, void *pool)
 {
     void      *item, *start, *old;
-    size_t    size;
+    size_t    old_size, size;
     uint32_t  n;
 
     n = vector->avalaible;
 
     if (n == vector->items) {
+        old_size = n * vector->item_size;
 
         if (n < 16) {
             /* Allocate new vector twice as much as current. */
@@ -102,7 +103,7 @@ nxt_vector_add(nxt_vector_t *vector, const nxt_mem_proto_t *proto, void *pool)
         old = vector->start;
         vector->start = start;
 
-        nxt_memcpy(start, old, size);
+        nxt_memcpy(start, old, old_size);
 
         if (vector->type == NXT_VECTOR_EMBEDDED) {
             vector->type = NXT_VECTOR_DESCRETE;


### PR DESCRIPTION
Thanks for the work you are doing. Unit is a really great tool.

I found that when system increase the size if `nxt_ vector_t`, the function copy more bytes into the new buffer from the old buffer than there are (the new size, not the old). This usually doesn't result in an apparent error since there is something in the allocator buffer, but occasionally it can end in a segfault.

The address-sanitizer will also not tell you this because of its own allocator. You could potentially [markup your allocator](https://github.com/google/sanitizers/wiki/AddressSanitizerManualPoisoning) to see such errors in tests.