### PR TITLE
Go: Use Homebrew include paths

### DIFF
--- a/go/ldflags-darwin.go
+++ b/go/ldflags-darwin.go
@@ -1,0 +1,14 @@
+//go:build darwin
+
+/*
+ * Copyright (C) Danielle De Leo
+ * Copyright (C) NGINX, Inc.
+ */
+
+package unit
+
+/*
+#cgo LDFLAGS: -L/opt/homebrew/lib
+#cgo CFLAGS: -I/opt/homebrew/include
+*/
+import "C"


### PR DESCRIPTION
This patch adds include paths for `libunit` installed via Homebrew only when built on Darwin (macOS). I don't know if Linux Homebrew uses the same paths, so this shouldn't get in the way in that edge case.

Small note, the syntax used on line 1 is the preferred syntax as of go1.18 and the old style of `// +build` should be `go fix`d across the repository in the future.

Fixes nginx/unit#967