### PR TITLE
Docker: Add a new target for generic language versions

### DIFF
--- a/pkg/docker/Makefile
+++ b/pkg/docker/Makefile
@@ -8,6 +8,8 @@ DEFAULT_VERSION := $(NXT_VERSION)
 VERSION ?= $(DEFAULT_VERSION)
 PATCHLEVEL ?= 1
 
+MODULE   =
+
 MODULES ?= go jsc node perl php python ruby wasm
 
 VARIANT ?= bullseye
@@ -105,7 +107,7 @@ export RUST_VERSION=1.71.0 \\\n \
 endef
 
 default:
-	@echo "valid targets: all build dockerfiles library clean"
+	@echo "valid targets: all build gen-<target> dockerfiles library clean"
 
 MODVERSIONS = $(foreach module, $(MODULES), $(foreach modversion, $(shell for v in $(VERSIONS_$(module)); do echo $$v; done | sort -r), $(module)$(modversion))) wasm minimal
 
@@ -130,6 +132,27 @@ Dockerfile.%: ../../version template.Dockerfile
 build-%: Dockerfile.%
 	docker pull $(CONTAINER_$*)
 	docker build --no-cache -t unit:$(VERSION)-$* -f Dockerfile.$* .
+
+gen-%: ../../version template.Dockerfile
+ifeq ($(MODULE), )
+	@echo "MODULE not set, set it to one of the following:"
+	@echo "    $(MODULES)"
+	@false
+else
+	@echo "===> Building Dockerfile.$*"
+	cat template.Dockerfile | sed \
+		-e 's,@@VERSION@@,$(VERSION),g' \
+		-e 's,@@PATCHLEVEL@@,$(PATCHLEVEL),g' \
+		-e 's,@@CONTAINER@@,$(CONTAINER_$*),g' \
+		-e 's,@@CONFIGURE@@,$(CONFIGURE_$(MODULE)),g' \
+		-e 's,@@INSTALL@@,$(INSTALL_$(MODULE)),g' \
+		-e 's,@@RUN@@,$(RUN_$(MODULE)),g' \
+		-e 's,@@MODULE_PREBUILD@@,$(MODULE_PREBUILD_$(MODULE)),g' \
+		-e 's,@@MODULE@@,$*,g' \
+		> Dockerfile.$*
+	docker pull $(CONTAINER_$*)
+	docker build --no-cache -t unit:$(VERSION)-$* -f Dockerfile.$* .
+endif
 
 library:
 	@echo "# this file is generated via https://github.com/nginx/unit/blob/$(shell git describe --always --abbrev=0 HEAD)/pkg/docker/Makefile"


### PR DESCRIPTION
You can use the Docker Makefile to create dockerfiles for specific language environments, e.g

  $ make build-python3.12 VERSIONS_python=3.12

However this breaks when trying to do something like

  $ make build-php8.3.0RC6 VERSIONS_php=8.3.0RC6 VARIANT_php=cli

This breaks due to the RC in the version, due to how we're trying to parse out the module name from the version string, we strip out anything that is a 0-9 or a . or -.

That works for 'python3.12' leaving 'python'. However for 'php8.3.0RC6' that leaves 'phpRC'.

After spending some time on this, the best (and simplest) solution I could come up with, that doesn't break existing usage, is to create a new make target for this.

So the above now becomes

  $ make gen-php8.3.0RC6 MODULE=php VERSIONS_php=8.3.0RC6 VARIANT_php=cli

The new target is gen-<language version> and you need to specify the language module.