### PR TITLE
Replaced slack community links with GitHub Discussions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Check out the [Quick Installation](README.md#quick-installation) and
 
 Please open an [issue](https://github.com/nginx/unit/issues/new) on GitHub with
 the label `question`.  You can also ask a question on
-[Slack](https://nginxcommunity.slack.com) or the NGINX Unit mailing list,
+[GitHub Discussions](https://github.com/nginx/unit/discussions) or the NGINX Unit mailing list,
 unit@nginx.org (subscribe
 [here](https://mailman.nginx.org/mailman3/lists/unit.nginx.org/)).
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ usability.
 ## Community
 
 - The go-to place to start asking questions and share your thoughts is
-  our [Slack channel](https://community.nginx.org/joinslack).
+ [GitHub Discussions](https://github.com/nginx/unit/discussions).
 
 - Our [GitHub issues page](https://github.com/nginx/unit/issues) offers
   space for a more technical discussion at your own pace.


### PR DESCRIPTION
Replaced Slack Community links with and redirected to GitHub Discussions as per this conversation https://github.com/nginx/unit/pull/1049#issuecomment-1881957291