### PR TITLE
HTTP: enhanced access log with conditional filtering.

### DIFF
--- a/src/nxt_http_request.c
+++ b/src/nxt_http_request.c
@@ -24,8 +24,8 @@ static void nxt_http_request_proto_info(nxt_task_t *task,
 static void nxt_http_request_mem_buf_completion(nxt_task_t *task, void *obj,
     void *data);
 static void nxt_http_request_done(nxt_task_t *task, void *obj, void *data);
-static void nxt_http_request_access_log(nxt_task_t *task, nxt_http_request_t *r,
-    nxt_router_conf_t *rtcf);
+static nxt_int_t nxt_http_request_access_log(nxt_task_t *task,
+    nxt_http_request_t *r, nxt_router_conf_t *rtcf);
 
 static u_char *nxt_http_date_cache_handler(u_char *buf, nxt_realtime_t *now,
     struct tm *tm, size_t size, const char *format);
@@ -818,6 +818,7 @@ nxt_http_request_error_handler(nxt_task_t *task, void *obj, void *data)
 void
 nxt_http_request_close_handler(nxt_task_t *task, void *obj, void *data)
 {
+    nxt_int_t                ret;
     nxt_http_proto_t         proto;
     nxt_router_conf_t        *rtcf;
     nxt_http_request_t       *r;
@@ -834,8 +835,10 @@ nxt_http_request_close_handler(nxt_task_t *task, void *obj, void *data)
         r->logged = 1;
 
         if (rtcf->access_log != NULL) {
-            nxt_http_request_access_log(task, r, rtcf);
-            return;
+            ret = nxt_http_request_access_log(task, r, rtcf);
+            if (ret == NXT_OK) {
+                return;
+            }
         }
     }
 
@@ -865,15 +868,54 @@ nxt_http_request_close_handler(nxt_task_t *task, void *obj, void *data)
 }
 
 
-static void
+static nxt_int_t
 nxt_http_request_access_log(nxt_task_t *task, nxt_http_request_t *r,
     nxt_router_conf_t *rtcf)
 {
+    nxt_int_t                ret;
+    nxt_str_t                str;
+    nxt_bool_t               expr;
     nxt_router_access_log_t  *access_log;
 
     access_log = rtcf->access_log;
 
-    access_log->handler(task, r, access_log, rtcf->log_format);
+    expr = 1;
+
+    if (rtcf->log_expr != NULL) {
+
+        if (nxt_tstr_is_const(rtcf->log_expr)) {
+            nxt_tstr_str(rtcf->log_expr, &str);
+
+        } else {
+            ret = nxt_tstr_query_init(&r->tstr_query, rtcf->tstr_state,
+                                      &r->tstr_cache, r, r->mem_pool);
+            if (nxt_slow_path(ret != NXT_OK)) {
+                return NXT_DECLINED;
+            }
+
+            nxt_tstr_query(task, r->tstr_query, rtcf->log_expr, &str);
+
+            if (nxt_slow_path(nxt_tstr_query_failed(r->tstr_query))) {
+                return NXT_DECLINED;
+            }
+        }
+
+        if (str.length == 0
+            || nxt_str_eq(&str, "0", 1)
+            || nxt_str_eq(&str, "false", 5)
+            || nxt_str_eq(&str, "null", 4)
+            || nxt_str_eq(&str, "undefined", 9))
+        {
+            expr = 0;
+        }
+    }
+
+    if (rtcf->log_negate ^ expr) {
+        access_log->handler(task, r, access_log, rtcf->log_format);
+        return NXT_OK;
+    }
+
+    return NXT_DECLINED;
 }
 
 

--- a/src/nxt_router.h
+++ b/src/nxt_router.h
@@ -54,6 +54,8 @@ typedef struct {
 
     nxt_router_access_log_t  *access_log;
     nxt_tstr_t               *log_format;
+    nxt_tstr_t               *log_expr;
+    uint8_t                  log_negate;  /* 1 bit */
 } nxt_router_conf_t;
 
 


### PR DESCRIPTION
HTTP: enhanced access log with conditional filtering.
This feature allows users to specify conditions to control if access log
should be recorded. The "if" option supports a string and JavaScript code.
If its value is empty, 0, false, null, or undefined, the logs will not be
recorded. And the '!' as a prefix inverses the condition.

For example:
```
    {
      	"access_log": {
	    "if": "`${new Date().getHours() < 22}`",
	    "path": "/path/access.log"
      	}
    }
```
Or
```
    {
      	"access_log": {
	    "if": "!`${new Date().getHours() >= 22}`",
	    "path": "/path/access.log"
      	}
    }
```
If the current hour is less than 22, the logs will be recorded.

Closes: <https://github.com/nginx/unit/issues/594>