### PR TITLE
Enable the setting of the file mode, owner and group of the UNIX domain control socket

### DIFF
--- a/docs/man/man8/unitd.8.in
+++ b/docs/man/man8/unitd.8.in
@@ -24,6 +24,9 @@
 .Nm
 .Op Fl Fl no-daemon
 .Op Fl Fl control Ar socket
+.Op Fl Fl control-mode Ar mode
+.Op Fl Fl control-user Ar user
+.Op Fl Fl control-group Ar group
 .Op Fl Fl group Ar name
 .Op Fl Fl user Ar name
 .Op Fl Fl log Ar file
@@ -53,6 +56,12 @@ Runs Unit in non-daemon mode.
 .It Fl Fl control Ar socket
 Overrides the control API's socket address in IPv4, IPv6,
 or UNIX-domain format.
+.It Fl Fl control-mode Ar mode
+Sets the permission of the UNIX-domain control socket.
+.It Fl Fl control-user Ar user
+Sets the owner of the UNIX-domain control socket.
+.It Fl Fl control-group Ar group
+Sets the group of the UNIX-domain control socket.
 .It Fl Fl group Ar name , Fl Fl user Ar name
 Override group name and user name used to run Unit's non-privileged processes.
 .It Fl Fl log Ar file

--- a/src/nxt_file.h
+++ b/src/nxt_file.h
@@ -177,6 +177,8 @@ NXT_EXPORT nxt_int_t nxt_file_info(nxt_file_t *file, nxt_file_info_t *fi);
 NXT_EXPORT nxt_int_t nxt_file_delete(nxt_file_name_t *name);
 NXT_EXPORT nxt_int_t nxt_file_set_access(nxt_file_name_t *name,
     nxt_file_access_t access);
+NXT_EXPORT nxt_int_t nxt_file_chown(nxt_file_name_t *name, const char *owner,
+    const char *group);
 NXT_EXPORT nxt_int_t nxt_file_rename(nxt_file_name_t *old_name,
     nxt_file_name_t *new_name);
 

--- a/src/nxt_runtime.c
+++ b/src/nxt_runtime.c
@@ -956,6 +956,12 @@ nxt_runtime_conf_read_cmd(nxt_task_t *task, nxt_runtime_t *rt)
 
     static const char  no_control[] =
                        "option \"--control\" requires socket address\n";
+    static const char  no_control_mode[] =
+                        "option \"--control-mode\" requires a mode\n";
+    static const char  no_control_user[] =
+                        "option \"--control-user\" requires a username\n";
+    static const char  no_control_group[] =
+                        "option \"--control-group\" requires a group name\n";
     static const char  no_user[] = "option \"--user\" requires username\n";
     static const char  no_group[] = "option \"--group\" requires group name\n";
     static const char  no_pid[] = "option \"--pid\" requires filename\n";
@@ -983,6 +989,13 @@ nxt_runtime_conf_read_cmd(nxt_task_t *task, nxt_runtime_t *rt)
         "\n"
         "  --control ADDRESS    set address of control API socket\n"
         "                       default: \"" NXT_CONTROL_SOCK "\"\n"
+        "\n"
+        "  --control-mode MODE  set mode of the control API socket\n"
+        "                       default: 0600\n"
+        "\n"
+        "  --control-user USER    set the owner of the control API socket\n"
+        "\n"
+        "  --control-group GROUP  set the group of the control API socket\n"
         "\n"
         "  --pid FILE           set pid filename\n"
         "                       default: \"" NXT_PID "\"\n"
@@ -1028,6 +1041,48 @@ nxt_runtime_conf_read_cmd(nxt_task_t *task, nxt_runtime_t *rt)
             p = *argv++;
 
             rt->control = p;
+
+            continue;
+        }
+
+        if (nxt_strcmp(p, "--control-mode") == 0) {
+            if (*argv == NULL) {
+                write(STDERR_FILENO, no_control_mode,
+                      nxt_length(no_control_mode));
+                return NXT_ERROR;
+            }
+
+            p = *argv++;
+
+            rt->control_mode = strtoul(p, NULL, 8);
+
+            continue;
+        }
+
+        if (nxt_strcmp(p, "--control-user") == 0) {
+            if (*argv == NULL) {
+                write(STDERR_FILENO, no_control_user,
+                      nxt_length(no_control_user));
+                return NXT_ERROR;
+            }
+
+            p = *argv++;
+
+            rt->control_user = p;
+
+            continue;
+        }
+
+        if (nxt_strcmp(p, "--control-group") == 0) {
+            if (*argv == NULL) {
+                write(STDERR_FILENO, no_control_group,
+                      nxt_length(no_control_group));
+                return NXT_ERROR;
+            }
+
+            p = *argv++;
+
+            rt->control_group = p;
 
             continue;
         }

--- a/src/nxt_runtime.h
+++ b/src/nxt_runtime.h
@@ -70,8 +70,12 @@ struct nxt_runtime_s {
     const char             *ver_tmp;
     const char             *conf;
     const char             *conf_tmp;
-    const char             *control;
     const char             *tmp;
+    const char             *control;
+
+    mode_t                 control_mode;
+    const char             *control_user;
+    const char             *control_group;
 
     nxt_str_t              certs;
     nxt_str_t              scripts;

--- a/tools/unitc
+++ b/tools/unitc
@@ -186,9 +186,9 @@ if [ $REMOTE -eq 0 ]; then
 			echo "${0##*/}: WARNING: unable to identify unitd command line parameters for PID $PID, assuming unitd defaults from \$PATH"
 			PARAMS=unitd
 		fi
-		CTRL_ADDR=$(echo "$PARAMS" | grep '\--control' | cut -f2 -d' ')
+		CTRL_ADDR=$(echo "$PARAMS" | grep '\--control ' | cut -f2 -d' ')
 		if [ "$CTRL_ADDR" = "" ]; then
-			CTRL_ADDR=$($(echo "$PARAMS") --help | grep -A1 '\--control' | tail -1 | cut -f2 -d\")
+			CTRL_ADDR=$($(echo "$PARAMS") --help | grep -A1 '\--control ADDRESS' | tail -1 | cut -f2 -d\")
 		fi
 		if [ "$CTRL_ADDR" = "" ]; then
 			echo "${0##*/}: ERROR: cannot detect control socket. Did you start unitd with a relative path? Try starting unitd with --control option."


### PR DESCRIPTION
This PR comprises four patches...

1) Add nxt_file_chown().

This adds a wrapper around [chown(2)](https://man7.org/linux/man-pages/man2/chown.2.html). It's slightly long-winded due to using the thread safe versions ([getpwnnam_r(3)](https://man7.org/linux/man-pages/man3/getpwnam_r.3.html) & [getgrnam_r(3)](https://man7.org/linux/man-pages/man3/getgrnam_r.3.html)) of [getpwnam(3)](https://man7.org/linux/man-pages/man3/getpwnam.3.html) & [getgrnam(3)](https://man7.org/linux/man-pages/man3/getgrnam.3.html).

2) Allow to set the permissions of the Unix domain control socket.

This allows the user to set the file mode, owner & group of the UNIX domain control socket via three new options; `--control-mode`, `--control-user` & `--control-group`.

Any combination of the above can be used. `mode` is standard octal format, e.g `660`.

3) Docs: Update man page for new --control-* options.

Yeah...

4) Tools: disambiguate unitc control socket detection.

Update to `unitc` from @lcrilly due to `--control` now being ambiguous in terms of a unitd options search string.