### PR TITLE
Wasm-wc: use more common uname switch to get operating system name

### DIFF
--- a/auto/modules/wasm-wasi-component
+++ b/auto/modules/wasm-wasi-component
@@ -82,7 +82,7 @@ fi
 $echo " + $NXT_WCM_MODULE module: $NXT_WCM_MOD_NAME"
 
 
-NXT_OS=$(uname -o)
+NXT_OS=$(uname -s)
 
 if [ $NXT_OS = "Darwin" ]; then
 	NXT_CARGO_CMD="cargo rustc --release --manifest-path src/wasm-wasi-component/Cargo.toml -- --emit link=target/release/libwasm_wasi_component.so -C link-args='-undefined dynamic_lookup'"


### PR DESCRIPTION
-o is not available on macOS 12.7 at least, and it's what homebrew seems to support still.

Also, the proposed switch seems to be used already in the codebase.