### PR TITLE
Wasm-wc: Add nxt_unit.o as a dependency in the auto script

### DIFF
--- a/auto/modules/wasm-wasi-component
+++ b/auto/modules/wasm-wasi-component
@@ -99,8 +99,7 @@ all: ${NXT_WCM_MODULE}
 
 ${NXT_WCM_MODULE}:  $NXT_BUILD_DIR/lib/unit/modules/$NXT_WCM_MOD_NAME
 
-$NXT_BUILD_DIR/lib/unit/modules/$NXT_WCM_MOD_NAME:
-	make build/src/nxt_unit.o
+$NXT_BUILD_DIR/lib/unit/modules/$NXT_WCM_MOD_NAME: build/src/nxt_unit.o
 	$NXT_CARGO_CMD
 
 install: ${NXT_WCM_MODULE}-install

--- a/auto/modules/wasm-wasi-component
+++ b/auto/modules/wasm-wasi-component
@@ -5,6 +5,8 @@
 NXT_WCM_MODULE=wasm-wasi-component
 NXT_WCM_MOD_NAME=`echo $NXT_WCM_MODULE | tr '-' '_'`.unit.so
 
+NXT_WCM_MOD_CARGO="src/wasm-wasi-component/target/release/libwasm_wasi_component.so"
+
 
 shift
 
@@ -97,16 +99,16 @@ cat << END >> $NXT_MAKEFILE
 
 all: ${NXT_WCM_MODULE}
 
-${NXT_WCM_MODULE}:  $NXT_BUILD_DIR/lib/unit/modules/$NXT_WCM_MOD_NAME
+${NXT_WCM_MODULE}:	${NXT_WCM_MOD_CARGO}
 
-$NXT_BUILD_DIR/lib/unit/modules/$NXT_WCM_MOD_NAME: build/src/nxt_unit.o
+${NXT_WCM_MOD_CARGO}: build/src/nxt_unit.o
 	$NXT_CARGO_CMD
 
 install: ${NXT_WCM_MODULE}-install
 
 ${NXT_WCM_MODULE}-install: ${NXT_WCM_MODULE} install-check
 	install -d \$(DESTDIR)$NXT_MODULESDIR
-	install -p src/wasm-wasi-component/target/release/libwasm_wasi_component.so \\
+	install -p ${NXT_WCM_MOD_CARGO} \\
 		\$(DESTDIR)$NXT_MODULESDIR/$NXT_WCM_MOD_NAME
 
 uninstall: ${NXT_WCM_MODULE}-uninstall


### PR DESCRIPTION
Rather than calling make itself to build nxt_unit.o make nxt_unit.o a dependency of the main module build target.

After this patch

```
$ make
cc -c -pipe -fPIC -fvisibility=hidden -O0 -W -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wmissing-prototypes  -g   -I src -I build/include   \
                      \
                     \
-o build/src/nxt_unit.o \
-MMD -MF build/src/nxt_unit.dep -MT build/src/nxt_unit.o \
src/nxt_unit.c
```

Compared to before

```
$ make
make build/src/nxt_unit.o
make[1]: Entering directory '/home/andrew/src/unit'
cc -c -pipe -fPIC -fvisibility=hidden -O0 -W -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wmissing-prototypes  -g   -I src -I build/include   \
                      \
                     \
-o build/src/nxt_unit.o \
-MMD -MF build/src/nxt_unit.dep -MT build/src/nxt_unit.o \
src/nxt_unit.c
```