### PR TITLE
Remove debug from builds and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,8 +136,7 @@ jobs:
             --openssl \
             --njs \
             --cc-opt="-I njs/src/ -I njs/build"  \
-            --ld-opt="-L njs/build" \
-            --debug
+            --ld-opt="-L njs/build"
 
       - name: Make unit
         run: |


### PR DESCRIPTION
The info and above errors should be more than enough for debugging
failures in GitHuB Actions CI.