### PR TITLE
Add "if" option to the "match" object.

### DIFF
--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -696,6 +696,10 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_match_members[] = {
         .type       = NXT_CONF_VLDT_OBJECT | NXT_CONF_VLDT_ARRAY,
         .validator  = nxt_conf_vldt_match_patterns_sets,
         .u.string   = "cookies"
+    }, {
+        .name       = nxt_string("if"),
+        .type       = NXT_CONF_VLDT_STRING,
+        .validator  = nxt_conf_vldt_if,
     },
 
     NXT_CONF_VLDT_END

--- a/src/nxt_http.h
+++ b/src/nxt_http.h
@@ -441,6 +441,9 @@ void nxt_h1p_complete_buffers(nxt_task_t *task, nxt_h1proto_t *h1p,
     nxt_bool_t all);
 nxt_msec_t nxt_h1p_conn_request_timer_value(nxt_conn_t *c, uintptr_t data);
 
+int nxt_http_cond_value(nxt_task_t *task, nxt_http_request_t *r,
+    nxt_tstr_cond_t *cond);
+
 extern const nxt_conn_state_t  nxt_h1p_idle_close_state;
 
 #endif  /* _NXT_HTTP_H_INCLUDED_ */

--- a/src/nxt_http_request.c
+++ b/src/nxt_http_request.c
@@ -936,9 +936,8 @@ nxt_http_request_access_log(nxt_task_t *task, nxt_http_request_t *r,
                 return NXT_DECLINED;
             }
 
-            nxt_tstr_query(task, r->tstr_query, rtcf->log_expr, &str);
-
-            if (nxt_slow_path(nxt_tstr_query_failed(r->tstr_query))) {
+            ret = nxt_tstr_query(task, r->tstr_query, rtcf->log_expr, &str);
+            if (nxt_slow_path(ret != NXT_OK)) {
                 return NXT_DECLINED;
             }
         }

--- a/src/nxt_http_rewrite.c
+++ b/src/nxt_http_rewrite.c
@@ -52,9 +52,8 @@ nxt_http_rewrite(nxt_task_t *task, nxt_http_request_t *r)
             return NXT_ERROR;
         }
 
-        nxt_tstr_query(task, r->tstr_query, action->rewrite, &str);
-
-        if (nxt_slow_path(nxt_tstr_query_failed(r->tstr_query))) {
+        ret = nxt_tstr_query(task, r->tstr_query, action->rewrite, &str);
+        if (nxt_slow_path(ret != NXT_OK)) {
             return NXT_ERROR;
         }
     }

--- a/src/nxt_http_route.c
+++ b/src/nxt_http_route.c
@@ -51,6 +51,7 @@ typedef struct {
     nxt_conf_value_t               *query;
     nxt_conf_value_t               *source;
     nxt_conf_value_t               *destination;
+    nxt_conf_value_t               *condition;
 } nxt_http_route_match_conf_t;
 
 
@@ -138,6 +139,7 @@ typedef union {
 
 typedef struct {
     uint32_t                       items;
+    nxt_tstr_cond_t                condition;
     nxt_http_action_t              action;
     nxt_http_route_test_t          test[];
 } nxt_http_route_match_t;
@@ -350,6 +352,12 @@ static nxt_conf_map_t  nxt_http_route_match_conf[] = {
         NXT_CONF_MAP_PTR,
         offsetof(nxt_http_route_match_conf_t, destination),
     },
+
+    {
+        nxt_string("if"),
+        NXT_CONF_MAP_PTR,
+        offsetof(nxt_http_route_match_conf_t, condition),
+    },
 };
 
 
