### PR TITLE
Config: Store abstract sockets with @ internally

### DIFF
--- a/src/nxt_conf.c
+++ b/src/nxt_conf.c
@@ -3,6 +3,7 @@
  * Copyright (C) Igor Sysoev
  * Copyright (C) Valentin V. Bartenev
  * Copyright (C) NGINX, Inc.
+ * Copyright 2024, Alejandro Colomar <alx@kernel.org>
  */
 
 #include <nxt_main.h>
@@ -171,6 +172,16 @@ nxt_conf_get_string(nxt_conf_value_t *value, nxt_str_t *str)
         str->length = value->u.string.length;
         str->start = value->u.string.start;
     }
+}
+
+
+nxt_str_t *
+nxt_conf_get_string_dup(nxt_conf_value_t *value, nxt_mp_t *mp, nxt_str_t *str)
+{
+    nxt_str_t  s;
+
+    nxt_conf_get_string(value, &s);
+    return nxt_str_dup(mp, str, &s);
 }
 
 

--- a/src/nxt_conf.h
+++ b/src/nxt_conf.h
@@ -3,6 +3,7 @@
  * Copyright (C) Igor Sysoev
  * Copyright (C) Valentin V. Bartenev
  * Copyright (C) NGINX, Inc.
+ * Copyright 2024, Alejandro Colomar <alx@kernel.org>
  */
 
 #ifndef _NXT_CONF_INCLUDED_
