### PR TITLE
.mailmap: Map Dylan's 2nd GitHub address

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -9,6 +9,7 @@ Artem Konev <artem.konev@nginx.com> <41629299+artemkonev@users.noreply.github.co
 Dan Callahan <d.callahan@f5.com> <dan.callahan@gmail.com>
 Danielle De Leo <d.deleo@f5.com> <danielle@fastmail.net>
 Dylan Arbour <d.arbour@f5.com> <arbourd@users.noreply.github.com>
+Dylan Arbour <d.arbour@f5.com> <7211830+arbourd@users.noreply.github.com>
 Konstantin Pavlov <thresh@nginx.com> <thresh@videolan.org>
 Konstantin Pavlov <thresh@nginx.com> <pavlov.konstantin@gmail.com>
 Max Romanov <max.romanov@gmail.com> <max.romanov@nginx.com>


### PR DESCRIPTION
I changed a setting and now GitHub will recognize both the legacy numberless version, and the newer version with UserID.

The with-UserID version will be used by the any changes stemming from the GitHub GUI.