### PR TITLE
Fix compiling against njs 0.8.3

### DIFF
--- a/src/nxt_js.c
+++ b/src/nxt_js.c
@@ -70,8 +70,6 @@ nxt_js_module_loader(njs_vm_t *vm, njs_external_ptr_t external, njs_str_t *name)
 
 
 static njs_vm_ops_t  nxt_js_ops = {
-    NULL,
-    NULL,
     nxt_js_module_loader,
     NULL,
 };

--- a/src/nxt_script.c
+++ b/src/nxt_script.c
@@ -38,8 +38,6 @@ static nxt_lvlhsh_t  nxt_script_info;
 
 
 static njs_vm_ops_t  nxt_js_ops = {
-    NULL,
-    NULL,
     nxt_js_module_loader,
     NULL,
 };


### PR DESCRIPTION
> [!NOTE]
> This PR applies to NJS _0.8.3_, not earlier versions.
> Original comment follows.

As [@hongzhidao](https://github.com/nginx/unit/discussions/1026#discussioncomment-7837216) noted, Unit 1.31 should use njs 0.8.1. This commit removes two NULL parameter when creating a `struct njs_vm_ops_t` variable in `nxt_script.c`  and `nxt_js.c` to comply with `njs_vm_ops_t` definition in `njs.h` from njs 0.8.2