### PR TITLE
Python: Fix an issue with HTTP header field values being incorrectly reported as non-ascii

### DIFF
--- a/src/python/nxt_python_wsgi.c
+++ b/src/python/nxt_python_wsgi.c
@@ -863,6 +863,8 @@ nxt_python_field_value(nxt_unit_field_t *f, int n, uint32_t vl)
     char      *p, *src;
     PyObject  *res;
 
+    src = nxt_unit_sptr_get(&f->value);
+
 #if PY_MAJOR_VERSION == 3
     res = PyUnicode_New(vl, 255);
 #else
@@ -875,7 +877,6 @@ nxt_python_field_value(nxt_unit_field_t *f, int n, uint32_t vl)
 
     p = PyString_AS_STRING(res);
 
-    src = nxt_unit_sptr_get(&f->value);
     p = nxt_cpymem(p, src, f->value_length);
 
     for (i = 1; i < n; i++) {

--- a/src/python/nxt_python_wsgi.c
+++ b/src/python/nxt_python_wsgi.c
@@ -866,10 +866,35 @@ nxt_python_field_value(nxt_unit_field_t *f, int n, uint32_t vl)
     src = nxt_unit_sptr_get(&f->value);
 
 #if PY_MAJOR_VERSION == 3
-    res = PyUnicode_New(vl, 255);
+    if (nxt_slow_path(n > 1)) {
+        char  *ptr;
+
+        p = nxt_unit_malloc(NULL, vl + 1);
+        if (nxt_slow_path(p == NULL)) {
+            return NULL;
+        }
+
+        ptr = p;
+        p = nxt_cpymem(p, src, f->value_length);
+
+        for (i = 1; i < n; i++) {
+            p = nxt_cpymem(p, ", ", 2);
+
+            src = nxt_unit_sptr_get(&f[i].value);
+            p = nxt_cpymem(p, src, f[i].value_length);
+        }
+        *p = '\0';
+
+        src = ptr;
+    }
+
+    res = PyUnicode_DecodeCharmap(src, vl, NULL, NULL);
+
+    if (nxt_slow_path(n > 1)) {
+        nxt_unit_free(NULL, src);
+    }
 #else
     res = PyString_FromStringAndSize(NULL, vl);
-#endif
 
     if (nxt_slow_path(res == NULL)) {
         return NULL;
@@ -885,6 +910,7 @@ nxt_python_field_value(nxt_unit_field_t *f, int n, uint32_t vl)
         src = nxt_unit_sptr_get(&f[i].value);
         p = nxt_cpymem(p, src, f[i].value_length);
     }
+#endif
 
     return res;
 }


### PR DESCRIPTION
This PR fixes an issue in Python 3.x whereby certain HTTP header field values where being incorrectly reported as non-ascii by the Python `.isascii()` method.

This PR comprises two patches

1)  Python: Do nxt_unit_sptr_get() earlier in nxt_python_field_value().

Does what it says on the tin. It's a preparatory patch that simply calls the `nxt_unit_sptr_get()` function earlier in `nxt_python_field_value()`.

2) Python: Fix header field values character encoding.

The meat and potatoes. This replaces the use of `PyUnicode_New()` with `PyUnicode_DecodeCharmap()`

This leaves the old code path in place for Python < 3.0. Python 2.7 has been deprecated for a few years, so hopefully at some point in the not _too_ distant future all the < Python 3.0 code can just get ripped out.