### PR TITLE
Var: Fix cacheable issue for njs variable access.

### DIFF
--- a/src/nxt_var.c
+++ b/src/nxt_var.c
@@ -147,7 +147,7 @@ nxt_var_ref_get(nxt_tstr_state_t *state, nxt_str_t *name, nxt_mp_t *mp)
 
     if (decl != NULL) {
         ref->handler = decl->handler;
-        ref->cacheable = decl->cacheable;
+        ref->cacheable = (mp == state->pool) ? decl->cacheable : 0;
 
         goto done;
     }


### PR DESCRIPTION
The variables accessed with JS template literal should be not cacheable. Since it is parsed by njs engine, Unit can't create indexes on these variables for caching purpose. For example:

   {
       "format": "`{bodyLength:\"${vars.body_bytes_sent}\",status:\"${vars.status}\"}\n`"
   }

The variables like the above are not cacheable.

Closes: https://github.com/nginx/unit/issues/1169