### PR TITLE
simplify package dependency

### DIFF
--- a/pkg/rpm/unit.module.spec.in
+++ b/pkg/rpm/unit.module.spec.in
@@ -39,7 +39,7 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires: pcre2-devel
 
-Requires: unit-r%%UNIT_VERSION%%
+Requires: unit = %{version}
 
 %description
 NGINX Unit is a runtime and delivery environment for modern distributed

--- a/pkg/rpm/unit.spec.in
+++ b/pkg/rpm/unit.spec.in
@@ -50,8 +50,6 @@ BuildRequires: pkgconfig
 BuildRequires: clang
 BuildRequires: llvm
 
-Provides: unit-r%{version}
-
 %description
 NGINX Unit is a runtime and delivery environment for modern distributed
 applications. It runs the application code in multiple languages


### PR DESCRIPTION
the `unit-r1.31.1` was introduced in 2ac4a7527

`Requires: unit = %{version}` is simpler, allows any release of the same version, and avoids additional metadata



A specific virtual provide will make sense for an API number  (for the future)

Example in unit
`Provides: unit(ABI) = 12`

Example for module
```
BuildRequires: unit-devel
Requires: unit(ABI) = %{unit_abi} 
```
`%{unit_api} `being defined in a rpm macro file provided by unit-devel
