### PR TITLE
NJS variable access support.

### DIFF
--- a/docs/changes.xml
+++ b/docs/changes.xml
@@ -67,6 +67,12 @@ conditional access logging.
 
 <change type="feature">
 <para>
+NJS variables access.
+</para>
+</change>
+
+<change type="feature">
+<para>
 $request_id variable contains a string that is formed using random data and
 can be used as a unique request identifier.
 </para>

--- a/src/nxt_http_variables.c
+++ b/src/nxt_http_variables.c
@@ -135,8 +135,7 @@ nxt_http_register_variables(void)
 
 
 nxt_int_t
-nxt_http_unknown_var_ref(nxt_tstr_state_t *state, nxt_var_ref_t *ref,
-    nxt_str_t *name)
+nxt_http_unknown_var_ref(nxt_mp_t *mp, nxt_var_ref_t *ref, nxt_str_t *name)
 {
     int64_t    hash;
     nxt_str_t  str, *lower;
@@ -152,7 +151,7 @@ nxt_http_unknown_var_ref(nxt_tstr_state_t *state, nxt_var_ref_t *ref,
             return NXT_ERROR;
         }
 
-        lower = nxt_str_alloc(state->pool, str.length);
+        lower = nxt_str_alloc(mp, str.length);
         if (nxt_slow_path(lower == NULL)) {
             return NXT_ERROR;
         }
@@ -175,7 +174,7 @@ nxt_http_unknown_var_ref(nxt_tstr_state_t *state, nxt_var_ref_t *ref,
             return NXT_ERROR;
         }
 
-        hash = nxt_http_header_hash(state->pool, &str);
+        hash = nxt_http_header_hash(mp, &str);
         if (nxt_slow_path(hash == -1)) {
             return NXT_ERROR;
         }
@@ -191,7 +190,7 @@ nxt_http_unknown_var_ref(nxt_tstr_state_t *state, nxt_var_ref_t *ref,
             return NXT_ERROR;
         }
 
-        hash = nxt_http_argument_hash(state->pool, &str);
+        hash = nxt_http_argument_hash(mp, &str);
         if (nxt_slow_path(hash == -1)) {
             return NXT_ERROR;
         }
@@ -207,7 +206,7 @@ nxt_http_unknown_var_ref(nxt_tstr_state_t *state, nxt_var_ref_t *ref,
             return NXT_ERROR;
         }
 
-        hash = nxt_http_cookie_hash(state->pool, &str);
+        hash = nxt_http_cookie_hash(mp, &str);
         if (nxt_slow_path(hash == -1)) {
             return NXT_ERROR;
         }
@@ -216,7 +215,7 @@ nxt_http_unknown_var_ref(nxt_tstr_state_t *state, nxt_var_ref_t *ref,
         return NXT_ERROR;
     }
 
-    ref->data = nxt_var_field_new(state->pool, &str, (uint32_t) hash);
+    ref->data = nxt_var_field_new(mp, &str, (uint32_t) hash);
     if (nxt_slow_path(ref->data == NULL)) {
         return NXT_ERROR;
     }

--- a/src/nxt_js.c
+++ b/src/nxt_js.c
@@ -240,7 +240,7 @@ nxt_js_add_tpl(nxt_js_conf_t *jcf, nxt_str_t *str, nxt_bool_t strz)
     nxt_str_t  *func;
 
     static nxt_str_t  func_str = nxt_string("function(uri, host, remoteAddr, "
-                                            "args, headers, cookies) {"
+                                            "args, headers, cookies, vars) {"
                                             "    return ");
 
     /*
@@ -391,7 +391,7 @@ nxt_js_call(nxt_task_t *task, nxt_js_conf_t *jcf, nxt_js_cache_t *cache,
     njs_uint_t          i, n;
     njs_value_t         *value;
     njs_function_t      *func;
-    njs_opaque_value_t  retval, opaque_value, arguments[6];
+    njs_opaque_value_t  retval, opaque_value, arguments[7];
 
     static const njs_str_t  js_args[] = {
         njs_str("uri"),
@@ -400,6 +400,7 @@ nxt_js_call(nxt_task_t *task, nxt_js_conf_t *jcf, nxt_js_cache_t *cache,
         njs_str("args"),
         njs_str("headers"),
         njs_str("cookies"),
+        njs_str("vars"),
     };
 
     vm = cache->vm;

--- a/src/nxt_js.c
+++ b/src/nxt_js.c
@@ -388,16 +388,19 @@ nxt_js_call(nxt_task_t *task, nxt_js_conf_t *jcf, nxt_js_cache_t *cache,
     njs_vm_t            *vm;
     njs_int_t           ret;
     njs_str_t           res;
+    njs_uint_t          i, n;
     njs_value_t         *value;
     njs_function_t      *func;
     njs_opaque_value_t  retval, opaque_value, arguments[6];
 
-    static const njs_str_t  uri_str = njs_str("uri");
-    static const njs_str_t  host_str = njs_str("host");
-    static const njs_str_t  remote_addr_str = njs_str("remoteAddr");
-    static const njs_str_t  args_str = njs_str("args");
-    static const njs_str_t  headers_str = njs_str("headers");
-    static const njs_str_t  cookies_str = njs_str("cookies");
+    static const njs_str_t  js_args[] = {
+        njs_str("uri"),
+        njs_str("host"),
+        njs_str("remoteAddr"),
+        njs_str("args"),
+        njs_str("headers"),
+        njs_str("cookies"),
+    };
 
     vm = cache->vm;
 
@@ -424,43 +427,17 @@ nxt_js_call(nxt_task_t *task, nxt_js_conf_t *jcf, nxt_js_cache_t *cache,
         return NXT_ERROR;
     }
 
-    value = njs_vm_object_prop(vm, njs_value_arg(&opaque_value), &uri_str,
-                               &arguments[0]);
-    if (nxt_slow_path(value == NULL)) {
-        return NXT_ERROR;
+    n = nxt_nitems(js_args);
+
+    for (i = 0; i < n; i++) {
+        value = njs_vm_object_prop(vm, njs_value_arg(&opaque_value),
+                                   &js_args[i], &arguments[i]);
+        if (nxt_slow_path(value == NULL)) {
+            return NXT_ERROR;
+        }
     }
 
-    value = njs_vm_object_prop(vm, njs_value_arg(&opaque_value), &host_str,
-                               &arguments[1]);
-    if (nxt_slow_path(value == NULL)) {
-        return NXT_ERROR;
-    }
-
-    value = njs_vm_object_prop(vm, njs_value_arg(&opaque_value),
-                               &remote_addr_str, &arguments[2]);
-    if (nxt_slow_path(value == NULL)) {
-        return NXT_ERROR;
-    }
-
-    value = njs_vm_object_prop(vm, njs_value_arg(&opaque_value), &args_str,
-                               &arguments[3]);
-    if (nxt_slow_path(value == NULL)) {
-        return NXT_ERROR;
-    }
-
-    value = njs_vm_object_prop(vm, njs_value_arg(&opaque_value), &headers_str,
-                               &arguments[4]);
-    if (nxt_slow_path(value == NULL)) {
-        return NXT_ERROR;
-    }
-
-    value = njs_vm_object_prop(vm, njs_value_arg(&opaque_value), &cookies_str,
-                               &arguments[5]);
-    if (nxt_slow_path(value == NULL)) {
-        return NXT_ERROR;
-    }
-
-    ret = njs_vm_invoke(vm, func, njs_value_arg(&arguments), 6,
+    ret = njs_vm_invoke(vm, func, njs_value_arg(&arguments), n,
                         njs_value_arg(&retval));
 
     if (ret != NJS_OK) {

--- a/src/nxt_var.c
+++ b/src/nxt_var.c
@@ -132,22 +132,24 @@ nxt_var_ref_get(nxt_tstr_state_t *state, nxt_str_t *name)
 
     ref->index = state->var_refs->nelts - 1;
 
-    ref->name = nxt_str_dup(state->pool, NULL, name);
-    if (nxt_slow_path(ref->name == NULL)) {
-        return NULL;
-    }
-
     decl = nxt_var_hash_find(name);
 
     if (decl != NULL) {
         ref->handler = decl->handler;
         ref->cacheable = decl->cacheable;
 
-        return ref;
+        goto done;
     }
 
     ret = nxt_http_unknown_var_ref(state, ref, name);
     if (nxt_slow_path(ret != NXT_OK)) {
+        return NULL;
+    }
+
+done:
+
+    ref->name = nxt_str_dup(state->pool, NULL, name);
+    if (nxt_slow_path(ref->name == NULL)) {
         return NULL;
     }
 

--- a/src/nxt_var.c
+++ b/src/nxt_var.c
@@ -141,7 +141,7 @@ nxt_var_ref_get(nxt_tstr_state_t *state, nxt_str_t *name)
         goto done;
     }
 
-    ret = nxt_http_unknown_var_ref(state, ref, name);
+    ret = nxt_http_unknown_var_ref(state->pool, ref, name);
     if (nxt_slow_path(ret != NXT_OK)) {
         return NULL;
     }

--- a/src/nxt_var.h
+++ b/src/nxt_var.h
@@ -62,7 +62,7 @@ nxt_int_t nxt_var_interpreter(nxt_task_t *task, nxt_tstr_state_t *state,
 nxt_str_t *nxt_var_get(nxt_task_t *task, nxt_var_cache_t *cache,
     nxt_str_t *name, void *ctx);
 
-nxt_int_t nxt_http_unknown_var_ref(nxt_tstr_state_t *state, nxt_var_ref_t *ref,
+nxt_int_t nxt_http_unknown_var_ref(nxt_mp_t *mp, nxt_var_ref_t *ref,
     nxt_str_t *name);
 
 

--- a/src/nxt_var.h
+++ b/src/nxt_var.h
@@ -59,8 +59,8 @@ nxt_int_t nxt_var_test(nxt_tstr_state_t *state, nxt_str_t *str, u_char *error);
 nxt_int_t nxt_var_interpreter(nxt_task_t *task, nxt_tstr_state_t *state,
     nxt_var_cache_t *cache, nxt_var_t *var, nxt_str_t *str, void *ctx,
     nxt_bool_t logging);
-nxt_str_t *nxt_var_get(nxt_task_t *task, nxt_var_cache_t *cache,
-    nxt_str_t *name, void *ctx);
+nxt_str_t *nxt_var_get(nxt_task_t *task, nxt_tstr_state_t *state,
+    nxt_var_cache_t *cache, nxt_str_t *name, void *ctx);
 
 nxt_int_t nxt_http_unknown_var_ref(nxt_mp_t *mp, nxt_var_ref_t *ref,
     nxt_str_t *name);


### PR DESCRIPTION
This PR is to introduce the feature of njs variable access. Here are 3 commits:
1. Generalize nxt_var_cache_value() to get variables via string names beside the reference index.
2. Introduce nxt_var_get() to access variables via string names, it'll be used in the next commit of access variables with njs.
3. njs variable access support.

Note, in the configuration, option values like `some $uri text`, and the part `uri` which is a variable name turned into an internal reference index for performance optimization. For the new feature, users can write JS code like `${uri}` in the configuration, the script is parsed with njs library, so it can only access variable with a string name `uri`.

So we need to support two ways of accessing variables: ref index and string name.