### PR TITLE
Add PHP 8.2 and 8.1 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
             os: ubuntu-latest
           - build: perl
             os: ubuntu-latest
+          - build: php-8.1
+            os: ubuntu-latest
+          - build: php-8.2
+            os: ubuntu-latest
           - build: php-8.3
             os: ubuntu-latest
           - build: python-3.11


### PR DESCRIPTION
`setup-php` action was fixed to add embed SAPI for older versions of PHP