### PR TITLE
Go: Add missing +build and go:build comments

### DIFF
--- a/go/ldflags-darwin.go
+++ b/go/ldflags-darwin.go
@@ -1,4 +1,5 @@
 //go:build darwin
+// +build darwin
 
 /*
  * Copyright (C) Danielle De Leo

--- a/go/ldflags-lrt.go
+++ b/go/ldflags-lrt.go
@@ -1,3 +1,4 @@
+//go:build linux || netbsd
 // +build linux netbsd
 
 /*


### PR DESCRIPTION
A RHEL 8 test was failing because it uses go1.16. The old style must be retained for backwards compat.