### PR TITLE
Add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily


### PR DESCRIPTION
We already [use dependabot for security related patches](https://github.com/nginx/unit/pull/1170), by default.

This change adds a dependabot.yml configuration file that explicitly enables the service to manage versions of Actions in GitHub Actions. This ensures that Actions like `setup-go` are updated timely.

This change does not affect how Dependabot manages versions for Go, Rust, etc. The file can be used to configure that for additional package managers and languages in the future, if desired.
