### PR TITLE
HTTP: Ensure REQUEST_URI immutability.

### DIFF
--- a/src/nxt_h1proto.c
+++ b/src/nxt_h1proto.c
@@ -2306,7 +2306,7 @@ nxt_h1p_peer_header_send(nxt_task_t *task, nxt_http_peer_t *peer)
 
     p = nxt_cpymem(p, r->method->start, r->method->length);
     *p++ = ' ';
-    p = nxt_cpymem(p, r->target.start, r->target.length);
+    p = nxt_cpymem(p, target.start, target.length);
     p = nxt_cpymem(p, " HTTP/1.1\r\n", 11);
     p = nxt_cpymem(p, "Connection: close\r\n", 19);
 

--- a/src/nxt_http_rewrite.c
+++ b/src/nxt_http_rewrite.c
@@ -28,9 +28,8 @@ nxt_http_rewrite_init(nxt_router_conf_t *rtcf, nxt_http_action_t *action,
 nxt_int_t
 nxt_http_rewrite(nxt_task_t *task, nxt_http_request_t *r)
 {
-    u_char                    *p;
     nxt_int_t                 ret;
-    nxt_str_t                 str, encoded_path, target;
+    nxt_str_t                 str;
     nxt_router_conf_t         *rtcf;
     nxt_http_action_t         *action;
     nxt_http_request_parse_t  rp;
@@ -72,30 +71,6 @@ nxt_http_rewrite(nxt_task_t *task, nxt_http_request_t *r)
         return NXT_ERROR;
     }
 
-    p = (rp.args.length > 0) ? rp.args.start - 1 : rp.target_end;
-
-    encoded_path.start = rp.target_start;
-    encoded_path.length = p - encoded_path.start;
-
-    if (r->args->length == 0) {
-        r->target = encoded_path;
-
-    } else {
-        target.length = encoded_path.length + 1 + r->args->length;
-
-        target.start = nxt_mp_alloc(r->mem_pool, target.length);
-        if (target.start == NULL) {
-            return NXT_ERROR;
-        }
-
-        p = nxt_cpymem(target.start, encoded_path.start, encoded_path.length);
-        *p++ = '?';
-        nxt_memcpy(p, r->args->start, r->args->length);
-
-        r->target = target;
-        r->args->start = p;
-    }
-
     r->path = nxt_mp_alloc(r->mem_pool, sizeof(nxt_str_t));
     if (nxt_slow_path(r->path == NULL)) {
         return NXT_ERROR;
@@ -107,7 +82,7 @@ nxt_http_rewrite(nxt_task_t *task, nxt_http_request_t *r)
     r->quoted_target = rp.quoted_target;
 
     if (nxt_slow_path(r->log_route)) {
-        nxt_log(task, NXT_LOG_NOTICE, "URI rewritten to \"%V\"", &r->target);
+        nxt_log(task, NXT_LOG_NOTICE, "URI rewritten to \"%V\"", r->path);
     }
 
     return NXT_OK;

--- a/test/test_variables.py
+++ b/test/test_variables.py
@@ -185,10 +185,10 @@ def test_variables_request_uri(
     assert client.get(url='/blah%2Fblah?a=b')['status'] == 200
 
     assert (
-        wait_for_record(fr'^::1 /bar /bar\?a=b$', 'access.log') is not None
+        wait_for_record(fr'^::1 /bar /foo\?a=b$', 'access.log') is not None
     ), 'req 8081 (proxy) rewrite'
     assert (
-        search_in_file(fr'^127\.0\.0\.1 /foo /foo\?a=b$', 'access.log')
+        search_in_file(fr'^127\.0\.0\.1 /foo /blah%2Fblah\?a=b$', 'access.log')
         is not None
     ), 'req 8080 rewrite'
 
@@ -201,11 +201,11 @@ def test_variables_request_uri(
 
     assert (
         wait_for_record(
-            fr'^127\.0\.0\.1 /foo/foo /foo%2Ffoo\?a=b$', 'access.log'
+            fr'^127\.0\.0\.1 /foo/foo /blah%2Fblah\?a=b$', 'access.log'
         )
         is not None
     ), 'req 8080 percent'
-    assert len(findall(fr'^::1 /bar /bar\?a=b$', 'access.log')) == 2
+    assert len(findall(fr'^::1 /bar /foo/foo\?a=b$', 'access.log')) == 1
 
 
 def test_variables_uri(search_in_file, wait_for_record):


### PR DESCRIPTION
1. <del>Another implementation of proxy request creation.</de.
2. Made the `$request_uri` constant.
3. Passed constant `REQUEST_URI` to applications.

Need to separate the PR after tests pass.

Here's a manual test.

```
# conf.json

{
    "listeners": {
        "*:8080": {
            "pass": "routes/a"
        },
        "*:8081": {
            "pass": "routes/b"
        }
    },
    "routes": {
        "a": [
            {
                "action": {
                    "rewrite": "/foo.php",
                    "proxy": "http://127.0.0.1:8081"
                }
            }
        ],
        "b": [
            {
                "action": {
                    "rewrite": "/index.php",
                    "pass": "applications/app"
                }
            }
        ]
    },
    "applications": {
        "app": {
            "type": "php",
            "root": "/www",
            "index": "index.php"
        }
    }
}
```

```
# /www/index.php

<?php

phpinfo();
```

```
> curl http://127.1:8080
$_SERVER['REQUEST_URI'] => /foo.php
```