### PR TITLE
Docker: redirect logs to stderr

### DIFF
--- a/pkg/docker/template.Dockerfile
+++ b/pkg/docker/template.Dockerfile
@@ -77,7 +77,7 @@ RUN set -ex \
     && apt-get purge -y --auto-remove build-essential \
     && rm -rf /var/lib/apt/lists/* \
     && rm -f /requirements.apt \
-    && ln -sf /dev/stdout /var/log/unit.log
+    && ln -sf /dev/stderr /var/log/unit.log
 
 COPY docker-entrypoint.sh /usr/local/bin/
 COPY welcome.* /usr/share/unit/welcome/


### PR DESCRIPTION
This allows to use /dev/stdout as application logs if users choose to do so.

Fixes https://github.com/nginx/unit/issues/982