### PR TITLE
Add additional replace rules for node:* modules to custom unit node loaders.

### DIFF
--- a/src/nodejs/unit-http/loader.js
+++ b/src/nodejs/unit-http/loader.js
@@ -11,10 +11,12 @@ if (module.parent && module.parent.id === "internal/preload") {
         Module.prototype.require = function (id) {
             switch(id) {
                 case "http":
+                case "node:http":
                 case "unit-http":
                     return http
 
                 case "websocket":
+                case "node:websocket":
                 case "unit-http/websocket":
                     return websocket
             }

--- a/src/nodejs/unit-http/loader.mjs
+++ b/src/nodejs/unit-http/loader.mjs
@@ -2,6 +2,7 @@
 export async function resolve(specifier, context, defaultResolver) {
     switch (specifier) {
         case "websocket":
+        case "node:websocket":
             return {
                 url: new URL("./websocket.js", import.meta.url).href,
                 format: "commonjs",
@@ -9,6 +10,7 @@ export async function resolve(specifier, context, defaultResolver) {
             }
 
         case "http":
+        case "node:http":
             return {
                 url: new URL("./http.js", import.meta.url).href,
                 format: "commonjs",


### PR DESCRIPTION
Closes: <https://github.com/nginx/unit/issues/1013>

In that particular issue the compiled nuxt files end up importing the http module as `node:http` rather than `http` only. This bypasses unit's custom loader implementation which only check for the `http` or `unit-http` modules, and their websocket counterparts.

This changeset adds replace sources for both the `node:http` and `node:websocket` import signatures.