### PR TITLE
Node.js: Use console.warn instead of stderr.write

### DIFF
--- a/src/nodejs/unit-http/http_server.js
+++ b/src/nodejs/unit-http/http_server.js
@@ -5,7 +5,6 @@
 
 'use strict';
 
-const { stderr } = require('process');
 const EventEmitter = require('events');
 const http = require('http');
 const util = require('util');
@@ -419,7 +418,7 @@ function Server(options, requestListener) {
         requestListener = options;
         options = {};
     } else {
-        stderr.write("http.Server constructor was called with unsupported options, using default settings\n");
+        console.warn("http.Server constructor was called with unsupported options, using default settings");
     }
 
     EventEmitter.call(this);


### PR DESCRIPTION
Functionally identical, but marginally more idiomatic.

Refines: fbeb2065b180e2376088387ee150d3975dc08cd5

cc: @javorszky

For reference, Node's console docs are here: https://nodejs.org/docs/latest-v20.x/api/console.html

`console.warn` is an alias for `console.error`, and `console.error` is documented as: "Prints to stderr with newline." The `console` global has been present since the very earliest releases of Node.