### PR TITLE
Test with root access in GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,22 +53,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Creates and outputs directories used by tests (/usr/local is unfriendly)
-      - name: Configure directories
-        id: dir
-        run: |
-          PREFIX=${HOME}/.unit
-          BIN=${PREFIX}/bin
-          VAR=${PREFIX}/var
-          mkdir -p $BIN
-          mkdir -p $VAR
-
-          echo "prefix=${PREFIX}" >> "$GITHUB_OUTPUT"
-          echo "bin=${BIN}" >> "$GITHUB_OUTPUT"
-          echo "bin=${BIN}" >> "$GITHUB_PATH"
-          echo "var=${VAR}" >> "$GITHUB_OUTPUT"
-          cat "$GITHUB_OUTPUT"
-
       # Provides module, language version and testpath from build name
       - name: Output build metadata
         id: metadata
@@ -127,15 +111,6 @@ jobs:
       - name: Configure unit
         run: |
           ./configure \
-            --prefix=${{ steps.dir.outputs.prefix }} \
-            --sbindir=${{ steps.dir.outputs.bin }} \
-            --logdir=${{ steps.dir.outputs.var }}/log \
-            --log=${{ steps.dir.outputs.var }}/log/unit/unit.log \
-            --runstatedir=${{ steps.dir.outputs.var }}/run \
-            --pid=${{ steps.dir.outputs.var }}/run/unit/unit.pid \
-            --control=unix:${{ steps.dir.outputs.var }}/run/unit/control.sock \
-            --modules=${{ steps.dir.outputs.prefix }}/lib/unit/modules \
-            --statedir=${{ steps.dir.outputs.var }}/state/unit \
             --tests \
             --openssl \
             --njs \
@@ -179,12 +154,12 @@ jobs:
 
       - name: Configure java
         run: |
-          ./configure java
+          sudo ./configure java
         if: steps.metadata.outputs.module == 'java'
 
       - name: Make java
         run: |
-          make java
+          sudo make java
         if: steps.metadata.outputs.module == 'java'
 
       ##
@@ -266,12 +241,12 @@ jobs:
 
       - name: Configure python3
         run: |
-          ./configure python --config=python3-config
+          sudo ./configure python --config=python3-config
         if: steps.metadata.outputs.module == 'python'
 
       - name: Make python3
         run: |
-          make python3
+          sudo make python3
         if: steps.metadata.outputs.module == 'python'
 
       ##
@@ -321,6 +296,13 @@ jobs:
       ## Tests
       ##
 
+      # /home/runner will be root only after calling sudo above
+      # Ensure all users and processes can execute
+      - name: Fix permissions
+        run: |
+          sudo chmod -R +x /home/runner
+          namei -l ${{ github.workspace }}
+
       # Install python3 if not present
       - uses: actions/setup-python@v5
         with:
@@ -329,11 +311,11 @@ jobs:
 
       - name: Install pytest
         run: |
-          pip install pytest
+          sudo -H pip install pytest
         if: steps.metadata.outputs.module != 'wasm'
 
       - name: Run ${{ steps.metadata.outputs.module }} tests
         run: |
-          pytest --print-log ${{ steps.metadata.outputs.testpath }}
+          sudo -E pytest --print-log ${{ steps.metadata.outputs.testpath }}
         # Skip pytest if wasm build, as there are no tests yet
         if: steps.metadata.outputs.module != 'wasm'


### PR DESCRIPTION
To enable tests that require privileged root access, this commit tests with `sudo`. The Java and Python jobs have additional permissions issues, so they are also configured and made with `sudo`.

A small permissions fix is required before running tests to allow non-root users to execute within the `/home/runner` directory.

This change also removes the custom directories that were required without root access.