### PR TITLE
Packaging for wasm wasi component module

### DIFF
--- a/pkg/deb/Makefile.wasm
+++ b/pkg/deb/Makefile.wasm
@@ -6,9 +6,9 @@ MODULE_SUMMARY_wasm=	WASM module for NGINX Unit
 MODULE_VERSION_wasm=	$(VERSION)
 MODULE_RELEASE_wasm=	1
 
-MODULE_CONFARGS_wasm=	wasm --include-path=\$$(CURDIR)/pkg/contrib/wasmtime/crates/c-api/include --lib-path=\$$(CURDIR)/pkg/contrib/wasmtime/target/release
-MODULE_MAKEARGS_wasm=	wasm
-MODULE_INSTARGS_wasm=	wasm-install
+MODULE_CONFARGS_wasm=	wasm --include-path=\$$(CURDIR)/pkg/contrib/wasmtime/crates/c-api/include --lib-path=\$$(CURDIR)/pkg/contrib/wasmtime/target/release \&\& ./configure wasm-wasi-component
+MODULE_MAKEARGS_wasm=	wasm wasm-wasi-component CFLAGS='\$$(CFLAGS) -Wno-missing-prototypes'
+MODULE_INSTARGS_wasm=	wasm-install wasm-wasi-component-install CFLAGS='\$$(CFLAGS) -Wno-missing-prototypes'
 
 MODULE_SOURCES_wasm=
 

--- a/pkg/rpm/Makefile.wasm
+++ b/pkg/rpm/Makefile.wasm
@@ -6,9 +6,9 @@ MODULE_SUMMARY_wasm=	WASM module for NGINX Unit
 MODULE_VERSION_wasm=	$(VERSION)
 MODULE_RELEASE_wasm=	1
 
-MODULE_CONFARGS_wasm=	wasm --include-path=\`pwd\`/pkg/contrib/wasmtime/crates/c-api/include --lib-path=\`pwd\`/pkg/contrib/wasmtime/target/release
-MODULE_MAKEARGS_wasm=	wasm
-MODULE_INSTARGS_wasm=	wasm-install
+MODULE_CONFARGS_wasm=	wasm --include-path=\`pwd\`/pkg/contrib/wasmtime/crates/c-api/include --lib-path=\`pwd\`/pkg/contrib/wasmtime/target/release \&\& ./configure wasm-wasi-component
+MODULE_MAKEARGS_wasm=	wasm wasm-wasi-component
+MODULE_INSTARGS_wasm=	wasm-install wasm-wasi-component-install
 
 MODULE_SOURCES_wasm=
 


### PR DESCRIPTION
Mostly mirrors the method used in the dockerfiles

Tested on RHEL 8, RHEL 9, Amazon Linux 2, Ubuntu 20.04, Ubuntu 22.04, Ubuntu 23.10.

Compared to `wasm` module, for `wasm-wasi-component` wasmtime and dependencies are built twice: once for debug and once for non-debug build. 
Also, both resulting module shared objects ship their own copy of wasmtime, making it three copies of wasmtime (one 11.0.1 and two 17.0.1) shipped in the package.