### PR TITLE
Hardening: ensure correct handling of NUL in some nxt_str_t, by using a distinct type

### DIFF
--- a/src/nxt_file.c
+++ b/src/nxt_file.c
@@ -298,7 +298,7 @@ nxt_file_info(nxt_file_t *file, nxt_file_info_t *fi)
 
 
 nxt_int_t
-nxt_file_delete(nxt_file_name_t *name)
+nxt_file_delete(const nxt_file_name_t *name)
 {
     nxt_thread_log_debug("unlink(\"%FN\")", name);
 
@@ -326,7 +326,8 @@ nxt_file_set_access(nxt_file_name_t *name, nxt_file_access_t access)
 
 
 nxt_int_t
-nxt_file_rename(nxt_file_name_t *old_name, nxt_file_name_t *new_name)
+nxt_file_rename(const nxt_file_name_t *old_name,
+    const nxt_file_name_t *new_name)
 {
     int  ret;
 
@@ -445,7 +446,7 @@ nxt_fd_blocking(nxt_task_t *task, nxt_fd_t fd)
 
 
 ssize_t
-nxt_fd_write(nxt_fd_t fd, u_char *buf, size_t size)
+nxt_fd_write(nxt_fd_t fd, const u_char *buf, size_t size)
 {
     ssize_t    n;
     nxt_err_t  err;

--- a/src/nxt_file.h
+++ b/src/nxt_file.h
@@ -73,7 +73,7 @@ typedef enum {
 
 
 typedef struct {
-    nxt_file_name_t                 *name;
+    const nxt_file_name_t           *name;
 
     /* Both are int's. */
     nxt_fd_t                        fd;
@@ -174,15 +174,15 @@ NXT_EXPORT nxt_int_t nxt_file_info(nxt_file_t *file, nxt_file_info_t *fi);
     (fi)->st_mtime
 
 
-NXT_EXPORT nxt_int_t nxt_file_delete(nxt_file_name_t *name);
+NXT_EXPORT nxt_int_t nxt_file_delete(const nxt_file_name_t *name);
 NXT_EXPORT nxt_int_t nxt_file_set_access(nxt_file_name_t *name,
     nxt_file_access_t access);
-NXT_EXPORT nxt_int_t nxt_file_rename(nxt_file_name_t *old_name,
-    nxt_file_name_t *new_name);
+NXT_EXPORT nxt_int_t nxt_file_rename(const nxt_file_name_t *old_name,
+    const nxt_file_name_t *new_name);
 
 NXT_EXPORT nxt_int_t nxt_fd_nonblocking(nxt_task_t *task, nxt_fd_t fd);
 NXT_EXPORT nxt_int_t nxt_fd_blocking(nxt_task_t *task, nxt_fd_t fd);
-NXT_EXPORT ssize_t nxt_fd_write(nxt_fd_t fd, u_char *buf, size_t size);
+NXT_EXPORT ssize_t nxt_fd_write(nxt_fd_t fd, const u_char *buf, size_t size);
 NXT_EXPORT ssize_t nxt_fd_read(nxt_fd_t fd, u_char *buf, size_t size);
 NXT_EXPORT void nxt_fd_close(nxt_fd_t fd);
 

--- a/src/nxt_http.h
+++ b/src/nxt_http.h
@@ -253,7 +253,7 @@ struct nxt_http_action_s {
         nxt_upstream_t              *upstream;
         uint32_t                    upstream_number;
         nxt_tstr_t                  *tstr;
-        nxt_str_t                   *pass;
+        nxt_strz_t                  *pass;
     } u;
 
     nxt_tstr_t                      *rewrite;

--- a/src/nxt_http.h
+++ b/src/nxt_http.h
@@ -360,7 +360,7 @@ nxt_http_action_t *nxt_http_action_create(nxt_task_t *task,
     nxt_router_temp_conf_t *tmcf, nxt_str_t *pass);
 nxt_int_t nxt_http_routes_resolve(nxt_task_t *task,
     nxt_router_temp_conf_t *tmcf);
-nxt_int_t nxt_http_pass_segments(nxt_mp_t *mp, nxt_str_t *pass,
+nxt_int_t nxt_http_pass_segments(nxt_mp_t *mp, const nxt_str_t *pass,
     nxt_str_t *segments, nxt_uint_t n);
 nxt_http_action_t *nxt_http_pass_application(nxt_task_t *task,
     nxt_router_conf_t *rtcf, nxt_str_t *name);

--- a/src/nxt_http_return.c
+++ b/src/nxt_http_return.c
@@ -87,7 +87,7 @@ nxt_http_return(nxt_task_t *task, nxt_http_request_t *r,
     nxt_strz_t  loc;
 
     if (conf->location == NULL) {
-        nxt_str_set(&loc, "");
+        nxt_str_set(&loc.z, "");
 
     } else {
         nxt_tstr_str(conf->location, &loc);
@@ -186,7 +186,7 @@ nxt_http_return_send_ready(nxt_task_t *task, void *obj, void *data)
     ctx = data;
 
     if (ctx != NULL) {
-        if (ctx->location.length > 0) {
+        if (ctx->location.zlength > 0) {
             ret = nxt_http_return_encode(r->mem_pool, &ctx->encoded,
                                          &ctx->location.s);
             if (nxt_slow_path(ret == NXT_ERROR)) {

--- a/src/nxt_http_return.c
+++ b/src/nxt_http_return.c
@@ -15,7 +15,7 @@ typedef struct {
 
 
 typedef struct {
-    nxt_str_t          location;
+    nxt_strz_t         location;
     nxt_str_t          encoded;
 } nxt_http_return_ctx_t;
 
@@ -37,6 +37,7 @@ nxt_http_return_init(nxt_router_conf_t *rtcf, nxt_http_action_t *action,
 {
     nxt_mp_t                *mp;
     nxt_str_t               str;
+    nxt_strz_t              strz;
     nxt_http_return_conf_t  *conf;
 
     mp = rtcf->mem_pool;
@@ -63,8 +64,8 @@ nxt_http_return_init(nxt_router_conf_t *rtcf, nxt_http_action_t *action,
     }
 
     if (nxt_tstr_is_const(conf->location)) {
-        nxt_tstr_str(conf->location, &str);
-        return nxt_http_return_encode(mp, &conf->encoded, &str);
+        nxt_tstr_str(conf->location, &strz);
+        return nxt_http_return_encode(mp, &conf->encoded, &strz.s);
     }
 
     return NXT_OK;
@@ -83,7 +84,7 @@ nxt_http_return(nxt_task_t *task, nxt_http_request_t *r,
     conf = action->u.conf;
 
 #if (NXT_DEBUG)
-    nxt_str_t  loc;
+    nxt_strz_t  loc;
 
     if (conf->location == NULL) {
         nxt_str_set(&loc, "");
@@ -92,7 +93,7 @@ nxt_http_return(nxt_task_t *task, nxt_http_request_t *r,
         nxt_tstr_str(conf->location, &loc);
     }
 
-    nxt_debug(task, "http return: %d (loc: \"%V\")", conf->status, &loc);
+    nxt_debug(task, "http return: %d (loc: \"%V\")", conf->status, &loc.s);
 #endif
 
     if (conf->status >= NXT_HTTP_BAD_REQUEST
@@ -187,7 +188,7 @@ nxt_http_return_send_ready(nxt_task_t *task, void *obj, void *data)
     if (ctx != NULL) {
         if (ctx->location.length > 0) {
             ret = nxt_http_return_encode(r->mem_pool, &ctx->encoded,
-                                         &ctx->location);
+                                         &ctx->location.s);
             if (nxt_slow_path(ret == NXT_ERROR)) {
                 goto fail;
             }

--- a/src/nxt_http_rewrite.c
+++ b/src/nxt_http_rewrite.c
@@ -30,7 +30,8 @@ nxt_http_rewrite(nxt_task_t *task, nxt_http_request_t *r)
 {
     u_char                    *p;
     nxt_int_t                 ret;
-    nxt_str_t                 str, encoded_path, target;
+    nxt_str_t                 encoded_path, target;
+    nxt_strz_t                str;
     nxt_router_conf_t         *rtcf;
     nxt_http_action_t         *action;
     nxt_http_request_parse_t  rp;

--- a/src/nxt_http_rewrite.c
+++ b/src/nxt_http_rewrite.c
@@ -65,8 +65,8 @@ nxt_http_rewrite(nxt_task_t *task, nxt_http_request_t *r)
 
     rp.mem_pool = r->mem_pool;
 
-    rp.target_start = str.start;
-    rp.target_end = str.start + str.length;
+    rp.target_start = str.z.start;
+    rp.target_end = str.z.start + str.z.length;
 
     ret = nxt_http_parse_complex_target(&rp);
     if (nxt_slow_path(ret != NXT_OK)) {

--- a/src/nxt_http_route.c
+++ b/src/nxt_http_route.c
@@ -196,7 +196,7 @@ static nxt_http_action_t *nxt_http_pass_var(nxt_task_t *task,
 static void nxt_http_pass_query_ready(nxt_task_t *task, void *obj, void *data);
 static void nxt_http_pass_query_error(nxt_task_t *task, void *obj, void *data);
 static nxt_int_t nxt_http_pass_find(nxt_mp_t *mp, nxt_router_conf_t *rtcf,
-    nxt_str_t *pass, nxt_http_action_t *action);
+    nxt_strz_t *pass, nxt_http_action_t *action);
 static nxt_int_t nxt_http_route_find(nxt_http_routes_t *routes, nxt_str_t *name,
     nxt_http_action_t *action);
 
@@ -1286,7 +1286,7 @@ nxt_http_action_resolve(nxt_task_t *task, nxt_router_temp_conf_t *tmcf,
     nxt_http_action_t *action)
 {
     nxt_int_t  ret;
-    nxt_str_t  pass;
+    nxt_strz_t  pass;
 
     if (action->handler != NULL) {
         if (action->fallback != NULL) {
@@ -1318,7 +1318,7 @@ nxt_http_pass_var(nxt_task_t *task, nxt_http_request_t *r,
     nxt_http_action_t *action)
 {
     nxt_int_t          ret;
-    nxt_str_t          str;
+    nxt_strz_t         str;
     nxt_tstr_t         *tstr;
     nxt_router_conf_t  *rtcf;
 
@@ -1398,13 +1398,13 @@ nxt_http_pass_query_error(nxt_task_t *task, void *obj, void *data)
 
 
 static nxt_int_t
-nxt_http_pass_find(nxt_mp_t *mp, nxt_router_conf_t *rtcf, nxt_str_t *pass,
+nxt_http_pass_find(nxt_mp_t *mp, nxt_router_conf_t *rtcf, nxt_strz_t *pass,
     nxt_http_action_t *action)
 {
     nxt_int_t  ret;
     nxt_str_t  segments[3];
 
-    ret = nxt_http_pass_segments(mp, pass, segments, 3);
+    ret = nxt_http_pass_segments(mp, &pass->s, segments, 3);
     if (nxt_slow_path(ret != NXT_OK)) {
         return ret;
     }

--- a/src/nxt_http_route.c
+++ b/src/nxt_http_route.c
@@ -1429,7 +1429,7 @@ nxt_http_pass_find(nxt_mp_t *mp, nxt_router_conf_t *rtcf, nxt_str_t *pass,
 
 
 nxt_int_t
-nxt_http_pass_segments(nxt_mp_t *mp, nxt_str_t *pass, nxt_str_t *segments,
+nxt_http_pass_segments(nxt_mp_t *mp, const nxt_str_t *pass, nxt_str_t *segments,
     nxt_uint_t n)
 {
     u_char     *p;

--- a/src/nxt_http_set_headers.c
+++ b/src/nxt_http_set_headers.c
@@ -152,7 +152,7 @@ nxt_http_set_headers(nxt_http_request_t *r)
 
         f = nxt_http_resp_header_find(r, hv->name.start, hv->name.length);
 
-        if (value[i].start != NULL) {
+        if (value[i].z.start != NULL) {
 
             if (f == NULL) {
                 f = nxt_list_zero_add(r->resp.fields);
@@ -164,8 +164,8 @@ nxt_http_set_headers(nxt_http_request_t *r)
                 f->name_length = hv->name.length;
             }
 
-            f->value = value[i].start;
-            f->value_length = value[i].length;
+            f->value = value[i].z.start;
+            f->value_length = value[i].z.length;
 
         } else if (f != NULL) {
             f->skip = 1;

--- a/src/nxt_http_set_headers.c
+++ b/src/nxt_http_set_headers.c
@@ -96,7 +96,7 @@ nxt_http_set_headers(nxt_http_request_t *r)
 {
     nxt_int_t              ret;
     nxt_uint_t             i, n;
-    nxt_str_t              *value;
+    nxt_strz_t             *value;
     nxt_http_field_t       *f;
     nxt_router_conf_t      *rtcf;
     nxt_http_action_t      *action;

--- a/src/nxt_http_static.c
+++ b/src/nxt_http_static.c
@@ -10,7 +10,7 @@
 typedef struct {
     nxt_tstr_t                  *tstr;
 #if (NXT_HAVE_OPENAT2)
-    u_char                      *fname;
+    const u_char                *fname;
 #endif
     uint8_t                     is_const;  /* 1 bit */
 } nxt_http_static_share_t;
@@ -52,9 +52,10 @@ static void nxt_http_static_send_error(nxt_task_t *task, void *obj, void *data);
 static void nxt_http_static_next(nxt_task_t *task, nxt_http_request_t *r,
     nxt_http_static_ctx_t *ctx, nxt_http_status_t status);
 #if (NXT_HAVE_OPENAT2)
-static u_char *nxt_http_static_chroot_match(u_char *chr, u_char *shr);
+static const u_char *nxt_http_static_chroot_match(const u_char *chr,
+    const u_char *shr);
 #endif
-static void nxt_http_static_extract_extension(nxt_str_t *path,
+static void nxt_http_static_extract_extension(const nxt_str_t *path,
     nxt_str_t *exten);
 static void nxt_http_static_body_handler(nxt_task_t *task, void *obj,
     void *data);
@@ -304,13 +305,14 @@ static void
 nxt_http_static_send_ready(nxt_task_t *task, void *obj, void *data)
 {
     size_t                  length, encode;
-    u_char                  *p, *fname;
+    u_char                  *p;
     struct tm               tm;
     nxt_buf_t               *fb;
     nxt_int_t               ret;
     nxt_str_t               *shr, *index, exten, *mtype;
     nxt_uint_t              level;
     nxt_file_t              *f, file;
+    const u_char            *fname;
     nxt_file_info_t         fi;
     nxt_http_field_t        *field;
     nxt_http_status_t       status;
@@ -708,8 +710,8 @@ nxt_http_static_next(nxt_task_t *task, nxt_http_request_t *r,
 
 #if (NXT_HAVE_OPENAT2)
 
-static u_char *
-nxt_http_static_chroot_match(u_char *chr, u_char *shr)
+static const u_char *
+nxt_http_static_chroot_match(const u_char *chr, const u_char *shr)
 {
     if (*chr != *shr) {
         return NULL;
@@ -764,7 +766,7 @@ nxt_http_static_chroot_match(u_char *chr, u_char *shr)
 
 
 static void
-nxt_http_static_extract_extension(nxt_str_t *path, nxt_str_t *exten)
+nxt_http_static_extract_extension(const nxt_str_t *path, nxt_str_t *exten)
 {
     u_char  ch, *p, *end;
 

--- a/src/nxt_http_static.c
+++ b/src/nxt_http_static.c
@@ -105,7 +105,7 @@ nxt_http_static_init(nxt_task_t *task, nxt_router_temp_conf_t *tmcf,
         cv = nxt_conf_get_array_element_or_itself(acf->share, i);
         nxt_conf_get_string(cv, &str);
 
-        tstr = nxt_tstr_compile(rtcf->tstr_state, &str, NXT_TSTR_STRZ);
+        tstr = nxt_tstr_compile(rtcf->tstr_state, &str, 0);
         if (nxt_slow_path(tstr == NULL)) {
             return NXT_ERROR;
         }
@@ -131,8 +131,7 @@ nxt_http_static_init(nxt_task_t *task, nxt_router_temp_conf_t *tmcf,
         nxt_str_t   chr, shr;
         nxt_bool_t  is_const;
 
-        conf->chroot = nxt_tstr_compile(rtcf->tstr_state, &acf->chroot,
-                                        NXT_TSTR_STRZ);
+        conf->chroot = nxt_tstr_compile(rtcf->tstr_state, &acf->chroot, 0);
         if (nxt_slow_path(conf->chroot == NULL)) {
             return NXT_ERROR;
         }

--- a/src/nxt_js.c
+++ b/src/nxt_js.c
@@ -232,7 +232,7 @@ nxt_js_add_module(nxt_js_conf_t *jcf, nxt_str_t *name, nxt_str_t *text)
 
 
 nxt_js_t *
-nxt_js_add_tpl(nxt_js_conf_t *jcf, nxt_str_t *str, nxt_bool_t strz)
+nxt_js_add_tpl(nxt_js_conf_t *jcf, nxt_str_t *str)
 {
     size_t     size;
     u_char     *p, *start;
@@ -243,16 +243,9 @@ nxt_js_add_tpl(nxt_js_conf_t *jcf, nxt_str_t *str, nxt_bool_t strz)
                                             "args, headers, cookies) {"
                                             "    return ");
 
-    /*
-     * Appending a terminating null character if strz is true.
-     */
     static nxt_str_t  strz_str = nxt_string(" + '\\x00'");
 
-    size = func_str.length + str->length + 1;
-
-    if (strz) {
-        size += strz_str.length;
-    }
+    size = func_str.length + str->length + 1 + strz_str.length;
 
     start = nxt_mp_nget(jcf->pool, size);
     if (nxt_slow_path(start == NULL)) {
@@ -263,10 +256,7 @@ nxt_js_add_tpl(nxt_js_conf_t *jcf, nxt_str_t *str, nxt_bool_t strz)
 
     p = nxt_cpymem(p, func_str.start, func_str.length);
     p = nxt_cpymem(p, str->start, str->length);
-
-    if (strz) {
-        p = nxt_cpymem(p, strz_str.start, strz_str.length);
-    }
+    p = nxt_cpymem(p, strz_str.start, strz_str.length);
 
     *p++ = '}';
 

--- a/src/nxt_js.c
+++ b/src/nxt_js.c
@@ -373,7 +373,7 @@ fail:
 
 nxt_int_t
 nxt_js_call(nxt_task_t *task, nxt_js_conf_t *jcf, nxt_js_cache_t *cache,
-    nxt_js_t *js, nxt_str_t *str, void *ctx)
+    nxt_js_t *js, nxt_strz_t *str, void *ctx)
 {
     njs_vm_t            *vm;
     njs_int_t           ret;
@@ -464,7 +464,7 @@ nxt_js_call(nxt_task_t *task, nxt_js_conf_t *jcf, nxt_js_cache_t *cache,
 
     ret = njs_vm_value_string(vm, &res, njs_value_arg(&retval));
 
-    str->length = res.length;
+    str->length = res.length - 1;
     str->start = res.start;
 
     return NXT_OK;

--- a/src/nxt_js.h
+++ b/src/nxt_js.h
@@ -28,7 +28,7 @@ void nxt_js_conf_release(nxt_js_conf_t *jcf);
 void nxt_js_set_proto(nxt_js_conf_t *jcf, njs_external_t *proto, nxt_uint_t n);
 nxt_int_t nxt_js_add_module(nxt_js_conf_t *jcf, nxt_str_t *name,
     nxt_str_t *text);
-nxt_js_t *nxt_js_add_tpl(nxt_js_conf_t *jcf, nxt_str_t *str, nxt_bool_t strz);
+nxt_js_t *nxt_js_add_tpl(nxt_js_conf_t *jcf, nxt_str_t *str);
 nxt_int_t nxt_js_compile(nxt_js_conf_t *jcf);
 nxt_int_t nxt_js_test(nxt_js_conf_t *jcf, nxt_str_t *str, u_char *error);
 nxt_int_t nxt_js_call(nxt_task_t *task, nxt_js_conf_t *jcf,

--- a/src/nxt_router_access_log.c
+++ b/src/nxt_router_access_log.c
@@ -17,7 +17,7 @@ typedef struct {
 
 
 typedef struct {
-    nxt_str_t                 text;
+    nxt_strz_t                text;
     nxt_router_access_log_t   *access_log;
 } nxt_router_access_log_ctx_t;
 

--- a/src/nxt_router_access_log.c
+++ b/src/nxt_router_access_log.c
@@ -183,7 +183,7 @@ nxt_router_access_log_write_ready(nxt_task_t *task, void *obj, void *data)
     r = obj;
     ctx = data;
 
-    nxt_fd_write(ctx->access_log->fd, ctx->text.start, ctx->text.length);
+    nxt_fd_write(ctx->access_log->fd, ctx->text.z.start, ctx->text.z.length);
 
     nxt_http_request_close_handler(task, r, r->proto.any);
 }

--- a/src/nxt_string.h
+++ b/src/nxt_string.h
@@ -97,6 +97,16 @@ typedef struct {
 } nxt_str_t;
 
 
+typedef union {
+    struct {
+        size_t                length;
+        u_char                *start;
+    };
+    const nxt_str_t           s;
+} nxt_strz_t;
+
+
+
 #define nxt_string(str)       { nxt_length(str), (u_char *) str }
 #define nxt_string_zero(str)  { sizeof(str), (u_char *) str }
 #define nxt_null_string       { 0, NULL }

--- a/src/nxt_string.h
+++ b/src/nxt_string.h
@@ -101,6 +101,10 @@ typedef union {
     struct {
         size_t                length;
         u_char                *start;
+    } z;
+    struct {
+        size_t                zlength;
+        const u_char         *zstart;
     };
     const nxt_str_t           s;
 } nxt_strz_t;

--- a/src/nxt_tstr.c
+++ b/src/nxt_tstr.c
@@ -86,16 +86,13 @@ nxt_tstr_compile(nxt_tstr_state_t *state, nxt_str_t *str,
 {
     u_char      *p;
     nxt_tstr_t  *tstr;
-    nxt_bool_t  strz;
-
-    strz = (flags & NXT_TSTR_STRZ) != 0;
 
     tstr = nxt_mp_get(state->pool, sizeof(nxt_tstr_t));
     if (nxt_slow_path(tstr == NULL)) {
         return NULL;
     }
 
-    tstr->str.length = str->length + strz;
+    tstr->str.length = str->length + 1;
 
     tstr->str.start = nxt_mp_nget(state->pool, tstr->str.length);
     if (nxt_slow_path(tstr->str.start == NULL)) {
@@ -103,10 +100,7 @@ nxt_tstr_compile(nxt_tstr_state_t *state, nxt_str_t *str,
     }
 
     p = nxt_cpymem(tstr->str.start, str->start, str->length);
-
-    if (strz) {
-        *p = '\0';
-    }
+    *p = '\0';
 
     tstr->flags = flags;
 
@@ -120,7 +114,7 @@ nxt_tstr_compile(nxt_tstr_state_t *state, nxt_str_t *str,
 
         nxt_tstr_str(tstr, &tpl);
 
-        tstr->u.js = nxt_js_add_tpl(state->jcf, &tpl, strz);
+        tstr->u.js = nxt_js_add_tpl(state->jcf, &tpl);
         if (nxt_slow_path(tstr->u.js == NULL)) {
             return NULL;
         }
@@ -214,9 +208,7 @@ nxt_tstr_str(nxt_tstr_t *tstr, nxt_str_t *str)
 {
     *str = tstr->str;
 
-    if (tstr->flags & NXT_TSTR_STRZ) {
-        str->length--;
-    }
+    str->length--;  // Hide the terminating NUL.
 }
 
 
@@ -283,9 +275,7 @@ nxt_tstr_query(nxt_task_t *task, nxt_tstr_query_t *query, nxt_tstr_t *tstr,
 #endif
     }
 
-    if (tstr->flags & NXT_TSTR_STRZ) {
-        val->length--;
-    }
+    val->length--;  // Hide the terminating NUL.
 
 #if (NXT_DEBUG)
     nxt_str_t  str;

--- a/src/nxt_tstr.c
+++ b/src/nxt_tstr.c
@@ -16,7 +16,7 @@ typedef enum {
 
 
 struct nxt_tstr_s {
-    nxt_str_t           str;
+    nxt_strz_t          str;
 
     union {
         nxt_var_t       *var;
@@ -204,9 +204,10 @@ nxt_tstr_is_const(nxt_tstr_t *tstr)
 
 
 void
-nxt_tstr_str(nxt_tstr_t *tstr, nxt_str_t *str)
+nxt_tstr_str(nxt_tstr_t *tstr, nxt_strz_t *str)
 {
-    *str = tstr->str;
+    str->length = tstr->str.length;
+    str->start = tstr->str.start;
 }
 
 
@@ -238,7 +239,7 @@ nxt_tstr_query_init(nxt_tstr_query_t **query_p, nxt_tstr_state_t *state,
 
 void
 nxt_tstr_query(nxt_task_t *task, nxt_tstr_query_t *query, nxt_tstr_t *tstr,
-    nxt_str_t *val)
+    nxt_strz_t *val)
 {
     nxt_int_t  ret;
 
@@ -274,11 +275,11 @@ nxt_tstr_query(nxt_task_t *task, nxt_tstr_query_t *query, nxt_tstr_t *tstr,
     }
 
 #if (NXT_DEBUG)
-    nxt_str_t  str;
+    nxt_strz_t  str;
 
     nxt_tstr_str(tstr, &str);
 
-    nxt_debug(task, "tstr query: \"%V\", result: \"%V\"", &str, val);
+    nxt_debug(task, "tstr query: \"%V\", result: \"%V\"", &str.s, val);
 #endif
 }
 

--- a/src/nxt_tstr.c
+++ b/src/nxt_tstr.c
@@ -92,14 +92,14 @@ nxt_tstr_compile(nxt_tstr_state_t *state, nxt_str_t *str,
         return NULL;
     }
 
-    tstr->str.length = str->length;
+    tstr->str.z.length = str->length;
 
-    tstr->str.start = nxt_mp_nget(state->pool, tstr->str.length + 1);
-    if (nxt_slow_path(tstr->str.start == NULL)) {
+    tstr->str.z.start = nxt_mp_nget(state->pool, tstr->str.z.length + 1);
+    if (nxt_slow_path(tstr->str.z.start == NULL)) {
         return NULL;
     }
 
-    p = nxt_cpymem(tstr->str.start, str->start, str->length);
+    p = nxt_cpymem(tstr->str.z.start, str->start, str->length);
     *p = '\0';
 
     tstr->flags = flags;
@@ -206,8 +206,7 @@ nxt_tstr_is_const(nxt_tstr_t *tstr)
 void
 nxt_tstr_str(nxt_tstr_t *tstr, nxt_strz_t *str)
 {
-    str->length = tstr->str.length;
-    str->start = tstr->str.start;
+    str->z = tstr->str.z;
 }
 
 

--- a/src/nxt_tstr.c
+++ b/src/nxt_tstr.c
@@ -92,9 +92,9 @@ nxt_tstr_compile(nxt_tstr_state_t *state, nxt_str_t *str,
         return NULL;
     }
 
-    tstr->str.length = str->length + 1;
+    tstr->str.length = str->length;
 
-    tstr->str.start = nxt_mp_nget(state->pool, tstr->str.length);
+    tstr->str.start = nxt_mp_nget(state->pool, tstr->str.length + 1);
     if (nxt_slow_path(tstr->str.start == NULL)) {
         return NULL;
     }
@@ -207,8 +207,6 @@ void
 nxt_tstr_str(nxt_tstr_t *tstr, nxt_str_t *str)
 {
     *str = tstr->str;
-
-    str->length--;  // Hide the terminating NUL.
 }
 
 
@@ -274,8 +272,6 @@ nxt_tstr_query(nxt_task_t *task, nxt_tstr_query_t *query, nxt_tstr_t *tstr,
         }
 #endif
     }
-
-    val->length--;  // Hide the terminating NUL.
 
 #if (NXT_DEBUG)
     nxt_str_t  str;

--- a/src/nxt_tstr.h
+++ b/src/nxt_tstr.h
@@ -32,7 +32,6 @@ typedef struct {
 
 
 typedef enum {
-    NXT_TSTR_STRZ       = 1 << 0,
     NXT_TSTR_LOGGING    = 1 << 1,
 } nxt_tstr_flags_t;
 

--- a/src/nxt_tstr.h
+++ b/src/nxt_tstr.h
@@ -44,13 +44,13 @@ nxt_int_t nxt_tstr_state_done(nxt_tstr_state_t *state, u_char *error);
 void nxt_tstr_state_release(nxt_tstr_state_t *state);
 
 nxt_bool_t nxt_tstr_is_const(nxt_tstr_t *tstr);
-void nxt_tstr_str(nxt_tstr_t *tstr, nxt_str_t *str);
+void nxt_tstr_str(nxt_tstr_t *tstr, nxt_strz_t *str);
 
 nxt_int_t nxt_tstr_query_init(nxt_tstr_query_t **query_p,
     nxt_tstr_state_t *state, nxt_tstr_cache_t *cache, void *ctx,
     nxt_mp_t *mp);
 void nxt_tstr_query(nxt_task_t *task, nxt_tstr_query_t *query, nxt_tstr_t *tstr,
-    nxt_str_t *val);
+    nxt_strz_t *val);
 nxt_bool_t nxt_tstr_query_failed(nxt_tstr_query_t *query);
 void nxt_tstr_query_resolve(nxt_task_t *task, nxt_tstr_query_t *query,
     void *data, nxt_work_handler_t ready, nxt_work_handler_t error);

--- a/src/nxt_var.c
+++ b/src/nxt_var.c
@@ -321,8 +321,8 @@ nxt_var_compile(nxt_tstr_state_t *state, nxt_strz_t *str)
 
     n = 0;
 
-    p = str->start;
-    end = p + str->length + 1;
+    p = str->z.start;
+    end = p + str->z.length + 1;
 
     while (p < end) {
         p = nxt_var_next_part(p, end, &part);
@@ -335,23 +335,23 @@ nxt_var_compile(nxt_tstr_state_t *state, nxt_strz_t *str)
         }
     }
 
-    size = sizeof(nxt_var_t) + n * sizeof(nxt_var_sub_t) + str->length + 1;
+    size = sizeof(nxt_var_t) + n * sizeof(nxt_var_sub_t) + str->z.length + 1;
 
     var = nxt_mp_get(state->pool, size);
     if (nxt_slow_path(var == NULL)) {
         return NULL;
     }
 
-    var->length = str->length + 1;
+    var->length = str->z.length + 1;
     var->vars = n;
 
     subs = nxt_var_subs(var);
     src = nxt_var_raw_start(var);
 
-    nxt_memcpy(src, str->start, str->length + 1);
+    nxt_memcpy(src, str->zstart, str->zlength + 1);
 
     n = 0;
-    p = str->start;
+    p = str->z.start;
 
     while (p < end) {
         next = nxt_var_next_part(p, end, &part);
@@ -364,7 +364,7 @@ nxt_var_compile(nxt_tstr_state_t *state, nxt_strz_t *str)
 
             subs[n].index = ref->index;
             subs[n].length = next - p;
-            subs[n].position = p - str->start;
+            subs[n].position = p - str->z.start;
 
             n++;
         }
@@ -528,8 +528,8 @@ nxt_var_interpreter(nxt_task_t *task, nxt_tstr_state_t *state,
         return NXT_ERROR;
     }
 
-    str->length = length;
-    str->start = p;
+    str->z.length = length;
+    str->z.start = p;
 
     part = parts.elts;
     src = nxt_var_raw_start(var);

--- a/src/nxt_var.c
+++ b/src/nxt_var.c
@@ -309,7 +309,7 @@ nxt_var_index_init(void)
 
 
 nxt_var_t *
-nxt_var_compile(nxt_tstr_state_t *state, nxt_str_t *str)
+nxt_var_compile(nxt_tstr_state_t *state, nxt_strz_t *str)
 {
     u_char         *p, *end, *next, *src;
     size_t         size;
@@ -486,7 +486,7 @@ nxt_var_next_part(u_char *start, u_char *end, nxt_str_t *part)
 
 nxt_int_t
 nxt_var_interpreter(nxt_task_t *task, nxt_tstr_state_t *state,
-    nxt_var_cache_t *cache, nxt_var_t *var, nxt_str_t *str, void *ctx,
+    nxt_var_cache_t *cache, nxt_var_t *var, nxt_strz_t *str, void *ctx,
     nxt_bool_t logging)
 {
     u_char         *p, *src;

--- a/src/nxt_var.c
+++ b/src/nxt_var.c
@@ -322,7 +322,7 @@ nxt_var_compile(nxt_tstr_state_t *state, nxt_str_t *str)
     n = 0;
 
     p = str->start;
-    end = p + str->length;
+    end = p + str->length + 1;
 
     while (p < end) {
         p = nxt_var_next_part(p, end, &part);
@@ -335,20 +335,20 @@ nxt_var_compile(nxt_tstr_state_t *state, nxt_str_t *str)
         }
     }
 
-    size = sizeof(nxt_var_t) + n * sizeof(nxt_var_sub_t) + str->length;
+    size = sizeof(nxt_var_t) + n * sizeof(nxt_var_sub_t) + str->length + 1;
 
     var = nxt_mp_get(state->pool, size);
     if (nxt_slow_path(var == NULL)) {
         return NULL;
     }
 
-    var->length = str->length;
+    var->length = str->length + 1;
     var->vars = n;
 
     subs = nxt_var_subs(var);
     src = nxt_var_raw_start(var);
 
-    nxt_memcpy(src, str->start, str->length);
+    nxt_memcpy(src, str->start, str->length + 1);
 
     n = 0;
     p = str->start;

--- a/src/nxt_var.h
+++ b/src/nxt_var.h
@@ -53,11 +53,11 @@ nxt_var_field_t *nxt_var_field_get(nxt_array_t *fields, uint16_t index);
 nxt_var_field_t *nxt_var_field_new(nxt_mp_t *mp, nxt_str_t *name,
     uint32_t hash);
 
-nxt_var_t *nxt_var_compile(nxt_tstr_state_t *state, nxt_str_t *str);
+nxt_var_t *nxt_var_compile(nxt_tstr_state_t *state, nxt_strz_t *str);
 nxt_int_t nxt_var_test(nxt_tstr_state_t *state, nxt_str_t *str, u_char *error);
 
 nxt_int_t nxt_var_interpreter(nxt_task_t *task, nxt_tstr_state_t *state,
-    nxt_var_cache_t *cache, nxt_var_t *var, nxt_str_t *str, void *ctx,
+    nxt_var_cache_t *cache, nxt_var_t *var, nxt_strz_t *str, void *ctx,
     nxt_bool_t logging);
 nxt_str_t *nxt_var_get(nxt_task_t *task, nxt_var_cache_t *cache,
     nxt_str_t *name, void *ctx);


### PR DESCRIPTION
v1 (compared to <https://github.com/nginx/unit/pull/1080> v8):

-  Drop behavior change [@VBart ]

```
$ git range-diff master gh/mtypes NUL
1:  ad561500 ! 1:  7e2f93e6 Static: Store the full path name in a nxt_str_t
    @@ Commit message
     
         Cc: Andrew Clayton <a.clayton@nginx.com>
         Cc: Andrei Zeliankou <zelenkov@nginx.com>
    +    Cc: "Valentin V. Bartenev" <vbartenev@gmail.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## src/nxt_http_static.c ##
2:  019b0814 ! 2:  a5a30451 Static: Don't include the terminating null byte in exten
    @@ Commit message
         Cc: Andrew Clayton <a.clayton@nginx.com>
         Cc: Zhidao Hong <z.hong@f5.com>
         Cc: Andrei Zeliankou <zelenkov@nginx.com>
    +    Cc: "Valentin V. Bartenev" <vbartenev@gmail.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## src/nxt_http_static.c ##
3:  43eda1b8 ! 3:  5c17aea0 Static: Unconditionally extract the extension
    @@ Commit message
     
         Cc: Andrew Clayton <a.clayton@nginx.com>
         Cc: Andrei Zeliankou <zelenkov@nginx.com>
    +    Cc: "Valentin V. Bartenev" <vbartenev@gmail.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## src/nxt_http_static.c ##
4:  eb2ad841 ! 4:  2fdde477 Static: Terminate string with a null byte
    @@ Commit message
         Cc: Andrew Clayton <a.clayton@nginx.com>
         Cc: Zhidao Hong <z.hong@f5.com>
         Cc: Andrei Zeliankou <zelenkov@nginx.com>
    +    Cc: "Valentin V. Bartenev" <vbartenev@gmail.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## src/nxt_http_static.c ##
5:  66db7eb0 < -:  -------- Static: Honor (MIME) "types" in "index"
6:  2ae41725 < -:  -------- Static: Unconditionally get the MIME type
```