### PR TITLE
Add key points to Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For details and available language packages, see the
 ### Docker
 
 ``` console
-$ docker pull unit
+$ docker pull unit:<TAG>
 $ mkdir /tmp/unit-control # customize as needed.
 $ docker run -d \
       --mount type=bind,src=/tmp/unit-control,dst=/var/run \
@@ -53,6 +53,8 @@ $ docker run -d \
 For a description of image tags, see the
 [docs](https://unit.nginx.org/installation/#docker-images).
 
+WARNING: latest image tag may not provide support for specific language modules,
+*do* check the available image tags from the link above before pulling your image.
 
 Your current working directory will now be mounted to the Unit image at `/www`.
 You can reach its socket at `/tmp/unit-control/control.unit.sock` assuming no 

--- a/README.md
+++ b/README.md
@@ -42,11 +42,21 @@ For details and available language packages, see the
 
 ``` console
 $ docker pull unit
+$ mkdir /tmp/unit-control # customize as needed.
+$ docker run -d \
+      --mount type=bind,src=/tmp/unit-control,dst=/var/run \
+      --mount type=bind,src=.,dst=/www \
+      --network host \
+      unit
 ```
 
 For a description of image tags, see the
 [docs](https://unit.nginx.org/installation/#docker-images).
 
+
+Your current working directory will now be mounted to the Unit image at `/www`.
+You can reach its socket at `/tmp/unit-control/control.unit.sock` assuming no 
+further customizations have been made.
 
 ### Amazon Linux, Fedora, Red Hat
 
@@ -71,6 +81,15 @@ $ wget https://raw.githubusercontent.com/nginx/unit/master/tools/setup-unit && c
 For details and available language packages, see the
 [docs](https://unit.nginx.org/installation/#official-packages).
 
+## Configuration
+
+NGINX Unit provides a RESTful API for dynamic configuration.
+See the [control API documentation](https://unit.nginx.org/controlapi/)
+for more information on what endpoints are available and how to use them.
+
+
+For full details of configuration management, see the
+[docs](https://unit.nginx.org/configuration/#configuration-management).
 
 ## Running a Hello World App
 
@@ -161,8 +180,10 @@ Unit's output should contain both snippets, neatly organized:
 }
 ```
 
-For full details of configuration management, see the
-[docs](https://unit.nginx.org/configuration/#configuration-management).
+## WebAssembly
+Unit supports running WebAssembly Components (WASI 0.2).
+For more information see the
+[Unit Configuration Docs](https://unit.nginx.org/configuration/#configuration-wasm).
 
 ## OpenAPI Specification
 


### PR DESCRIPTION
I noted that our Docker instructions don't provide a complete quickstart, and leaves the user thinking about what additional steps need to be taken to host their application. While this isn't too hard to figure out on it's own I find that just having the instruction there saves time otherwise spent looking at examples and finding/reading the Dockerfile.

Additionally, after stumbling on our deprecated WASM functionality before the supported component; I found it prudent to show our WASM documentation front and center. Hopefully this will spare potential users any confusion they get finding the wrong thing first.

Finally, I wanted to point out the configuration docs in their own section, because I missed the single inline link we have to them the first two times I read through our Readme.