### PR TITLE
Update setup-go to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,9 +146,10 @@ jobs:
       ## Go
       ##
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '${{ steps.metadata.outputs.version }}'
+          cache: false
         if: steps.metadata.outputs.module == 'go'
 
       - name: Configure go


### PR DESCRIPTION
Removes deprecation notices on actions builds. v5 updates the version of
node and `cache: false` disables the errors related to not finding a
go.sum