### PR TITLE
Add status badges to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # NGINX Unit
 
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
+[![CI](https://github.com/nginx/unit/actions/workflows/ci.yml/badge.svg)](https://github.com/nginx/unit/actions/workflows/ci.yml "GitHub workflow CI")
 
 ## Universal Web App Server
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # NGINX Unit
 
+[![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
+
 ## Universal Web App Server
 
 ![NGINX Unit Logo](docs/unitlogo.svg)


### PR DESCRIPTION
This adds a 'repostatus' badge, set to 'active', as per F5/NGINX OSS
policy...

It also adds a GitHub workflows badge that shows the current state of our
CI builds and points to the Unit workflows page.

You can see what they look like [here](https://github.com/ac000/unit/blob/ci-badge/README.md).

Note: For the workflows badge (the second one) the 'CI' text (on the
black background) can be changed.
