### PR TITLE
fix: Take options as well as requestListener

### DIFF
--- a/docs/changes.xml
+++ b/docs/changes.xml
@@ -53,6 +53,12 @@ NGINX Unit updated to 1.32.0.
 </para>
 </change>
 
+<change type="bugfix">
+<para>
+http.createServer() now accepts "options" argument introduced in Node.js v9.6.0, v8.12.0.
+</para>
+</change>
+
 <change type="feature">
 <para>
 conditional access logging.

--- a/src/nodejs/unit-http/http.js
+++ b/src/nodejs/unit-http/http.js
@@ -11,8 +11,8 @@ const {
     ServerResponse,
 } = require('./http_server');
 
-function createServer (requestHandler) {
-    return new Server(requestHandler);
+function createServer (options, requestHandler) {
+    return new Server(options, requestHandler);
 }
 
 const http = require("http")

--- a/src/nodejs/unit-http/http_server.js
+++ b/src/nodejs/unit-http/http_server.js
@@ -5,6 +5,7 @@
 
 'use strict';
 
+const { stderr } = require('process');
 const EventEmitter = require('events');
 const http = require('http');
 const util = require('util');
@@ -413,7 +414,14 @@ ServerRequest.prototype._read = function _read(n) {
 };
 
 
-function Server(requestListener) {
+function Server(options, requestListener) {
+    if (typeof options === 'function') {
+        requestListener = options;
+        options = {};
+    } else {
+        stderr.write("http.Server constructor was called with unsupported options, using default settings\n");
+    }
+
     EventEmitter.call(this);
 
     this.unit = new unit_lib.Unit();

--- a/test/node/options/app.js
+++ b/test/node/options/app.js
@@ -1,0 +1,4 @@
+require('http').createServer({}, function (req, res) {
+    res.writeHead(200, {'Content-Length': 12, 'Content-Type': 'text/plain'})
+       .end('Hello World\n');
+}).listen(8080);

--- a/test/test_node_application.py
+++ b/test/test_node_application.py
@@ -21,6 +21,12 @@ def test_node_application_basic():
 
     assert_basic_application()
 
+def test_node_application_options(wait_for_record):
+    client.load('options')
+
+    assert_basic_application()
+    assert wait_for_record(r'constructor was called with unsupported') is not None
+
 
 def test_node_application_loader_unit_http():
     client.load('loader/unit_http')


### PR DESCRIPTION
Closes https://github.com/nginx/unit/issues/1043

Unit-http have not kept up with the signature of nodejs's http package development. Nodejs allows an optional `options` object to be passed to the `createServer` function, we didn't. This resulted in function signature errors when user code that did make use of the options arg tried to call unit's replaced function.

This change changes the signature to be more in line with how nodejs does it discarding it and printing a message to stderr so it shows up in unit logs.