### PR TITLE
Avoid a segfault in nxt_conn_io_sendbuf()

### DIFF
--- a/src/nxt_conn_write.c
+++ b/src/nxt_conn_write.c
@@ -172,6 +172,13 @@ nxt_conn_io_sendbuf(nxt_task_t *task, nxt_sendbuf_t *sb)
         return 0;
     }
 
+    /*
+     * XXX Temporary fix for <https://github.com/nginx/unit/issues/1125>
+     */
+    if (niov == 0 && sb->buf == NULL) {
+        return 0;
+    }
+
     if (niov == 0 && nxt_buf_is_file(sb->buf)) {
         return nxt_conn_io_sendfile(task, sb);
     }


### PR DESCRIPTION
This is a simple temporary fix (doesn't address the underlying problem) for an issue reported by a user on GitHub whereby downloading of files from a PHP application would cause the router process to crash.

This is actually a generic problem that will affect anything sending data via nxt_unit_response_write().

This is just a simple fix for the 1.32 release, after which the full correct fix will be worked out.