### PR TITLE
Clang static analyser fixes

### DIFF
--- a/src/nxt_var.c
+++ b/src/nxt_var.c
@@ -566,7 +566,7 @@ nxt_var_interpreter(nxt_task_t *task, nxt_tstr_state_t *state,
     }
 
     if (last != var->length) {
-        p = nxt_cpymem(p, &src[last], var->length - last);
+        nxt_cpymem(p, &src[last], var->length - last);
     }
 
     return NXT_OK;


### PR DESCRIPTION
These commits fix a couple of issues found by the clang static analyser.

- Var: Remove a dead assignment in nxt_var_interpreter()

The first removes a dead assignment whereby we store the return from a nxt_cpymem() bu then return from the function before doing anything further with it.

- Avoid potential NULL pointer dereference in nxt_router_temp_conf()

The second fixes a potential NULL pointer dereference.  