### PR TITLE
HTTP: Added variable validation to the response_headers option

### DIFF
--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -2572,6 +2572,7 @@ static nxt_int_t
 nxt_conf_vldt_response_header(nxt_conf_validation_t *vldt, nxt_str_t *name,
     nxt_conf_value_t *value)
 {
+    nxt_str_t   str;
     nxt_uint_t  type;
 
     static nxt_str_t  content_length = nxt_string("Content-Length");
@@ -2588,7 +2589,17 @@ nxt_conf_vldt_response_header(nxt_conf_validation_t *vldt, nxt_str_t *name,
 
     type = nxt_conf_type(value);
 
-    if (type == NXT_CONF_STRING || type == NXT_CONF_NULL) {
+    if (type == NXT_CONF_NULL) {
+        return NXT_OK;
+    }
+
+    if (type == NXT_CONF_STRING) {
+        nxt_conf_get_string(value, &str);
+
+        if (nxt_is_tstr(&str)) {
+            return nxt_conf_vldt_var(vldt, name, &str);
+        }
+
         return NXT_OK;
     }
 


### PR DESCRIPTION
This is to improve error messages for response headers configuration. Take the configuration as an example:

```
  {
      "response_headers": {
          "a": "$b"
      }
  }
```

Previously, when applying it the user would see this error message:

```
  failed to apply previous configuration
```

After this change, the user will see this improved error message:

```
  the previous configuration is invalid: Unknown variable "b" in the "a" value
```