### PR TITLE
Docker: Switch python3.12 to using github

### DIFF
--- a/pkg/docker/Dockerfile.python3.12
+++ b/pkg/docker/Dockerfile.python3.12
@@ -11,11 +11,11 @@ LABEL org.opencontainers.image.version="1.31.1"
 RUN set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
     && apt-get update \
-    && apt-get install --no-install-recommends --no-install-suggests -y ca-certificates mercurial build-essential libssl-dev libpcre2-dev curl pkg-config \
+    && apt-get install --no-install-recommends --no-install-suggests -y ca-certificates git build-essential libssl-dev libpcre2-dev curl pkg-config \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
-    && hg clone -u 1.31.1-1 https://hg.nginx.org/unit \
+    && git clone -b 1.31.1-1 https://github.com/nginx/unit \
     && cd unit \
     && NCPU="$(getconf _NPROCESSORS_ONLN)" \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \


### PR DESCRIPTION
Forgotten in
<https://github.com/nginx/unit/commit/c3af21e970ca3c822004cfda7c5b56ec07d99da9>