### PR TITLE
Pointer constification

### DIFF
--- a/src/nxt_conf.c
+++ b/src/nxt_conf.c
@@ -130,16 +130,17 @@ static nxt_int_t nxt_conf_copy_array(nxt_mp_t *mp, const nxt_conf_op_t *op,
 static nxt_int_t nxt_conf_copy_object(nxt_mp_t *mp, const nxt_conf_op_t *op,
     nxt_conf_value_t *dst, const nxt_conf_value_t *src);
 
-static size_t nxt_conf_json_string_length(nxt_conf_value_t *value);
-static u_char *nxt_conf_json_print_string(u_char *p, nxt_conf_value_t *value);
-static size_t nxt_conf_json_array_length(nxt_conf_value_t *value,
+static size_t nxt_conf_json_string_length(const nxt_conf_value_t *value);
+static u_char *nxt_conf_json_print_string(u_char *p,
+    const nxt_conf_value_t *value);
+static size_t nxt_conf_json_array_length(const nxt_conf_value_t *value,
     nxt_conf_json_pretty_t *pretty);
-static u_char *nxt_conf_json_print_array(u_char *p, nxt_conf_value_t *value,
+static u_char *nxt_conf_json_print_array(u_char *p,
+    const nxt_conf_value_t *value, nxt_conf_json_pretty_t *pretty);
+static size_t nxt_conf_json_object_length(const nxt_conf_value_t *value,
     nxt_conf_json_pretty_t *pretty);
-static size_t nxt_conf_json_object_length(nxt_conf_value_t *value,
-    nxt_conf_json_pretty_t *pretty);
-static u_char *nxt_conf_json_print_object(u_char *p, nxt_conf_value_t *value,
-    nxt_conf_json_pretty_t *pretty);
+static u_char *nxt_conf_json_print_object(u_char *p,
+    const nxt_conf_value_t *value, nxt_conf_json_pretty_t *pretty);
 
 static size_t nxt_conf_json_escape_length(u_char *p, size_t size);
 static u_char *nxt_conf_json_escape(u_char *dst, u_char *src, size_t size);
@@ -162,21 +163,22 @@ nxt_conf_json_indentation(u_char *p, uint32_t level)
 
 
 void
-nxt_conf_get_string(nxt_conf_value_t *value, nxt_str_t *str)
+nxt_conf_get_string(const nxt_conf_value_t *value, nxt_str_t *str)
 {
     if (value->type == NXT_CONF_VALUE_SHORT_STRING) {
         str->length = value->u.str.length;
-        str->start = value->u.str.start;
+        str->start = (u_char *) value->u.str.start;
 
     } else {
         str->length = value->u.string.length;
-        str->start = value->u.string.start;
+        str->start = (u_char *) value->u.string.start;
     }
 }
 
 
 nxt_str_t *
-nxt_conf_get_string_dup(nxt_conf_value_t *value, nxt_mp_t *mp, nxt_str_t *str)
+nxt_conf_get_string_dup(const nxt_conf_value_t *value, nxt_mp_t *mp,
+    nxt_str_t *str)
 {
     nxt_str_t  s;
 
@@ -2233,7 +2235,8 @@ nxt_conf_json_parse_error(nxt_conf_json_error_t *error, u_char *pos,
 
 
 size_t
-nxt_conf_json_length(nxt_conf_value_t *value, nxt_conf_json_pretty_t *pretty)
+nxt_conf_json_length(const nxt_conf_value_t *value,
+    nxt_conf_json_pretty_t *pretty)
 {
     switch (value->type) {
 
@@ -2265,7 +2268,7 @@ nxt_conf_json_length(nxt_conf_value_t *value, nxt_conf_json_pretty_t *pretty)
 
 
 u_char *
-nxt_conf_json_print(u_char *p, nxt_conf_value_t *value,
+nxt_conf_json_print(u_char *p, const nxt_conf_value_t *value,
     nxt_conf_json_pretty_t *pretty)
 {
     switch (value->type) {
@@ -2299,7 +2302,7 @@ nxt_conf_json_print(u_char *p, nxt_conf_value_t *value,
 
 
 static size_t
-nxt_conf_json_string_length(nxt_conf_value_t *value)
+nxt_conf_json_string_length(const nxt_conf_value_t *value)
 {
     nxt_str_t  str;
 
@@ -2310,7 +2313,7 @@ nxt_conf_json_string_length(nxt_conf_value_t *value)
 
 
 static u_char *
-nxt_conf_json_print_string(u_char *p, nxt_conf_value_t *value)
+nxt_conf_json_print_string(u_char *p, const nxt_conf_value_t *value)
 {
     nxt_str_t  str;
 
@@ -2327,7 +2330,7 @@ nxt_conf_json_print_string(u_char *p, nxt_conf_value_t *value)
 
 
 static size_t
-nxt_conf_json_array_length(nxt_conf_value_t *value,
+nxt_conf_json_array_length(const nxt_conf_value_t *value,
     nxt_conf_json_pretty_t *pretty)
 {
     size_t            len;
@@ -2369,7 +2372,7 @@ nxt_conf_json_array_length(nxt_conf_value_t *value,
 
 
 static u_char *
-nxt_conf_json_print_array(u_char *p, nxt_conf_value_t *value,
+nxt_conf_json_print_array(u_char *p, const nxt_conf_value_t *value,
     nxt_conf_json_pretty_t *pretty)
 {
     nxt_uint_t        n;
@@ -2421,7 +2424,7 @@ nxt_conf_json_print_array(u_char *p, nxt_conf_value_t *value,
 
 
 static size_t
-nxt_conf_json_object_length(nxt_conf_value_t *value,
+nxt_conf_json_object_length(const nxt_conf_value_t *value,
     nxt_conf_json_pretty_t *pretty)
 {
     size_t                    len;
@@ -2465,7 +2468,7 @@ nxt_conf_json_object_length(nxt_conf_value_t *value,
 
 
 static u_char *
-nxt_conf_json_print_object(u_char *p, nxt_conf_value_t *value,
+nxt_conf_json_print_object(u_char *p, const nxt_conf_value_t *value,
     nxt_conf_json_pretty_t *pretty)
 {
     nxt_uint_t                n;

--- a/src/nxt_conf.c
+++ b/src/nxt_conf.c
@@ -123,12 +123,12 @@ static u_char *nxt_conf_json_parse_number(nxt_mp_t *mp, nxt_conf_value_t *value,
 static void nxt_conf_json_parse_error(nxt_conf_json_error_t *error, u_char *pos,
     const char *detail);
 
-static nxt_int_t nxt_conf_copy_value(nxt_mp_t *mp, nxt_conf_op_t *op,
-    nxt_conf_value_t *dst, nxt_conf_value_t *src);
-static nxt_int_t nxt_conf_copy_array(nxt_mp_t *mp, nxt_conf_op_t *op,
-    nxt_conf_value_t *dst, nxt_conf_value_t *src);
-static nxt_int_t nxt_conf_copy_object(nxt_mp_t *mp, nxt_conf_op_t *op,
-    nxt_conf_value_t *dst, nxt_conf_value_t *src);
+static nxt_int_t nxt_conf_copy_value(nxt_mp_t *mp, const nxt_conf_op_t *op,
+    nxt_conf_value_t *dst, const nxt_conf_value_t *src);
+static nxt_int_t nxt_conf_copy_array(nxt_mp_t *mp, const nxt_conf_op_t *op,
+    nxt_conf_value_t *dst, const nxt_conf_value_t *src);
+static nxt_int_t nxt_conf_copy_object(nxt_mp_t *mp, const nxt_conf_op_t *op,
+    nxt_conf_value_t *dst, const nxt_conf_value_t *src);
 
 static size_t nxt_conf_json_string_length(nxt_conf_value_t *value);
 static u_char *nxt_conf_json_print_string(u_char *p, nxt_conf_value_t *value);
@@ -186,7 +186,7 @@ nxt_conf_get_string_dup(nxt_conf_value_t *value, nxt_mp_t *mp, nxt_str_t *str)
 
 
 void
-nxt_conf_set_string(nxt_conf_value_t *value, nxt_str_t *str)
+nxt_conf_set_string(nxt_conf_value_t *value, const nxt_str_t *str)
 {
     if (str->length > NXT_CONF_MAX_SHORT_STRING) {
         value->type = NXT_CONF_VALUE_STRING;
@@ -245,7 +245,7 @@ nxt_conf_get_boolean(nxt_conf_value_t *value)
 
 
 nxt_uint_t
-nxt_conf_object_members_count(nxt_conf_value_t *value)
+nxt_conf_object_members_count(const nxt_conf_value_t *value)
 {
     return value->u.object->count;
 }
@@ -276,7 +276,7 @@ nxt_conf_create_object(nxt_mp_t *mp, nxt_uint_t count)
 
 
 void
-nxt_conf_set_member(nxt_conf_value_t *object, nxt_str_t *name,
+nxt_conf_set_member(nxt_conf_value_t *object, const nxt_str_t *name,
     const nxt_conf_value_t *value, uint32_t index)
 {
     nxt_conf_object_member_t  *member;
@@ -290,8 +290,8 @@ nxt_conf_set_member(nxt_conf_value_t *object, nxt_str_t *name,
 
 
 nxt_int_t
-nxt_conf_set_member_dup(nxt_conf_value_t *object, nxt_mp_t *mp, nxt_str_t *name,
-    nxt_conf_value_t *value, uint32_t index)
+nxt_conf_set_member_dup(nxt_conf_value_t *object, nxt_mp_t *mp,
+    const nxt_str_t *name, const nxt_conf_value_t *value, uint32_t index)
 {
     nxt_conf_object_member_t  *member;
 
@@ -304,8 +304,8 @@ nxt_conf_set_member_dup(nxt_conf_value_t *object, nxt_mp_t *mp, nxt_str_t *name,
 
 
 void
-nxt_conf_set_member_string(nxt_conf_value_t *object, nxt_str_t *name,
-    nxt_str_t *value, uint32_t index)
+nxt_conf_set_member_string(nxt_conf_value_t *object, const nxt_str_t *name,
+    const nxt_str_t *value, uint32_t index)
 {
     nxt_conf_object_member_t  *member;
 
@@ -319,7 +319,7 @@ nxt_conf_set_member_string(nxt_conf_value_t *object, nxt_str_t *name,
 
 nxt_int_t
 nxt_conf_set_member_string_dup(nxt_conf_value_t *object, nxt_mp_t *mp,
-    nxt_str_t *name, nxt_str_t *value, uint32_t index)
+    const nxt_str_t *name, const nxt_str_t *value, uint32_t index)
 {
     nxt_conf_object_member_t  *member;
 
@@ -332,7 +332,7 @@ nxt_conf_set_member_string_dup(nxt_conf_value_t *object, nxt_mp_t *mp,
 
 
 void
-nxt_conf_set_member_integer(nxt_conf_value_t *object, nxt_str_t *name,
+nxt_conf_set_member_integer(nxt_conf_value_t *object, const nxt_str_t *name,
     int64_t value, uint32_t index)
 {
     u_char                    *p, *end;
@@ -353,7 +353,7 @@ nxt_conf_set_member_integer(nxt_conf_value_t *object, nxt_str_t *name,
 
 
 void
-nxt_conf_set_member_null(nxt_conf_value_t *object, nxt_str_t *name,
+nxt_conf_set_member_null(nxt_conf_value_t *object, const nxt_str_t *name,
     uint32_t index)
 {
     nxt_conf_object_member_t  *member;
@@ -400,7 +400,7 @@ nxt_conf_set_element(nxt_conf_value_t *array, nxt_uint_t index,
 
 nxt_int_t
 nxt_conf_set_element_string_dup(nxt_conf_value_t *array, nxt_mp_t *mp,
-    nxt_uint_t index, nxt_str_t *value)
+    nxt_uint_t index, const nxt_str_t *value)
 {
     nxt_conf_value_t  *element;
 
@@ -411,21 +411,21 @@ nxt_conf_set_element_string_dup(nxt_conf_value_t *array, nxt_mp_t *mp,
 
 
 nxt_uint_t
-nxt_conf_array_elements_count(nxt_conf_value_t *value)
+nxt_conf_array_elements_count(const nxt_conf_value_t *value)
 {
     return value->u.array->count;
 }
 
 
 nxt_uint_t
-nxt_conf_array_elements_count_or_1(nxt_conf_value_t *value)
+nxt_conf_array_elements_count_or_1(const nxt_conf_value_t *value)
 {
     return (value->type == NXT_CONF_VALUE_ARRAY) ? value->u.array->count : 1;
 }
 
 
 nxt_uint_t
-nxt_conf_type(nxt_conf_value_t *value)
+nxt_conf_type(const nxt_conf_value_t *value)
 {
     switch (value->type) {
 
@@ -459,7 +459,7 @@ nxt_conf_type(nxt_conf_value_t *value)
 
 
 nxt_conf_value_t *
-nxt_conf_get_path(nxt_conf_value_t *value, nxt_str_t *path)
+nxt_conf_get_path(nxt_conf_value_t *value, const nxt_str_t *path)
 {
     nxt_str_t              token;
     nxt_int_t              ret, index;
@@ -550,7 +550,7 @@ nxt_conf_path_next_token(nxt_conf_path_parse_t *parse, nxt_str_t *token)
 
 
 nxt_conf_value_t *
-nxt_conf_get_object_member(nxt_conf_value_t *value, nxt_str_t *name,
+nxt_conf_get_object_member(const nxt_conf_value_t *value, const nxt_str_t *name,
     uint32_t *index)
 {
     nxt_str_t                 str;
@@ -584,8 +584,8 @@ nxt_conf_get_object_member(nxt_conf_value_t *value, nxt_str_t *name,
 
 
 nxt_int_t
-nxt_conf_map_object(nxt_mp_t *mp, nxt_conf_value_t *value, nxt_conf_map_t *map,
-    nxt_uint_t n, void *data)
+nxt_conf_map_object(nxt_mp_t *mp, const nxt_conf_value_t *value,
+    const nxt_conf_map_t *map, nxt_uint_t n, void *data)
 {
     double            num;
     nxt_str_t         str, *s;
@@ -736,7 +736,7 @@ nxt_conf_map_object(nxt_mp_t *mp, nxt_conf_value_t *value, nxt_conf_map_t *map,
 
 
 nxt_conf_value_t *
-nxt_conf_next_object_member(nxt_conf_value_t *value, nxt_str_t *name,
+nxt_conf_next_object_member(const nxt_conf_value_t *value, nxt_str_t *name,
     uint32_t *next)
 {
     uint32_t                  n;
@@ -764,7 +764,7 @@ nxt_conf_next_object_member(nxt_conf_value_t *value, nxt_str_t *name,
 
 
 nxt_conf_value_t *
-nxt_conf_get_array_element(nxt_conf_value_t *value, uint32_t index)
+nxt_conf_get_array_element(const nxt_conf_value_t *value, uint32_t index)
 {
     nxt_conf_array_t  *array;
 
@@ -802,7 +802,7 @@ nxt_conf_get_array_element_or_itself(nxt_conf_value_t *value, uint32_t index)
 
 
 void
-nxt_conf_array_qsort(nxt_conf_value_t *value,
+nxt_conf_array_qsort(const nxt_conf_value_t *value,
     int (*compare)(const void *, const void *))
 {
     nxt_conf_array_t  *array;
@@ -818,8 +818,9 @@ nxt_conf_array_qsort(nxt_conf_value_t *value,
 
 
 nxt_conf_op_ret_t
-nxt_conf_op_compile(nxt_mp_t *mp, nxt_conf_op_t **ops, nxt_conf_value_t *root,
-    nxt_str_t *path, nxt_conf_value_t *value, nxt_bool_t add)
+nxt_conf_op_compile(nxt_mp_t *mp, nxt_conf_op_t **ops,
+    const nxt_conf_value_t *root, const nxt_str_t *path,
+    nxt_conf_value_t *value, nxt_bool_t add)
 {
     nxt_str_t                 token;
     nxt_int_t                 ret, index;
@@ -956,7 +957,7 @@ nxt_conf_op_compile(nxt_mp_t *mp, nxt_conf_op_t **ops, nxt_conf_value_t *root,
 
 
 nxt_conf_value_t *
-nxt_conf_clone(nxt_mp_t *mp, nxt_conf_op_t *op, nxt_conf_value_t *value)
+nxt_conf_clone(nxt_mp_t *mp, nxt_conf_op_t *op, const nxt_conf_value_t *value)
 {
     nxt_int_t         rc;
     nxt_conf_value_t  *copy;
@@ -977,8 +978,8 @@ nxt_conf_clone(nxt_mp_t *mp, nxt_conf_op_t *op, nxt_conf_value_t *value)
 
 
 static nxt_int_t
-nxt_conf_copy_value(nxt_mp_t *mp, nxt_conf_op_t *op, nxt_conf_value_t *dst,
-    nxt_conf_value_t *src)
+nxt_conf_copy_value(nxt_mp_t *mp, const nxt_conf_op_t *op,
+    nxt_conf_value_t *dst, const nxt_conf_value_t *src)
 {
     if (op != NULL
         && src->type != NXT_CONF_VALUE_ARRAY
@@ -1020,8 +1021,8 @@ nxt_conf_copy_value(nxt_mp_t *mp, nxt_conf_op_t *op, nxt_conf_value_t *dst,
 
 
 static nxt_int_t
-nxt_conf_copy_array(nxt_mp_t *mp, nxt_conf_op_t *op, nxt_conf_value_t *dst,
-    nxt_conf_value_t *src)
+nxt_conf_copy_array(nxt_mp_t *mp, const nxt_conf_op_t *op,
+    nxt_conf_value_t *dst, const nxt_conf_value_t *src)
 {
     size_t            size;
     nxt_int_t         rc;
@@ -1120,8 +1121,8 @@ nxt_conf_copy_array(nxt_mp_t *mp, nxt_conf_op_t *op, nxt_conf_value_t *dst,
 
 
 static nxt_int_t
-nxt_conf_copy_object(nxt_mp_t *mp, nxt_conf_op_t *op, nxt_conf_value_t *dst,
-    nxt_conf_value_t *src)
+nxt_conf_copy_object(nxt_mp_t *mp, const nxt_conf_op_t *op,
+    nxt_conf_value_t *dst, const nxt_conf_value_t *src)
 {
     size_t                    size;
     nxt_int_t                 rc;

--- a/src/nxt_conf.h
+++ b/src/nxt_conf.h
@@ -79,27 +79,28 @@ typedef struct {
 } nxt_conf_validation_t;
 
 
-NXT_EXPORT nxt_uint_t nxt_conf_type(nxt_conf_value_t *value);
+NXT_EXPORT nxt_uint_t nxt_conf_type(const nxt_conf_value_t *value);
 
 NXT_EXPORT nxt_conf_value_t *nxt_conf_get_path(nxt_conf_value_t *value,
-    nxt_str_t *path);
-NXT_EXPORT nxt_conf_value_t *nxt_conf_get_object_member(nxt_conf_value_t *value,
-    nxt_str_t *name, uint32_t *index);
+    const nxt_str_t *path);
+NXT_EXPORT nxt_conf_value_t *nxt_conf_get_object_member(
+    const nxt_conf_value_t *value, const nxt_str_t *name, uint32_t *index);
 NXT_EXPORT nxt_conf_value_t *nxt_conf_next_object_member(
-    nxt_conf_value_t *value, nxt_str_t *name, uint32_t *next);
-NXT_EXPORT nxt_conf_value_t *nxt_conf_get_array_element(nxt_conf_value_t *value,
-    uint32_t index);
+    const nxt_conf_value_t *value, nxt_str_t *name, uint32_t *next);
+NXT_EXPORT nxt_conf_value_t *nxt_conf_get_array_element(
+    const nxt_conf_value_t *value, uint32_t index);
 NXT_EXPORT nxt_conf_value_t *nxt_conf_get_array_element_or_itself(
     nxt_conf_value_t *value, uint32_t index);
 
-NXT_EXPORT nxt_int_t nxt_conf_map_object(nxt_mp_t *mp, nxt_conf_value_t *value,
-    nxt_conf_map_t *map, nxt_uint_t n, void *data);
+NXT_EXPORT nxt_int_t nxt_conf_map_object(nxt_mp_t *mp,
+    const nxt_conf_value_t *value, const nxt_conf_map_t *map, nxt_uint_t n,
+    void *data);
 
 nxt_conf_op_ret_t nxt_conf_op_compile(nxt_mp_t *mp, nxt_conf_op_t **ops,
-    nxt_conf_value_t *root, nxt_str_t *path, nxt_conf_value_t *value,
+    const nxt_conf_value_t *root, const nxt_str_t *path, nxt_conf_value_t *value,
     nxt_bool_t add);
 nxt_conf_value_t *nxt_conf_clone(nxt_mp_t *mp, nxt_conf_op_t *op,
-    nxt_conf_value_t *value);
+    const nxt_conf_value_t *value);
 
 nxt_conf_value_t *nxt_conf_json_parse(nxt_mp_t *mp, u_char *start, u_char *end,
     nxt_conf_json_error_t *error);
@@ -119,37 +120,41 @@ nxt_int_t nxt_conf_validate(nxt_conf_validation_t *vldt);
 NXT_EXPORT void nxt_conf_get_string(nxt_conf_value_t *value, nxt_str_t *str);
 NXT_EXPORT nxt_str_t *nxt_conf_get_string_dup(nxt_conf_value_t *value,
     nxt_mp_t *mp, nxt_str_t *str);
-NXT_EXPORT void nxt_conf_set_string(nxt_conf_value_t *value, nxt_str_t *str);
+NXT_EXPORT void nxt_conf_set_string(nxt_conf_value_t *value,
+    const nxt_str_t *str);
 NXT_EXPORT nxt_int_t nxt_conf_set_string_dup(nxt_conf_value_t *value,
     nxt_mp_t *mp, const nxt_str_t *str);
 NXT_EXPORT double nxt_conf_get_number(nxt_conf_value_t *value);
 NXT_EXPORT uint8_t nxt_conf_get_boolean(nxt_conf_value_t *value);
 
 // FIXME reimplement and reorder functions below
-NXT_EXPORT nxt_uint_t nxt_conf_object_members_count(nxt_conf_value_t *value);
+NXT_EXPORT nxt_uint_t nxt_conf_object_members_count(
+    const nxt_conf_value_t *value);
 nxt_conf_value_t *nxt_conf_create_object(nxt_mp_t *mp, nxt_uint_t count);
-void nxt_conf_set_member(nxt_conf_value_t *object, nxt_str_t *name,
+void nxt_conf_set_member(nxt_conf_value_t *object, const nxt_str_t *name,
     const nxt_conf_value_t *value, uint32_t index);
 nxt_int_t nxt_conf_set_member_dup(nxt_conf_value_t *object, nxt_mp_t *mp,
-    nxt_str_t *name, nxt_conf_value_t *value, uint32_t index);
-void nxt_conf_set_member_string(nxt_conf_value_t *object, nxt_str_t *name,
-    nxt_str_t *value, uint32_t index);
-nxt_int_t nxt_conf_set_member_string_dup(nxt_conf_value_t *object, nxt_mp_t *mp,
-    nxt_str_t *name, nxt_str_t *value, uint32_t index);
-void nxt_conf_set_member_integer(nxt_conf_value_t *object, nxt_str_t *name,
-    int64_t value, uint32_t index);
-void nxt_conf_set_member_null(nxt_conf_value_t *object, nxt_str_t *name,
+    const nxt_str_t *name, const nxt_conf_value_t *value, uint32_t index);
+void nxt_conf_set_member_string(nxt_conf_value_t *object,
+    const nxt_str_t *name, const nxt_str_t *value, uint32_t index);
+nxt_int_t nxt_conf_set_member_string_dup(nxt_conf_value_t *object,
+    nxt_mp_t *mp, const nxt_str_t *name, const nxt_str_t *value,
+    uint32_t index);
+void nxt_conf_set_member_integer(nxt_conf_value_t *object,
+    const nxt_str_t *name, int64_t value, uint32_t index);
+void nxt_conf_set_member_null(nxt_conf_value_t *object, const nxt_str_t *name,
     uint32_t index);
 
 nxt_conf_value_t *nxt_conf_create_array(nxt_mp_t *mp, nxt_uint_t count);
 void nxt_conf_set_element(nxt_conf_value_t *array, nxt_uint_t index,
     const nxt_conf_value_t *value);
-nxt_int_t nxt_conf_set_element_string_dup(nxt_conf_value_t *array, nxt_mp_t *mp,
-    nxt_uint_t index, nxt_str_t *value);
-NXT_EXPORT nxt_uint_t nxt_conf_array_elements_count(nxt_conf_value_t *value);
+nxt_int_t nxt_conf_set_element_string_dup(nxt_conf_value_t *array,
+    nxt_mp_t *mp, nxt_uint_t index, const nxt_str_t *value);
+NXT_EXPORT nxt_uint_t nxt_conf_array_elements_count(
+    const nxt_conf_value_t *value);
 NXT_EXPORT nxt_uint_t nxt_conf_array_elements_count_or_1(
-    nxt_conf_value_t *value);
-void nxt_conf_array_qsort(nxt_conf_value_t *value,
+    const nxt_conf_value_t *value);
+void nxt_conf_array_qsort(const nxt_conf_value_t *value,
     int (*compare)(const void *, const void *));
 
 

--- a/src/nxt_conf.h
+++ b/src/nxt_conf.h
@@ -108,17 +108,18 @@ nxt_conf_value_t *nxt_conf_json_parse(nxt_mp_t *mp, u_char *start, u_char *end,
 #define nxt_conf_json_parse_str(mp, str)                                      \
     nxt_conf_json_parse(mp, (str)->start, (str)->start + (str)->length, NULL)
 
-size_t nxt_conf_json_length(nxt_conf_value_t *value,
+size_t nxt_conf_json_length(const nxt_conf_value_t *value,
     nxt_conf_json_pretty_t *pretty);
-u_char *nxt_conf_json_print(u_char *p, nxt_conf_value_t *value,
+u_char *nxt_conf_json_print(u_char *p, const nxt_conf_value_t *value,
     nxt_conf_json_pretty_t *pretty);
 void nxt_conf_json_position(u_char *start, const u_char *pos, nxt_uint_t *line,
     nxt_uint_t *column);
 
 nxt_int_t nxt_conf_validate(nxt_conf_validation_t *vldt);
 
-NXT_EXPORT void nxt_conf_get_string(nxt_conf_value_t *value, nxt_str_t *str);
-NXT_EXPORT nxt_str_t *nxt_conf_get_string_dup(nxt_conf_value_t *value,
+NXT_EXPORT void nxt_conf_get_string(const nxt_conf_value_t *value,
+    nxt_str_t *str);
+NXT_EXPORT nxt_str_t *nxt_conf_get_string_dup(const nxt_conf_value_t *value,
     nxt_mp_t *mp, nxt_str_t *str);
 NXT_EXPORT void nxt_conf_set_string(nxt_conf_value_t *value,
     const nxt_str_t *str);

--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -1445,7 +1445,7 @@ nxt_conf_vldt_type(nxt_conf_validation_t *vldt, const nxt_str_t *name,
     nxt_uint_t  value_type, n, t;
     u_char      buf[nxt_length(NXT_CONF_VLDT_ANY_TYPE_STR)];
 
-    static nxt_str_t  type_name[] = {
+    static const nxt_str_t  type_name[] = {
         nxt_string("a null"),
         nxt_string("a boolean"),
         nxt_string("an integer number"),
@@ -1568,7 +1568,7 @@ nxt_conf_vldt_if(nxt_conf_validation_t *vldt, nxt_conf_value_t *value,
 {
     nxt_str_t  str;
 
-    static nxt_str_t  if_str = nxt_string("if");
+    static const nxt_str_t  if_str = nxt_string("if");
 
     if (nxt_conf_type(value) != NXT_CONF_STRING) {
         return nxt_conf_vldt_error(vldt, "The \"if\" must be a string");
@@ -1731,7 +1731,7 @@ nxt_conf_vldt_action(nxt_conf_validation_t *vldt, nxt_conf_value_t *value,
     nxt_conf_value_t        *action;
     nxt_conf_vldt_object_t  *members;
 
-    static struct {
+    static const struct {
         nxt_str_t               name;
         nxt_conf_vldt_object_t  *members;
 
@@ -1778,7 +1778,7 @@ nxt_conf_vldt_pass(nxt_conf_validation_t *vldt, nxt_conf_value_t *value,
     nxt_int_t  ret;
     nxt_str_t  segments[3];
 
-    static nxt_str_t  targets_str = nxt_string("targets");
+    static const nxt_str_t  targets_str = nxt_string("targets");
 
     nxt_conf_get_string(value, &pass);
 
@@ -1932,7 +1932,7 @@ nxt_conf_vldt_share_element(nxt_conf_validation_t *vldt,
 {
     nxt_str_t  str;
 
-    static nxt_str_t  share = nxt_string("share");
+    static const nxt_str_t  share = nxt_string("share");
 
     if (nxt_conf_type(value) != NXT_CONF_STRING) {
         return nxt_conf_vldt_error(vldt, "The \"share\" array must "
@@ -1982,7 +1982,7 @@ nxt_conf_vldt_python(nxt_conf_validation_t *vldt, nxt_conf_value_t *value,
 {
     nxt_conf_value_t  *targets;
 
-    static nxt_str_t  targets_str = nxt_string("targets");
+    static const nxt_str_t  targets_str = nxt_string("targets");
 
     targets = nxt_conf_get_object_member(value, &targets_str, NULL);
 
@@ -2575,7 +2575,7 @@ nxt_conf_vldt_response_header(nxt_conf_validation_t *vldt, nxt_str_t *name,
     nxt_str_t   str;
     nxt_uint_t  type;
 
-    static nxt_str_t  content_length = nxt_string("Content-Length");
+    static const nxt_str_t  content_length = nxt_string("Content-Length");
 
     if (name->length == 0) {
         return nxt_conf_vldt_error(vldt, "The response header name "
@@ -2615,7 +2615,7 @@ nxt_conf_vldt_app_name(nxt_conf_validation_t *vldt, nxt_conf_value_t *value,
     nxt_str_t         name;
     nxt_conf_value_t  *apps, *app;
 
-    static nxt_str_t  apps_str = nxt_string("applications");
+    static const nxt_str_t  apps_str = nxt_string("applications");
 
     nxt_conf_get_string(value, &name);
 
@@ -2647,8 +2647,8 @@ nxt_conf_vldt_forwarded(nxt_conf_validation_t *vldt, nxt_conf_value_t *value,
 {
     nxt_conf_value_t  *client_ip, *protocol;
 
-    static nxt_str_t  client_ip_str = nxt_string("client_ip");
-    static nxt_str_t  protocol_str = nxt_string("protocol");
+    static const nxt_str_t  client_ip_str = nxt_string("client_ip");
+    static const nxt_str_t  protocol_str = nxt_string("protocol");
 
     client_ip = nxt_conf_get_object_member(value, &client_ip_str, NULL);
     protocol = nxt_conf_get_object_member(value, &protocol_str, NULL);
@@ -2673,9 +2673,9 @@ nxt_conf_vldt_app(nxt_conf_validation_t *vldt, nxt_str_t *name,
     nxt_conf_value_t       *type_value;
     nxt_app_lang_module_t  *lang;
 
-    static nxt_str_t  type_str = nxt_string("type");
+    static const nxt_str_t  type_str = nxt_string("type");
 
-    static struct {
+    static const struct {
         nxt_conf_vldt_handler_t  validator;
         nxt_conf_vldt_object_t   *members;
 
@@ -3188,7 +3188,7 @@ nxt_conf_vldt_php(nxt_conf_validation_t *vldt, nxt_conf_value_t *value,
 {
     nxt_conf_value_t  *targets;
 
-    static nxt_str_t  targets_str = nxt_string("targets");
+    static const nxt_str_t  targets_str = nxt_string("targets");
 
     targets = nxt_conf_get_object_member(value, &targets_str, NULL);
 
@@ -3269,7 +3269,7 @@ nxt_conf_vldt_upstream(nxt_conf_validation_t *vldt, nxt_str_t *name,
     nxt_int_t         ret;
     nxt_conf_value_t  *conf;
 
-    static nxt_str_t  servers = nxt_string("servers");
+    static const nxt_str_t  servers = nxt_string("servers");
 
     ret = nxt_conf_vldt_type(vldt, name, value, NXT_CONF_VLDT_OBJECT);
 
@@ -3414,7 +3414,7 @@ nxt_conf_vldt_access_log(nxt_conf_validation_t *vldt, nxt_conf_value_t *value,
     nxt_int_t                        ret;
     nxt_conf_vldt_access_log_conf_t  conf;
 
-    static nxt_str_t  format_str = nxt_string("format");
+    static const nxt_str_t  format_str = nxt_string("format");
 
     if (nxt_conf_type(value) == NXT_CONF_STRING) {
         return NXT_OK;

--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -73,11 +73,11 @@ struct nxt_conf_vldt_object_s {
 
 
 static nxt_int_t nxt_conf_vldt_type(nxt_conf_validation_t *vldt,
-    nxt_str_t *name, nxt_conf_value_t *value, nxt_conf_vldt_type_t type);
+    const nxt_str_t *name, nxt_conf_value_t *value, nxt_conf_vldt_type_t type);
 static nxt_int_t nxt_conf_vldt_error(nxt_conf_validation_t *vldt,
     const char *fmt, ...);
-static nxt_int_t nxt_conf_vldt_var(nxt_conf_validation_t *vldt, nxt_str_t *name,
-    nxt_str_t *value);
+static nxt_int_t nxt_conf_vldt_var(nxt_conf_validation_t *vldt,
+    const nxt_str_t *name, nxt_str_t *value);
 static nxt_int_t nxt_conf_vldt_if(nxt_conf_validation_t *vldt,
     nxt_conf_value_t *value, void *data);
 nxt_inline nxt_int_t nxt_conf_vldt_unsupported(nxt_conf_validation_t *vldt,
@@ -1436,7 +1436,7 @@ nxt_conf_validate(nxt_conf_validation_t *vldt)
 
 
 static nxt_int_t
-nxt_conf_vldt_type(nxt_conf_validation_t *vldt, nxt_str_t *name,
+nxt_conf_vldt_type(nxt_conf_validation_t *vldt, const nxt_str_t *name,
     nxt_conf_value_t *value, nxt_conf_vldt_type_t type)
 {
     u_char      *p;
@@ -1548,7 +1548,7 @@ nxt_conf_vldt_unsupported(nxt_conf_validation_t *vldt, nxt_conf_value_t *value,
 
 
 static nxt_int_t
-nxt_conf_vldt_var(nxt_conf_validation_t *vldt, nxt_str_t *name,
+nxt_conf_vldt_var(nxt_conf_validation_t *vldt, const nxt_str_t *name,
     nxt_str_t *value)
 {
     u_char  error[NXT_MAX_ERROR_STR];

--- a/src/nxt_controller.c
+++ b/src/nxt_controller.c
@@ -1912,8 +1912,8 @@ nxt_controller_cert_in_use(nxt_str_t *name)
     nxt_str_t         str;
     nxt_conf_value_t  *listeners, *listener, *value;
 
-    static nxt_str_t  listeners_path = nxt_string("/listeners");
-    static nxt_str_t  certificate_path = nxt_string("/tls/certificate");
+    static const nxt_str_t  listeners_path = nxt_string("/listeners");
+    static const nxt_str_t  certificate_path = nxt_string("/tls/certificate");
 
     listeners = nxt_conf_get_path(nxt_controller_conf.root, &listeners_path);
 
@@ -2178,7 +2178,7 @@ nxt_controller_script_in_use(nxt_str_t *name)
     nxt_str_t         str;
     nxt_conf_value_t  *js_module, *element;
 
-    static nxt_str_t  js_module_path = nxt_string("/settings/js_module");
+    static const nxt_str_t  js_module_path = nxt_string("/settings/js_module");
 
     js_module = nxt_conf_get_path(nxt_controller_conf.root,
                                     &js_module_path);
@@ -2486,13 +2486,13 @@ nxt_controller_response(nxt_task_t *task, nxt_controller_request_t *req,
     nxt_conf_value_t        *value, *location;
     nxt_conf_json_pretty_t  pretty;
 
-    static nxt_str_t  success_str = nxt_string("success");
-    static nxt_str_t  error_str = nxt_string("error");
-    static nxt_str_t  detail_str = nxt_string("detail");
-    static nxt_str_t  location_str = nxt_string("location");
-    static nxt_str_t  offset_str = nxt_string("offset");
-    static nxt_str_t  line_str = nxt_string("line");
-    static nxt_str_t  column_str = nxt_string("column");
+    static const nxt_str_t  success_str = nxt_string("success");
+    static const nxt_str_t  error_str = nxt_string("error");
+    static const nxt_str_t  detail_str = nxt_string("detail");
+    static const nxt_str_t  location_str = nxt_string("location");
+    static const nxt_str_t  offset_str = nxt_string("offset");
+    static const nxt_str_t  line_str = nxt_string("line");
+    static const nxt_str_t  column_str = nxt_string("column");
 
     static nxt_time_string_t  date_cache = {
         (nxt_atomic_uint_t) -1,

--- a/src/nxt_controller.c
+++ b/src/nxt_controller.c
@@ -2652,11 +2652,12 @@ static u_char *
 nxt_controller_date(u_char *buf, nxt_realtime_t *now, struct tm *tm,
     size_t size, const char *format)
 {
-    static const char  *week[] = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri",
-                                   "Sat" };
+    static const char * const  week[] = { "Sun", "Mon", "Tue", "Wed", "Thu",
+                                          "Fri", "Sat" };
 
-    static const char  *month[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                                    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
+    static const char * const  month[] = { "Jan", "Feb", "Mar", "Apr", "May",
+                                           "Jun", "Jul", "Aug", "Sep", "Oct",
+                                           "Nov", "Dec" };
 
     return nxt_sprintf(buf, buf + size, format,
                        week[tm->tm_wday], tm->tm_mday,

--- a/src/nxt_http.h
+++ b/src/nxt_http.h
@@ -305,11 +305,12 @@ struct nxt_http_forward_s {
 nxt_inline u_char *
 nxt_http_date(u_char *buf, struct tm *tm)
 {
-    static const char  *week[] = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri",
-                                   "Sat" };
+    static const char * const  week[] = { "Sun", "Mon", "Tue", "Wed", "Thu",
+                                          "Fri", "Sat" };
 
-    static const char  *month[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                                    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
+    static const char * const  month[] = { "Jan", "Feb", "Mar", "Apr", "May",
+                                           "Jun", "Jul", "Aug", "Sep", "Oct",
+                                           "Nov", "Dec" };
 
     return nxt_sprintf(buf, buf + NXT_HTTP_DATE_LEN,
                        "%s, %02d %s %4d %02d:%02d:%02d GMT",

--- a/src/nxt_http_route.c
+++ b/src/nxt_http_route.c
@@ -405,8 +405,8 @@ nxt_http_route_match_create(nxt_task_t *task, nxt_router_temp_conf_t *tmcf,
     nxt_http_route_addr_rule_t   *addr_rule;
     nxt_http_route_match_conf_t  mtcf;
 
-    static nxt_str_t  match_path = nxt_string("/match");
-    static nxt_str_t  action_path = nxt_string("/action");
+    static const nxt_str_t  match_path = nxt_string("/match");
+    static const nxt_str_t  action_path = nxt_string("/action");
 
     match_conf = nxt_conf_get_path(cv, &match_path);
 

--- a/src/nxt_http_variables.c
+++ b/src/nxt_http_variables.c
@@ -366,8 +366,9 @@ nxt_http_log_date(u_char *buf, nxt_realtime_t *now, struct tm *tm,
     u_char  sign;
     time_t  gmtoff;
 
-    static const char  *month[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                                    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
+    static const char * const  month[] = { "Jan", "Feb", "Mar", "Apr", "May",
+                                           "Jun", "Jul", "Aug", "Sep", "Oct",
+                                           "Nov", "Dec" };
 
     gmtoff = nxt_timezone(tm) / 60;
 

--- a/src/nxt_isolation.c
+++ b/src/nxt_isolation.c
@@ -224,8 +224,8 @@ nxt_isolation_set_cgroup(nxt_task_t *task, nxt_conf_value_t *isolation,
     nxt_str_t         str;
     nxt_conf_value_t  *obj;
 
-    static nxt_str_t  cgname = nxt_string("cgroup");
-    static nxt_str_t  path = nxt_string("path");
+    static const nxt_str_t  cgname = nxt_string("cgroup");
+    static const nxt_str_t  path = nxt_string("path");
 
     obj = nxt_conf_get_object_member(isolation, &cgname, NULL);
     if (obj == NULL) {
@@ -260,7 +260,7 @@ nxt_isolation_set_namespaces(nxt_task_t *task, nxt_conf_value_t *isolation,
     nxt_int_t         ret;
     nxt_conf_value_t  *obj;
 
-    static nxt_str_t  nsname = nxt_string("namespaces");
+    static const nxt_str_t  nsname = nxt_string("namespaces");
 
     obj = nxt_conf_get_object_member(isolation, &nsname, NULL);
     if (obj != NULL) {
@@ -286,8 +286,8 @@ nxt_isolation_set_creds(nxt_task_t *task, nxt_conf_value_t *isolation,
     nxt_clone_t       *clone;
     nxt_conf_value_t  *array;
 
-    static nxt_str_t uidname = nxt_string("uidmap");
-    static nxt_str_t gidname = nxt_string("gidmap");
+    static const nxt_str_t uidname = nxt_string("uidmap");
+    static const nxt_str_t gidname = nxt_string("gidmap");
 
     clone = &process->isolation.clone;
 
@@ -323,7 +323,7 @@ nxt_isolation_credential_map(nxt_task_t *task, nxt_mp_t *mp,
     nxt_uint_t        i;
     nxt_conf_value_t  *obj;
 
-    static nxt_conf_map_t  nxt_clone_map_entry_conf[] = {
+    static const nxt_conf_map_t  nxt_clone_map_entry_conf[] = {
         {
             nxt_string("container"),
             NXT_CONF_MAP_INT64,
@@ -496,7 +496,7 @@ nxt_isolation_set_rootfs(nxt_task_t *task, nxt_conf_value_t *isolation,
     nxt_str_t         str;
     nxt_conf_value_t  *obj;
 
-    static nxt_str_t  rootfs_name = nxt_string("rootfs");
+    static const nxt_str_t  rootfs_name = nxt_string("rootfs");
 
     obj = nxt_conf_get_object_member(isolation, &rootfs_name, NULL);
     if (obj != NULL) {
@@ -536,10 +536,10 @@ nxt_isolation_set_automount(nxt_task_t *task, nxt_conf_value_t *isolation,
     nxt_conf_value_t         *conf, *value;
     nxt_process_automount_t  *automount;
 
-    static nxt_str_t  automount_name = nxt_string("automount");
-    static nxt_str_t  langdeps_name = nxt_string("language_deps");
-    static nxt_str_t  tmp_name = nxt_string("tmpfs");
-    static nxt_str_t  proc_name = nxt_string("procfs");
+    static const nxt_str_t  automount_name = nxt_string("automount");
+    static const nxt_str_t  langdeps_name = nxt_string("language_deps");
+    static const nxt_str_t  tmp_name = nxt_string("tmpfs");
+    static const nxt_str_t  proc_name = nxt_string("procfs");
 
     automount = &process->isolation.automount;
 
@@ -1110,7 +1110,7 @@ nxt_isolation_set_new_privs(nxt_task_t *task, nxt_conf_value_t *isolation,
 {
     nxt_conf_value_t  *obj;
 
-    static nxt_str_t  new_privs_name = nxt_string("new_privs");
+    static const nxt_str_t  new_privs_name = nxt_string("new_privs");
 
     obj = nxt_conf_get_object_member(isolation, &new_privs_name, NULL);
     if (obj != NULL) {

--- a/src/nxt_js.c
+++ b/src/nxt_js.c
@@ -124,9 +124,9 @@ nxt_js_vm_create(nxt_js_conf_t *jcf)
     njs_vm_opt_t     opts;
     nxt_js_module_t  *module, *mod;
 
-    static nxt_str_t  import_str = nxt_string("import");
-    static nxt_str_t  from_str = nxt_string("from");
-    static nxt_str_t  global_str = nxt_string("globalThis");
+    static const nxt_str_t  import_str = nxt_string("import");
+    static const nxt_str_t  from_str = nxt_string("from");
+    static const nxt_str_t  global_str = nxt_string("globalThis");
 
     njs_vm_opt_init(&opts);
 
@@ -237,14 +237,15 @@ nxt_js_add_tpl(nxt_js_conf_t *jcf, nxt_str_t *str, nxt_bool_t strz)
     nxt_js_t   *js;
     nxt_str_t  *func;
 
-    static nxt_str_t  func_str = nxt_string("function(uri, host, remoteAddr, "
-                                            "args, headers, cookies, vars) {"
-                                            "    return ");
+    static const nxt_str_t  func_str =
+                                nxt_string("function(uri, host, remoteAddr, "
+                                           "args, headers, cookies, vars) {"
+                                           "    return ");
 
     /*
      * Appending a terminating null character if strz is true.
      */
-    static nxt_str_t  strz_str = nxt_string(" + '\\x00'");
+    static const nxt_str_t  strz_str = nxt_string(" + '\\x00'");
 
     size = func_str.length + str->length + 1;
 

--- a/src/nxt_php_sapi.c
+++ b/src/nxt_php_sapi.c
@@ -377,9 +377,9 @@ nxt_php_setup(nxt_task_t *task, nxt_process_t *process,
     nxt_conf_value_t    *value;
     nxt_php_app_conf_t  *c;
 
-    static nxt_str_t  file_str = nxt_string("file");
-    static nxt_str_t  user_str = nxt_string("user");
-    static nxt_str_t  admin_str = nxt_string("admin");
+    static const nxt_str_t  file_str = nxt_string("file");
+    static const nxt_str_t  user_str = nxt_string("user");
+    static const nxt_str_t  admin_str = nxt_string("admin");
 
     c = &conf->u.php;
 
@@ -529,9 +529,9 @@ nxt_php_set_target(nxt_task_t *task, nxt_php_target_t *target,
     nxt_int_t         ret;
     nxt_conf_value_t  *value;
 
-    static nxt_str_t  root_str = nxt_string("root");
-    static nxt_str_t  script_str = nxt_string("script");
-    static nxt_str_t  index_str = nxt_string("index");
+    static const nxt_str_t  root_str = nxt_string("root");
+    static const nxt_str_t  script_str = nxt_string("script");
+    static const nxt_str_t  index_str = nxt_string("index");
 
     value = nxt_conf_get_object_member(conf, &root_str, NULL);
 

--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -1634,25 +1634,29 @@ nxt_router_conf_create(nxt_task_t *task, nxt_router_temp_conf_t *tmcf,
     nxt_router_app_conf_t       apcf;
     nxt_router_listener_conf_t  lscf;
 
-    static nxt_str_t  http_path = nxt_string("/settings/http");
-    static nxt_str_t  applications_path = nxt_string("/applications");
-    static nxt_str_t  listeners_path = nxt_string("/listeners");
-    static nxt_str_t  routes_path = nxt_string("/routes");
-    static nxt_str_t  access_log_path = nxt_string("/access_log");
+    static const nxt_str_t  http_path = nxt_string("/settings/http");
+    static const nxt_str_t  applications_path = nxt_string("/applications");
+    static const nxt_str_t  listeners_path = nxt_string("/listeners");
+    static const nxt_str_t  routes_path = nxt_string("/routes");
+    static const nxt_str_t  access_log_path = nxt_string("/access_log");
 #if (NXT_TLS)
-    static nxt_str_t  certificate_path = nxt_string("/tls/certificate");
-    static nxt_str_t  conf_commands_path = nxt_string("/tls/conf_commands");
-    static nxt_str_t  conf_cache_path = nxt_string("/tls/session/cache_size");
-    static nxt_str_t  conf_timeout_path = nxt_string("/tls/session/timeout");
-    static nxt_str_t  conf_tickets = nxt_string("/tls/session/tickets");
+    static const nxt_str_t  certificate_path = nxt_string("/tls/certificate");
+    static const nxt_str_t  conf_commands_path =
+                                nxt_string("/tls/conf_commands");
+    static const nxt_str_t  conf_cache_path =
+                                nxt_string("/tls/session/cache_size");
+    static const nxt_str_t  conf_timeout_path =
+                                nxt_string("/tls/session/timeout");
+    static const nxt_str_t  conf_tickets = nxt_string("/tls/session/tickets");
 #endif
 #if (NXT_HAVE_NJS)
-    static nxt_str_t  js_module_path = nxt_string("/settings/js_module");
+    static const nxt_str_t  js_module_path = nxt_string("/settings/js_module");
 #endif
-    static nxt_str_t  static_path = nxt_string("/settings/http/static");
-    static nxt_str_t  websocket_path = nxt_string("/settings/http/websocket");
-    static nxt_str_t  forwarded_path = nxt_string("/forwarded");
-    static nxt_str_t  client_ip_path = nxt_string("/client_ip");
+    static const nxt_str_t  static_path = nxt_string("/settings/http/static");
+    static const nxt_str_t  websocket_path =
+                                nxt_string("/settings/http/websocket");
+    static const nxt_str_t  forwarded_path = nxt_string("/forwarded");
+    static const nxt_str_t  client_ip_path = nxt_string("/client_ip");
 
     root = nxt_conf_json_parse(tmcf->mem_pool, start, end, NULL);
     if (root == NULL) {
@@ -2283,7 +2287,7 @@ nxt_router_conf_process_static(nxt_task_t *task, nxt_router_conf_t *rtcf,
     nxt_uint_t        exts;
     nxt_conf_value_t  *mtypes_conf, *ext_conf, *value;
 
-    static nxt_str_t  mtypes_path = nxt_string("/mime_types");
+    static const nxt_str_t  mtypes_path = nxt_string("/mime_types");
 
     mp = rtcf->mem_pool;
 
@@ -2360,11 +2364,11 @@ nxt_router_conf_forward(nxt_task_t *task, nxt_mp_t *mp, nxt_conf_value_t *conf)
     nxt_http_forward_t          *forward;
     nxt_http_route_addr_rule_t  *source;
 
-    static nxt_str_t  header_path = nxt_string("/header");
-    static nxt_str_t  client_ip_path = nxt_string("/client_ip");
-    static nxt_str_t  protocol_path = nxt_string("/protocol");
-    static nxt_str_t  source_path = nxt_string("/source");
-    static nxt_str_t  recursive_path = nxt_string("/recursive");
+    static const nxt_str_t  header_path = nxt_string("/header");
+    static const nxt_str_t  client_ip_path = nxt_string("/client_ip");
+    static const nxt_str_t  protocol_path = nxt_string("/protocol");
+    static const nxt_str_t  source_path = nxt_string("/source");
+    static const nxt_str_t  recursive_path = nxt_string("/recursive");
 
     header_conf = nxt_conf_get_path(conf, &header_path);
 

--- a/src/nxt_router_access_log.c
+++ b/src/nxt_router_access_log.c
@@ -75,7 +75,7 @@ nxt_router_access_log_create(nxt_task_t *task, nxt_router_conf_t *rtcf,
     nxt_router_access_log_t       *access_log;
     nxt_router_access_log_conf_t  alcf;
 
-    static nxt_str_t  log_format_str = nxt_string("$remote_addr - - "
+    static const nxt_str_t  log_format_str = nxt_string("$remote_addr - - "
         "[$time_local] \"$request_line\" $status $body_bytes_sent "
         "\"$header_referer\" \"$header_user_agent\"");
 

--- a/src/nxt_unit.c
+++ b/src/nxt_unit.c
@@ -1948,9 +1948,9 @@ nxt_unit_request_group_dup_fields(nxt_unit_request_info_t *req)
     nxt_unit_field_t    *fields, f;
     nxt_unit_request_t  *r;
 
-    static nxt_str_t  content_length = nxt_string("content-length");
-    static nxt_str_t  content_type = nxt_string("content-type");
-    static nxt_str_t  cookie = nxt_string("cookie");
+    static const nxt_str_t  content_length = nxt_string("content-length");
+    static const nxt_str_t  content_type = nxt_string("content-type");
+    static const nxt_str_t  cookie = nxt_string("cookie");
 
     nxt_unit_req_debug(req, "group_dup_fields");
 

--- a/src/nxt_upstream.c
+++ b/src/nxt_upstream.c
@@ -25,7 +25,7 @@ nxt_upstreams_create(nxt_task_t *task, nxt_router_temp_conf_t *tmcf,
     nxt_upstreams_t   *upstreams;
     nxt_conf_value_t  *upstreams_conf, *upcf;
 
-    static nxt_str_t  upstreams_name = nxt_string("upstreams");
+    static const nxt_str_t  upstreams_name = nxt_string("upstreams");
 
     upstreams_conf = nxt_conf_get_object_member(conf, &upstreams_name, NULL);
 

--- a/src/nxt_upstream_round_robin.c
+++ b/src/nxt_upstream_round_robin.c
@@ -52,8 +52,8 @@ nxt_upstream_round_robin_create(nxt_task_t *task, nxt_router_temp_conf_t *tmcf,
     nxt_conf_value_t            *servers_conf, *srvcf, *wtcf;
     nxt_upstream_round_robin_t  *urr;
 
-    static nxt_str_t  servers = nxt_string("servers");
-    static nxt_str_t  weight = nxt_string("weight");
+    static const nxt_str_t  servers = nxt_string("servers");
+    static const nxt_str_t  weight = nxt_string("weight");
 
     mp = tmcf->router_conf->mem_pool;
 


### PR DESCRIPTION
This patch series marks various pointer function arguments as `const` in the configuration sub-system.

The main impetus of this was to convert a bunch of

```c
static nxt_str_t ...
```

variable declarations to

```c
static const nxt_str_t ...
```

Having these _only_ `static` seems a bit weird, given what that means and that they we're really being treated as string literals.

Making them `static const` really makes them  const, and remove the thread safety issue, in that if you try to write to them then the compiler will yell at you!

There is also precedent for this in Unit as we already had

```
src/nxt_conf_validation.c:2032:    static const nxt_str_t  wsgi = nxt_string("wsgi");
src/nxt_conf_validation.c:2033:    static const nxt_str_t  asgi = nxt_string("asgi");
src/nxt_conf_validation.c:2424:    static const nxt_str_t  http = nxt_string("http");
src/nxt_conf_validation.c:2425:    static const nxt_str_t  https = nxt_string("https");
src/nxt_controller.c:513:    static const nxt_str_t json = nxt_string(
src/nxt_controller.c:1281:    static const nxt_str_t empty_obj = nxt_string("{}");
src/nxt_h1proto.c:865:    static const nxt_str_t tmp_name_pattern = nxt_string("/req-XXXXXXXX");
src/nxt_h1proto.c:1230:    static const nxt_str_t  connection[3] = {
src/nxt_http_variables.c:521:    static const nxt_str_t  connection[3] = {
src/nxt_php_sapi.c:196:    static const nxt_str_t  chdir = nxt_string("chdir");
src/nxt_router.c:273:static const nxt_str_t http_prefix = nxt_string("HTTP_");
src/nxt_router.c:274:static const nxt_str_t empty_prefix = nxt_string("");
```

Why?

Well it helps improve the code quality by helping to reduce programmer errors, by enabling the compiler to warn you when you are trying to modify something you shouldn't.

As Linus [said](https://yarchive.net/comp/const.html)

> - Anything that *can* take a const pointer should always do so.

With the current fad of C bashing about it being _unsafe_, let's show the doom-sayers that there are things we can do in C (and more so with modern C) that can help eliminate whole classes of problems and this is just _one small_ part of that.