### PR TITLE
Explicitly build with -std=gnu11 (C11 with GNU extensions)

### DIFF
--- a/auto/cc/test
+++ b/auto/cc/test
@@ -67,8 +67,7 @@ case $NXT_CC_NAME in
 
         NXT_CFLAGS="$NXT_CFLAGS -fno-strict-overflow"
 
-        # c99/gnu99 conflict with Solaris XOPEN.
-        #NXT_CFLAGS="$NXT_CFLAGS -std=gnu99"
+        NXT_CFLAGS="$NXT_CFLAGS -std=gnu11"
 
         NXT_CFLAGS="$NXT_CFLAGS -O"
         NXT_CFLAGS="$NXT_CFLAGS -Wall -Wextra"
@@ -109,6 +108,8 @@ case $NXT_CC_NAME in
         NXT_CFLAGS="$NXT_CFLAGS -fvisibility=hidden"
 
         NXT_CFLAGS="$NXT_CFLAGS -fno-strict-overflow"
+
+        NXT_CFLAGS="$NXT_CFLAGS -std=gnu11"
 
         NXT_CFLAGS="$NXT_CFLAGS -O"
         NXT_CFLAGS="$NXT_CFLAGS -Wall -Wextra"


### PR DESCRIPTION
Currently Unit doesn't specify any specific C standard for compiling and will thus be compiled under whatever the compiler happens to default to.

For most recent'ish compilers that will be gnu11/17 (C11/17 + GNU extensions).

For some of the oldest still-supported systems, e.g RHEL/CentOS 7 and Debian 8 that will be gnu90 (with GCC 4.8.x).

Up until now this hasn't really been an issue and we have been able to use some C99 features that are implemented as GNU extensions in older compilers, e.g

  -  designated initializers
  -  flexible array members
  -  trailing comma in enum declaration (compiles with -std=c89, warns with -std=c89 -pedantic)
  -  snprintf(3)
  -  long long (well we test for it but don't actually use it)
  -  bool / stdbool.h
  -  variadic macros

However there are a couple of C99 features that aren't GNU extensions that would be handy to be able to use, i.e

 -  The ability to declare variables inside for () loops, e.g

        for (int i = 0; ...; ...)

 -  C99 inline functions (not to be confused with what's available with -std=gnu89).

However, if we are going to switch up to C99, then perhaps we should just leap frog to C11 instead (the Linux Kernel did in fact make the switch from gnu89 to gnu11 in March '22).

GCC 4.8 as in CentOS 7 & Debian 8 has *some* support for C11, so while we can make full use of C99, we couldn't yet make full use of C11, but in a few years when those systems go EOL we will no longer have that restriction and in the meantime we can restrict ourselves to the supported set of features (or implement fallbacks where appropriate).

It can only be a benefit that we would be compiling Unit consistently under the same language standard.

This will also help give the impression that Unit is a modern C code base.