### PR TITLE
HTTP: Refactoring nxt_h1p_peer_header_send()

### DIFF
--- a/src/nxt_http.h
+++ b/src/nxt_http.h
@@ -192,6 +192,8 @@ struct nxt_http_request_s {
     nxt_http_status_t               status:16;
 
     uint8_t                         log_route;    /* 1 bit */
+    uint8_t                         quoted_target;  /* 1 bit */
+    uint8_t                         uri_changed;  /* 1 bit */
 
     uint8_t                         pass_count;   /* 8 bits */
     uint8_t                         app_target;

--- a/src/nxt_http_parse.c
+++ b/src/nxt_http_parse.c
@@ -286,13 +286,11 @@ continue_target:
         case NXT_HTTP_TARGET_SPACE:
             rp->target_end = p;
             goto space_after_target;
-#if 0
+
         case NXT_HTTP_TARGET_QUOTE_MARK:
             rp->quoted_target = 1;
             goto rest_of_target;
-#else
-        case NXT_HTTP_TARGET_QUOTE_MARK:
-#endif
+
         case NXT_HTTP_TARGET_HASH:
             rp->complex_target = 1;
             goto rest_of_target;
@@ -434,12 +432,7 @@ space_after_target:
 
         rp->request_line_end = p;
 
-        if (rp->complex_target != 0
-#if 0
-            || rp->quoted_target != 0
-#endif
-           )
-        {
+        if (rp->complex_target || rp->quoted_target) {
             rc = nxt_http_parse_complex_target(rp);
 
             if (nxt_slow_path(rc != NXT_OK)) {
@@ -1041,7 +1034,7 @@ nxt_http_parse_complex_target(nxt_http_request_parse_t *rp)
             break;
 
         case sw_quoted:
-            //rp->quoted_target = 1;
+            rp->quoted_target = 1;
 
             if (ch >= '0' && ch <= '9') {
                 high = (u_char) (ch - '0');

--- a/src/nxt_http_parse.h
+++ b/src/nxt_http_parse.h
@@ -61,9 +61,9 @@ struct nxt_http_request_parse_s {
 
     /* target with "/." */
     uint8_t                   complex_target;         /* 1 bit */
-#if 0
     /* target with "%" */
     uint8_t                   quoted_target;          /* 1 bit */
+#if 0
     /* target with " " */
     uint8_t                   space_in_target;        /* 1 bit */
 #endif

--- a/src/nxt_http_rewrite.c
+++ b/src/nxt_http_rewrite.c
@@ -103,6 +103,9 @@ nxt_http_rewrite(nxt_task_t *task, nxt_http_request_t *r)
 
     *r->path = rp.path;
 
+    r->uri_changed = 1;
+    r->quoted_target = rp.quoted_target;
+
     if (nxt_slow_path(r->log_route)) {
         nxt_log(task, NXT_LOG_NOTICE, "URI rewritten to \"%V\"", &r->target);
     }


### PR DESCRIPTION
Previously, proxy request was constructed based on the `r->target` field. However, r->target will remain unchanged in the future, even in cases of URL rewriting.
To accommodate this, I refactored the handling of the proxy target.