### PR TITLE
Node.js: fixed "httpVersion" variable format

### DIFF
--- a/docs/changes.xml
+++ b/docs/changes.xml
@@ -40,6 +40,13 @@ with Next.js.
 </para>
 </change>
 
+<change type="bugfix">
+<para>
+ServerRequest.httpVersion variable format in Node.js module.
+</para>
+</change>
+
+
 </changes>
 
 

--- a/src/nodejs/unit-http/unit.cpp
+++ b/src/nodejs/unit-http/unit.cpp
@@ -581,6 +581,7 @@ Unit::get_server_object()
 void
 Unit::create_headers(nxt_unit_request_info_t *req, napi_value request)
 {
+    char                *p;
     uint32_t            i;
     napi_value          headers, raw_headers;
     napi_status         status;
@@ -602,7 +603,12 @@ Unit::create_headers(nxt_unit_request_info_t *req, napi_value request)
 
     set_named_property(request, "headers", headers);
     set_named_property(request, "rawHeaders", raw_headers);
-    set_named_property(request, "httpVersion", r->version, r->version_length);
+
+    // trim the "HTTP/" protocol prefix
+    p = (char *) nxt_unit_sptr_get(&r->version);
+    p += 5;
+
+    set_named_property(request, "httpVersion", create_string_latin1(p, 3));
     set_named_property(request, "method", r->method, r->method_length);
     set_named_property(request, "url", r->target, r->target_length);
 

--- a/test/test_node_application.py
+++ b/test/test_node_application.py
@@ -80,7 +80,7 @@ def test_node_application_variables(date_to_sec_epoch, sec_epoch):
         'Request-Method': 'POST',
         'Request-Uri': '/',
         'Http-Host': 'localhost',
-        'Server-Protocol': 'HTTP/1.1',
+        'Server-Protocol': '1.1',
         'Custom-Header': 'blah',
     }, 'headers'
     assert resp['body'] == body, 'body'


### PR DESCRIPTION
According to the Node.js documenation this variable
should only include numbering scheme.

Thanks to @dbit-xia.

Closes: https://github.com/nginx/unit/issues/1085