### PR TITLE
Packages: Pass CFLAGS to compile wasm modules on all packaging targets

### DIFF
--- a/pkg/deb/Makefile.wasm
+++ b/pkg/deb/Makefile.wasm
@@ -7,8 +7,8 @@ MODULE_VERSION_wasm=	$(VERSION)
 MODULE_RELEASE_wasm=	1
 
 MODULE_CONFARGS_wasm=	wasm --include-path=\$$(CURDIR)/pkg/contrib/wasmtime/crates/c-api/include --lib-path=\$$(CURDIR)/pkg/contrib/wasmtime/target/release \&\& ./configure wasm-wasi-component
-MODULE_MAKEARGS_wasm=	wasm wasm-wasi-component CFLAGS='\$$(CFLAGS) -Wno-missing-prototypes'
-MODULE_INSTARGS_wasm=	wasm-install wasm-wasi-component-install CFLAGS='\$$(CFLAGS) -Wno-missing-prototypes'
+MODULE_MAKEARGS_wasm=	wasm wasm-wasi-component CFLAGS=\"\$$(shell grep ^CFLAGS \$$(BUILDDIR_\$$*)/build/Makefile | cut -d' ' -f 3-) -Wno-missing-prototypes\"
+MODULE_INSTARGS_wasm=	wasm-install wasm-wasi-component-install
 
 MODULE_SOURCES_wasm=
 

--- a/pkg/rpm/Makefile.wasm
+++ b/pkg/rpm/Makefile.wasm
@@ -7,7 +7,7 @@ MODULE_VERSION_wasm=	$(VERSION)
 MODULE_RELEASE_wasm=	1
 
 MODULE_CONFARGS_wasm=	wasm --include-path=\`pwd\`/pkg/contrib/wasmtime/crates/c-api/include --lib-path=\`pwd\`/pkg/contrib/wasmtime/target/release \&\& ./configure wasm-wasi-component
-MODULE_MAKEARGS_wasm=	wasm wasm-wasi-component
+MODULE_MAKEARGS_wasm=	wasm wasm-wasi-component CFLAGS=\"\$$(grep ^CFLAGS build/Makefile | cut -d' ' -f 3-) -Wno-missing-prototypes\"
 MODULE_INSTARGS_wasm=	wasm-install wasm-wasi-component-install
 
 MODULE_SOURCES_wasm=


### PR DESCRIPTION
This extends the approach used for debian-based packages in 3f805bc64e28 to rpm as well.  Notable change for both deb and rpm packaging is to use CFLAGS as defined in the build/Makefile, and not pass them from the environment which might not be there (as is the case for rpm).

While at it, stop passing CFLAGS in the install phase, as it should no longer invoke builds (see d54af163c46b).

The rpm part was overlooked in 7a6405566c0, since testing was not done on the platforms where problem manifested itself, notably Amazon Linux 2023 and Fedora 38+.