### PR TITLE
Tests: compatibility with OpenSSL 3.2.0

### DIFF
--- a/test/unit/applications/tls.py
+++ b/test/unit/applications/tls.py
@@ -85,9 +85,13 @@ subjectAltName = @alt_names
 default_bits = 2048
 encrypt_key = no
 distinguished_name = req_distinguished_name
+x509_extensions = myca_extensions
 
 {a_sec if alt_names else ""}
-[ req_distinguished_name ]'''
+[ req_distinguished_name ]
+
+[ myca_extensions ]
+basicConstraints = critical,CA:TRUE'''
             )
 
     def load(self, script, name=None):


### PR DESCRIPTION
OpenSSL 3.2.0 generates X.509v3 certificates by default. These certificates, even self-signed, cannot sign other certificates unless "CA:TRUE" is explicitly set in the basicConstraints extension. As a result, tests attempting this are currently failing.

Fix is to provide "CA:TRUE" in the basicConstraints for self-signed root certificates used in "openssl ca" commands.