### PR TITLE
HTTP: added TSTR validation flag to the rewrite option.

### DIFF
--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -690,6 +690,7 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_action_common_members[] = {
     {
         .name       = nxt_string("rewrite"),
         .type       = NXT_CONF_VLDT_STRING,
+        .flags      = NXT_CONF_VLDT_TSTR,
     },
     {
         .name       = nxt_string("response_headers"),


### PR DESCRIPTION
Take the configuration as an example:
```
{
    "rewrite": "`${foo + "
}
```
Before it was compiled in the router process with a simple error message:
```
failed to apply previous configuration
```
It should be checked in the controller process with the error message:
```
the previous configuration is invalid: "SyntaxError: Unexpected end of input in default:1" in the "rewrite" value.
```