### PR TITLE
Fix isolation uid/gidmaps on arm64

### DIFF
--- a/src/nxt_clone.c
+++ b/src/nxt_clone.c
@@ -143,7 +143,7 @@ nxt_clone_credential_map_set(nxt_task_t *task, const char* mapfile, pid_t pid,
         end = mapinfo + len;
 
         for (i = 0; i < map->size; i++) {
-            p = nxt_sprintf(p, end, "%d %d %d", map->map[i].container,
+            p = nxt_sprintf(p, end, "%L %L %L", map->map[i].container,
                             map->map[i].host, map->map[i].size);
 
             if (nxt_slow_path(p == end)) {
@@ -332,7 +332,7 @@ nxt_clone_vldt_credential_gidmap(nxt_task_t *task,
 
         if (nxt_slow_path((nxt_gid_t) m.host != nxt_egid)) {
             nxt_log(task, NXT_LOG_ERR, "\"gidmap\" field has an entry for "
-                    "host gid %d but unprivileged unit can only map itself "
+                    "host gid %L but unprivileged unit can only map itself "
                     "(gid %d) into child namespaces.", m.host, nxt_egid);
 
             return NXT_ERROR;
@@ -340,7 +340,7 @@ nxt_clone_vldt_credential_gidmap(nxt_task_t *task,
 
         if (nxt_slow_path(m.size > 1)) {
             nxt_log(task, NXT_LOG_ERR, "\"gidmap\" field has an entry with "
-                    "\"size\": %d, but for unprivileged unit it must be 1.",
+                    "\"size\": %L, but for unprivileged unit it must be 1.",
                     m.size);
 
             return NXT_ERROR;

--- a/src/nxt_clone.h
+++ b/src/nxt_clone.h
@@ -9,6 +9,8 @@
 
 #if (NXT_HAVE_CLONE_NEWUSER)
 
+typedef int64_t                 nxt_cred_t;
+
 typedef struct {
     nxt_int_t                   container;
     nxt_int_t                   host;

--- a/src/nxt_clone.h
+++ b/src/nxt_clone.h
@@ -12,9 +12,9 @@
 typedef int64_t                 nxt_cred_t;
 
 typedef struct {
-    nxt_int_t                   container;
-    nxt_int_t                   host;
-    nxt_int_t                   size;
+    nxt_cred_t                  container;
+    nxt_cred_t                  host;
+    nxt_cred_t                  size;
 } nxt_clone_map_entry_t;
 
 typedef struct {

--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -1327,12 +1327,15 @@ static nxt_conf_vldt_object_t nxt_conf_vldt_app_procmap_members[] = {
     {
         .name       = nxt_string("container"),
         .type       = NXT_CONF_VLDT_INTEGER,
+        .flags      = NXT_CONF_VLDT_REQUIRED,
     }, {
         .name       = nxt_string("host"),
         .type       = NXT_CONF_VLDT_INTEGER,
+        .flags      = NXT_CONF_VLDT_REQUIRED,
     }, {
         .name       = nxt_string("size"),
         .type       = NXT_CONF_VLDT_INTEGER,
+        .flags      = NXT_CONF_VLDT_REQUIRED,
     },
 
     NXT_CONF_VLDT_END

--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -218,8 +218,6 @@ static nxt_int_t nxt_conf_vldt_clone_namespaces(nxt_conf_validation_t *vldt,
     nxt_conf_value_t *value, void *data);
 
 #if (NXT_HAVE_CLONE_NEWUSER)
-static nxt_int_t nxt_conf_vldt_clone_procmap(nxt_conf_validation_t *vldt,
-    const char* mapfile, nxt_conf_value_t *value);
 static nxt_int_t nxt_conf_vldt_clone_uidmap(nxt_conf_validation_t *vldt,
     nxt_conf_value_t *value);
 static nxt_int_t nxt_conf_vldt_clone_gidmap(nxt_conf_validation_t *vldt,
@@ -3091,73 +3089,6 @@ nxt_conf_vldt_isolation(nxt_conf_validation_t *vldt, nxt_conf_value_t *value,
 
 #if (NXT_HAVE_CLONE_NEWUSER)
 
-typedef struct {
-    nxt_int_t container;
-    nxt_int_t host;
-    nxt_int_t size;
-} nxt_conf_vldt_clone_procmap_conf_t;
-
-
-static nxt_conf_map_t nxt_conf_vldt_clone_procmap_conf_map[] = {
-    {
-        nxt_string("container"),
-        NXT_CONF_MAP_INT32,
-        offsetof(nxt_conf_vldt_clone_procmap_conf_t, container),
-    },
-
-    {
-        nxt_string("host"),
-        NXT_CONF_MAP_INT32,
-        offsetof(nxt_conf_vldt_clone_procmap_conf_t, host),
-    },
-
-    {
-        nxt_string("size"),
-        NXT_CONF_MAP_INT32,
-        offsetof(nxt_conf_vldt_clone_procmap_conf_t, size),
-    },
-
-};
-
-
-static nxt_int_t
-nxt_conf_vldt_clone_procmap(nxt_conf_validation_t *vldt, const char *mapfile,
-        nxt_conf_value_t *value)
-{
-    nxt_int_t                           ret;
-    nxt_conf_vldt_clone_procmap_conf_t  procmap;
-
-    procmap.container = -1;
-    procmap.host = -1;
-    procmap.size = -1;
-
-    ret = nxt_conf_map_object(vldt->pool, value,
-                              nxt_conf_vldt_clone_procmap_conf_map,
-                              nxt_nitems(nxt_conf_vldt_clone_procmap_conf_map),
-                              &procmap);
-    if (ret != NXT_OK) {
-        return ret;
-    }
-
-    if (procmap.container == -1) {
-        return nxt_conf_vldt_error(vldt, "The %s requires the "
-                "\"container\" field set.", mapfile);
-    }
-
-    if (procmap.host == -1) {
-        return nxt_conf_vldt_error(vldt, "The %s requires the "
-                "\"host\" field set.", mapfile);
-    }
-
-    if (procmap.size == -1) {
-        return nxt_conf_vldt_error(vldt, "The %s requires the "
-                "\"size\" field set.", mapfile);
-    }
-
-    return NXT_OK;
-}
-
-
 static nxt_int_t
 nxt_conf_vldt_clone_uidmap(nxt_conf_validation_t *vldt, nxt_conf_value_t *value)
 {
@@ -3174,7 +3105,7 @@ nxt_conf_vldt_clone_uidmap(nxt_conf_validation_t *vldt, nxt_conf_value_t *value)
         return ret;
     }
 
-    return nxt_conf_vldt_clone_procmap(vldt, "uid_map", value);
+    return NXT_OK;
 }
 
 
@@ -3194,7 +3125,7 @@ nxt_conf_vldt_clone_gidmap(nxt_conf_validation_t *vldt, nxt_conf_value_t *value)
         return ret;
     }
 
-    return nxt_conf_vldt_clone_procmap(vldt, "gid_map", value);
+    return NXT_OK;
 }
 
 #endif

--- a/src/nxt_isolation.c
+++ b/src/nxt_isolation.c
@@ -326,19 +326,19 @@ nxt_isolation_credential_map(nxt_task_t *task, nxt_mp_t *mp,
     static nxt_conf_map_t  nxt_clone_map_entry_conf[] = {
         {
             nxt_string("container"),
-            NXT_CONF_MAP_INT,
+            NXT_CONF_MAP_INT64,
             offsetof(nxt_clone_map_entry_t, container),
         },
 
         {
             nxt_string("host"),
-            NXT_CONF_MAP_INT,
+            NXT_CONF_MAP_INT64,
             offsetof(nxt_clone_map_entry_t, host),
         },
 
         {
             nxt_string("size"),
-            NXT_CONF_MAP_INT,
+            NXT_CONF_MAP_INT64,
             offsetof(nxt_clone_map_entry_t, size),
         },
     };


### PR DESCRIPTION
This pull-request fixes an issue on arm64 when using user namespaces on Linux whereby the "container", "host" and "size" members of the uid/gidmaps could be corrupted. 

This would happen due to using nxt_int_t's to store these things, but on arm64 (and potentially others) these are 64bits. However there was an assumption that these would only be 32bits and due to setting these variables through a 32bit union alias, we would only set the four lower half bytes, leaving whatever was around in the upper half, giving some whacked out values.

It consists of the following five commits.

- Isolation: Add a new nxt_cred_t type

This adds a new type for holding uid/gids on Linux when using user namespaces.

- Configuration: Add a new CRED map type

This adds a new configuration map type that corresponds to the above.

- Isolation: Use an appropriate type for storing uid/gids

This is the meat and potatoes of the series. It switches over to using the above two new items.

The following two commits are some cleanup allowed by the previous.

- Configuration: Use the NXT_CONF_VLDT_REQUIRED flag for procmap

Each of the "container", "host" and "size" parameters are _required_.

- Configuration: Remove procmap validation code

This removes the custom validation of the above three items, it's sole purpose was to check that they were set and now we _know_ they will be.