@@ -116,6 +117,8 @@ void nxt_conf_json_position(u_char *start, const u_char *pos, nxt_uint_t *line,
 nxt_int_t nxt_conf_validate(nxt_conf_validation_t *vldt);
 
 NXT_EXPORT void nxt_conf_get_string(nxt_conf_value_t *value, nxt_str_t *str);
+NXT_EXPORT nxt_str_t *nxt_conf_get_string_dup(nxt_conf_value_t *value,
+    nxt_mp_t *mp, nxt_str_t *str);
 NXT_EXPORT void nxt_conf_set_string(nxt_conf_value_t *value, nxt_str_t *str);
 NXT_EXPORT nxt_int_t nxt_conf_set_string_dup(nxt_conf_value_t *value,
     nxt_mp_t *mp, const nxt_str_t *str);

--- a/src/nxt_http_static.c
+++ b/src/nxt_http_static.c
@@ -117,9 +117,7 @@ nxt_http_static_init(nxt_task_t *task, nxt_router_temp_conf_t *tmcf,
         nxt_str_set(&conf->index, "index.html");
 
     } else {
-        nxt_conf_get_string(acf->index, &str);
-
-        ret = nxt_str_dup(mp, &conf->index, &str);
+        ret = nxt_conf_get_string_dup(acf->index, mp, &conf->index);
         if (nxt_slow_path(ret == NULL)) {
             return NXT_ERROR;
         }

--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -2275,7 +2275,7 @@ nxt_router_conf_process_static(nxt_task_t *task, nxt_router_conf_t *rtcf,
 {
     uint32_t          next, i;
     nxt_mp_t          *mp;
-    nxt_str_t         *type, exten, str;
+    nxt_str_t         *type, exten, str, *s;
     nxt_int_t         ret;
     nxt_uint_t        exts;
     nxt_conf_value_t  *mtypes_conf, *ext_conf, *value;
@@ -2311,9 +2311,8 @@ nxt_router_conf_process_static(nxt_task_t *task, nxt_router_conf_t *rtcf,
             }
 
             if (nxt_conf_type(ext_conf) == NXT_CONF_STRING) {
-                nxt_conf_get_string(ext_conf, &str);
-
-                if (nxt_slow_path(nxt_str_dup(mp, &exten, &str) == NULL)) {
+                s = nxt_conf_get_string_dup(ext_conf, mp, &exten);
+                if (nxt_slow_path(s == NULL)) {
                     return NXT_ERROR;
                 }
 
@@ -2331,9 +2330,8 @@ nxt_router_conf_process_static(nxt_task_t *task, nxt_router_conf_t *rtcf,
             for (i = 0; i < exts; i++) {
                 value = nxt_conf_get_array_element(ext_conf, i);
 
-                nxt_conf_get_string(value, &str);
-
-                if (nxt_slow_path(nxt_str_dup(mp, &exten, &str) == NULL)) {
+                s = nxt_conf_get_string_dup(value, mp, &exten);
+                if (nxt_slow_path(s == NULL)) {
                     return NXT_ERROR;
                 }
 
@@ -2425,14 +2423,11 @@ static nxt_int_t
 nxt_router_conf_forward_header(nxt_mp_t *mp, nxt_conf_value_t *conf,
     nxt_http_forward_header_t *fh)
 {
-    char       c;
-    size_t     i;
-    uint32_t   hash;
-    nxt_str_t  header;
+    char      c;
+    size_t    i;
+    uint32_t  hash;
 
-    nxt_conf_get_string(conf, &header);
-
-    fh->header = nxt_str_dup(mp, NULL, &header);
+    fh->header = nxt_conf_get_string_dup(conf, mp, NULL);
     if (nxt_slow_path(fh->header == NULL)) {
         return NXT_ERROR;
     }


### PR DESCRIPTION
We accept both \u0000socket-name and @socket-name as abstract Unix sockets.  The first one is passed to the kernel pristine, while the second is transformed '@'->'\0'.

The commit that added support for Unix sockets accepts both variants, but we internally stored it in the same way, using \u0000... for both.

We want to support abstract sockets transparently to the user, so that if the user configures unitd with '@', if we receive a query about the current configuration, the user should see the same exact thing that was configured.  So, this commit avoids the transformation in the internal state file, storing user input pristine, and we only transform the '@' for a string that will be used internally (not user-visible).

This commit (indirectly) fixes a small bug, where we created abstract sockets with a trailing '\0' in their name due to calling twice nxt_sockaddr_parse() on the same string.  By calling that function only once with each copy of the string, we have fixed that bug.

This bug was found thanks to some experiment about using 'const' for some strings.

And here's some history:

-  9041d276fc6a ("nxt_sockaddr_parse() introducted.")

   This commit introduced support for abstract Unix sockets, but they only worked as "servers", and not as "listeners".  We modified (corrupted?) the JSON config file, and stored a \u0000.

-  d8e0768a5bae ("Fixed support for abstract Unix sockets.")

   This commit (partially) fixed support for abstract Unix sockets, so they they worked also as listeners.  We still modified the JSON config file, and stored a \u0000.

   That next commit also documents some issue about a terminating '\0', but I don't remember the details about it.  I'm not sure it it was introduced here or before.

-  e2aec6686a4d ("Storing abstract sockets with @ internally.")

   This commit fixed the problem by which we were modifying the config file, but only for "listeners", not for "servers".  (It also fixes the issue about the terminating '\0'.)  We completely forgot about "servers".

To reproduce the problem, I used the following config:

```json
{
	"listeners": {
		"*:80": {
			"pass": "routes/u"
		},
		"unix:@abstract": {
			"pass": "routes/a"
		}
	},

	"routes": {
		"u": [{
			"action": {
				"pass": "upstreams/u"
			}
		}],
		"a": [{
			"action": {
				"return": 302,
				"location": "/i/am/not/at/home/"
			}
		}]
	},

	"upstreams": {
		"u": {
			"servers": {
				"unix:@abstract": {}
			}
		}
	}
}
```

And then check the state file:

```sh
$ sudo cat /opt/local/nginx/unit/master/var/lib/unit/conf.json \
| jq . \
| grep unix;
    "unix:@abstract": {
        "unix:\u0000abstract": {}
```

After this patch, the state file has a '@' as expected:
    
```sh
$ sudo cat /opt/local/nginx/unit/unix/var/lib/unit/conf.json \
| jq . \
| grep unix;
    "unix:@abstract": {
        "unix:@abstract": {}
```

Fixes: e2aec6686a4d ("Storing abstract sockets with @ internally.")
Fixes: 9041d276fc6a ("nxt_sockaddr_parse() introducted.")
Cc: @lcrilly 