@@ -397,7 +405,9 @@ nxt_http_route_match_create(nxt_task_t *task, nxt_router_temp_conf_t *tmcf,
     uint32_t                     n;
     nxt_mp_t                     *mp;
     nxt_int_t                    ret;
-    nxt_conf_value_t             *match_conf, *action_conf;
+    nxt_str_t                    str;
+    nxt_conf_value_t             *match_conf, *action_conf, *condition;
+    nxt_router_conf_t            *rtcf;
     nxt_http_route_test_t        *test;
     nxt_http_route_rule_t        *rule;
     nxt_http_route_table_t       *table;
@@ -405,6 +415,7 @@ nxt_http_route_match_create(nxt_task_t *task, nxt_router_temp_conf_t *tmcf,
     nxt_http_route_addr_rule_t   *addr_rule;
     nxt_http_route_match_conf_t  mtcf;
 
+    static const nxt_str_t  if_path = nxt_string("/if");
     static const nxt_str_t  match_path = nxt_string("/match");
     static const nxt_str_t  action_path = nxt_string("/action");
 
@@ -413,9 +424,21 @@ nxt_http_route_match_create(nxt_task_t *task, nxt_router_temp_conf_t *tmcf,
     n = (match_conf != NULL) ? nxt_conf_object_members_count(match_conf) : 0;
     size = sizeof(nxt_http_route_match_t) + n * sizeof(nxt_http_route_test_t *);
 
-    mp = tmcf->router_conf->mem_pool;
+    rtcf = tmcf->router_conf;
+    mp = rtcf->mem_pool;
 
-    match = nxt_mp_alloc(mp, size);
+    condition = NULL;
+
+    if (match_conf != NULL) {
+        condition = nxt_conf_get_path(match_conf, &if_path);
+
+        if (condition != NULL) {
+            n--;
+            size -= sizeof(nxt_http_route_test_t *);
+        }
+    }
+
+    match = nxt_mp_zalloc(mp, size);
     if (nxt_slow_path(match == NULL)) {
         return NULL;
     }
@@ -432,7 +455,7 @@ nxt_http_route_match_create(nxt_task_t *task, nxt_router_temp_conf_t *tmcf,
         return NULL;
     }
 
-    if (n == 0) {
+    if (n == 0 && condition == NULL) {
         return match;
     }
 
@@ -443,6 +466,15 @@ nxt_http_route_match_create(nxt_task_t *task, nxt_router_temp_conf_t *tmcf,
                               nxt_nitems(nxt_http_route_match_conf), &mtcf);
     if (ret != NXT_OK) {
         return NULL;
+    }
+
+    if (condition != NULL) {
+        nxt_conf_get_string(condition, &str);
+
+        ret = nxt_tstr_cond_compile(rtcf->tstr_state, &str, &match->condition);
+        if (nxt_slow_path(ret != NXT_OK)) {
+            return NULL;
+        }
     }
 
     test = &match->test[0];
@@ -1595,6 +1627,12 @@ nxt_http_route_match(nxt_task_t *task, nxt_http_request_t *r,
 {
     nxt_int_t              ret;
     nxt_http_route_test_t  *test, *end;
+
+    ret = nxt_http_cond_value(task, r, &match->condition);
+    if (ret <= 0) {
+        /* 0 => NULL, -1 => NXT_HTTP_ACTION_ERROR. */
+        return (nxt_http_action_t *) (intptr_t) ret;
+    }
 
     test = &match->test[0];
     end = test + match->items;

--- a/src/nxt_http_set_headers.c
+++ b/src/nxt_http_set_headers.c
@@ -139,9 +139,8 @@ nxt_http_set_headers(nxt_http_request_t *r)
                 return NXT_ERROR;
             }
 
-            nxt_tstr_query(&r->task, r->tstr_query, hv->value, &value[i]);
-
-            if (nxt_slow_path(nxt_tstr_query_failed(r->tstr_query))) {
+            ret = nxt_tstr_query(&r->task, r->tstr_query, hv->value, &value[i]);
+            if (nxt_slow_path(ret != NXT_OK)) {
                 return NXT_ERROR;
             }
         }

--- a/src/nxt_router.h
+++ b/src/nxt_router.h
@@ -54,8 +54,7 @@ typedef struct {
 
     nxt_router_access_log_t  *access_log;
     nxt_tstr_t               *log_format;
-    nxt_tstr_t               *log_expr;
-    uint8_t                  log_negate;  /* 1 bit */
+    nxt_tstr_cond_t          log_cond;
 } nxt_router_conf_t;
 
 

--- a/src/nxt_router_access_log.c
+++ b/src/nxt_router_access_log.c
@@ -143,15 +143,8 @@ nxt_router_access_log_create(nxt_task_t *task, nxt_router_conf_t *rtcf,
     if (alcf.expr != NULL) {
         nxt_conf_get_string(alcf.expr, &str);
 
-        if (str.length > 0 && str.start[0] == '!') {
-            rtcf->log_negate = 1;
-
-            str.start++;
-            str.length--;
-        }
-
-        rtcf->log_expr = nxt_tstr_compile(rtcf->tstr_state, &str, 0);
-        if (nxt_slow_path(rtcf->log_expr == NULL)) {
+        ret = nxt_tstr_cond_compile(rtcf->tstr_state, &str, &rtcf->log_cond);
+        if (nxt_slow_path(ret != NXT_OK)) {
             return NXT_ERROR;
         }
     }

--- a/src/nxt_tstr.c
+++ b/src/nxt_tstr.c
@@ -246,7 +246,7 @@ nxt_tstr_query_init(nxt_tstr_query_t **query_p, nxt_tstr_state_t *state,
 }
 
 
-void
+nxt_int_t
 nxt_tstr_query(nxt_task_t *task, nxt_tstr_query_t *query, nxt_tstr_t *tstr,
     nxt_str_t *val)
 {
@@ -254,11 +254,11 @@ nxt_tstr_query(nxt_task_t *task, nxt_tstr_query_t *query, nxt_tstr_t *tstr,
 
     if (nxt_tstr_is_const(tstr)) {
         nxt_tstr_str(tstr, val);
-        return;
+        return NXT_OK;
     }
 
     if (nxt_slow_path(query->failed)) {
-        return;
+        return NXT_ERROR;
     }
 
     if (tstr->type == NXT_TSTR_VAR) {
@@ -268,7 +268,7 @@ nxt_tstr_query(nxt_task_t *task, nxt_tstr_query_t *query, nxt_tstr_t *tstr,
 
         if (nxt_slow_path(ret != NXT_OK)) {
             query->failed = 1;
-            return;
+            return NXT_ERROR;
         }
 
     } else {
@@ -278,7 +278,7 @@ nxt_tstr_query(nxt_task_t *task, nxt_tstr_query_t *query, nxt_tstr_t *tstr,
 
         if (nxt_slow_path(ret != NXT_OK)) {
             query->failed = 1;
-            return;
+            return NXT_ERROR;
         }
 #endif
     }
@@ -294,6 +294,8 @@ nxt_tstr_query(nxt_task_t *task, nxt_tstr_query_t *query, nxt_tstr_t *tstr,
 
     nxt_debug(task, "tstr query: \"%V\", result: \"%V\"", &str, val);
 #endif
+
+    return NXT_OK;
 }
 
 

--- a/src/nxt_tstr.c
+++ b/src/nxt_tstr.c
@@ -196,6 +196,26 @@ nxt_tstr_state_release(nxt_tstr_state_t *state)
 }
 
 
+nxt_int_t
+nxt_tstr_cond_compile(nxt_tstr_state_t *state, nxt_str_t *str,
+    nxt_tstr_cond_t *cond)
+{
+    if (str->length > 0 && str->start[0] == '!') {
+        cond->negate = 1;
+
+        str->start++;
+        str->length--;
+    }
+
+    cond->expr = nxt_tstr_compile(state, str, 0);
+    if (nxt_slow_path(cond->expr == NULL)) {
+        return NXT_ERROR;
+    }
+
+    return NXT_OK;
+}
+
+
 nxt_bool_t
 nxt_tstr_is_const(nxt_tstr_t *tstr)
 {

--- a/src/nxt_tstr.h
+++ b/src/nxt_tstr.h
@@ -50,8 +50,8 @@ void nxt_tstr_str(nxt_tstr_t *tstr, nxt_str_t *str);
 nxt_int_t nxt_tstr_query_init(nxt_tstr_query_t **query_p,
     nxt_tstr_state_t *state, nxt_tstr_cache_t *cache, void *ctx,
     nxt_mp_t *mp);
-void nxt_tstr_query(nxt_task_t *task, nxt_tstr_query_t *query, nxt_tstr_t *tstr,
-    nxt_str_t *val);
+nxt_int_t nxt_tstr_query(nxt_task_t *task, nxt_tstr_query_t *query,
+    nxt_tstr_t *tstr, nxt_str_t *val);
 nxt_bool_t nxt_tstr_query_failed(nxt_tstr_query_t *query);
 void nxt_tstr_query_resolve(nxt_task_t *task, nxt_tstr_query_t *query,
     void *data, nxt_work_handler_t ready, nxt_work_handler_t error);

--- a/src/nxt_tstr.h
+++ b/src/nxt_tstr.h
@@ -52,11 +52,6 @@ nxt_int_t nxt_tstr_query_init(nxt_tstr_query_t **query_p,
     nxt_mp_t *mp);
 nxt_int_t nxt_tstr_query(nxt_task_t *task, nxt_tstr_query_t *query,
     nxt_tstr_t *tstr, nxt_str_t *val);
-nxt_bool_t nxt_tstr_query_failed(nxt_tstr_query_t *query);
-void nxt_tstr_query_resolve(nxt_task_t *task, nxt_tstr_query_t *query,
-    void *data, nxt_work_handler_t ready, nxt_work_handler_t error);
-void nxt_tstr_query_handle(nxt_task_t *task, nxt_tstr_query_t *query,
-    nxt_bool_t failed);
 void nxt_tstr_query_release(nxt_tstr_query_t *query);
 
 

--- a/src/nxt_tstr.h
+++ b/src/nxt_tstr.h
@@ -37,12 +37,20 @@ typedef enum {
 } nxt_tstr_flags_t;
 
 
+typedef struct {
+    nxt_tstr_t          *expr;
+    uint8_t             negate;  /* 1 bit */
+} nxt_tstr_cond_t;
+
+
 nxt_tstr_state_t *nxt_tstr_state_new(nxt_mp_t *mp, nxt_bool_t test);
 nxt_tstr_t *nxt_tstr_compile(nxt_tstr_state_t *state, const nxt_str_t *str,
     nxt_tstr_flags_t flags);
 nxt_int_t nxt_tstr_test(nxt_tstr_state_t *state, nxt_str_t *str, u_char *error);
 nxt_int_t nxt_tstr_state_done(nxt_tstr_state_t *state, u_char *error);
 void nxt_tstr_state_release(nxt_tstr_state_t *state);
+nxt_int_t nxt_tstr_cond_compile(nxt_tstr_state_t *state, nxt_str_t *str,
+    nxt_tstr_cond_t *cond);
 
 nxt_bool_t nxt_tstr_is_const(nxt_tstr_t *tstr);
 void nxt_tstr_str(nxt_tstr_t *tstr, nxt_str_t *str);

--- a/src/nxt_var.c
+++ b/src/nxt_var.c
@@ -30,14 +30,8 @@ struct nxt_var_query_s {
 
     nxt_var_cache_t     cache;
 
-    nxt_uint_t          waiting;
-    nxt_uint_t          failed;   /* 1 bit */
-
     void                *ctx;
     void                *data;
-
-    nxt_work_handler_t  ready;
-    nxt_work_handler_t  error;
 };
 
 

--- a/test/test_routing.py
+++ b/test/test_routing.py
@@ -2009,3 +2009,60 @@ def test_routes_match_destination_proxy():
     ), 'proxy configure'
 
     assert client.get()['status'] == 200, 'proxy'
+
+
+def test_routes_match_if():
+
+    def set_if(condition):
+        assert 'success' in client.conf(f'"{condition}"', 'routes/0/match/if')
+
+    def try_if(condition, status):
+        set_if(condition)
+        assert client.get(url=f'/{condition}')['status'] == status
+
+    assert 'success' in client.conf(
+        {
+            "listeners": {"*:8080": {"pass": "routes"}},
+            "routes": [
+                {
+                    "match": {"method": "GET"},
+                    "action": {"return": 200},
+                }
+            ],
+            "applications": {},
+        }
+    ), 'routing configure'
+
+    # const
+
+    try_if('', 404)
+    try_if('0', 404)
+    try_if('false', 404)
+    try_if('undefined', 404)
+    try_if('!', 200)
+    try_if('!null', 200)
+    try_if('1', 200)
+
+    # variable
+
+    set_if('$arg_foo')
+    assert client.get(url='/bar?bar')['status'] == 404
+    assert client.get(url='/foo_empty?foo')['status'] == 404
+    assert client.get(url='/foo?foo=1')['status'] == 200
+
+    set_if('!$arg_foo')
+    assert client.get(url='/bar?bar')['status'] == 200
+    assert client.get(url='/foo_empty?foo')['status'] == 200
+    assert client.get(url='/foo?foo=1')['status'] == 404
+
+    # njs
+
+    set_if('`${args.foo == \'1\'}`')
+    assert client.get(url='/foo_1?foo=1')['status'] == 200
+    assert client.get(url='/foo_2?foo=2')['status'] == 404
+
+    set_if('!`${args.foo == \'1\'}`')
+    assert client.get(url='/foo_1?foo=1')['status'] == 404
+    assert client.get(url='/foo_2?foo=2')['status'] == 200
+
+    assert 'error' in client.conf('$arg_', 'routes/0/match/if')


### PR DESCRIPTION
Two things:
1. restrict variables to only support synchronous way.
Initially, variable query was designed to accomodate both synchronous and asynchronous operations. However, upon consideration of actual requirements, we recognized that asynchronous support was not needed.
This refactoring is intended to simplify the usage of variable queries and prepare for the subsequent feature of variable updating.

2. Add if option to match object to make matching scripting. For example:
```
{
    "listeners": {
        "*:8080": {
            "pass": "routes"
        }
    },
    "routes": [
        {
            "match": {
                "if": "!`${headers['User-Agent'].split('/')[0] == 'curl'}`"
            },
            "action": {
                "return": 204
            }
        }
    ]
}
```
