### PR TITLE
.mailmap: Add an entry for Ava's GitHub address

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -6,6 +6,7 @@ Andrei Zeliankou <zelenkov@nginx.com> <xim.andrew@gmail.com>
 Andrew Clayton <a.clayton@nginx.com> <andrew@digital-domain.net>
 Andrew Clayton <a.clayton@nginx.com> <a.clayton@f5.com>
 Artem Konev <artem.konev@nginx.com> <41629299+artemkonev@users.noreply.github.com>
+Ava Hahn <a.hahn@f5.com> <110854134+avahahn@users.noreply.github.com>
 Dan Callahan <d.callahan@f5.com> <dan.callahan@gmail.com>
 Danielle De Leo <d.deleo@f5.com> <danielle@fastmail.net>
 Dylan Arbour <d.arbour@f5.com> <arbourd@users.noreply.github.com>


### PR DESCRIPTION
You can always see the original names/addresses used by passing --no-mailmap to the various git commands.

See gitmailmap(5)