### PR TITLE
Add GitHub workflows for extra coverage

### DIFF
--- a/.github/workflows/ci-dev-distro-compiler.yaml
+++ b/.github/workflows/ci-dev-distro-compiler.yaml
@@ -1,0 +1,177 @@
+name: "CI - Fedora Rawhide / Alpine Edge / GCC / Clang"
+
+on:
+  push:
+    branches: master
+    paths:
+      - configure
+      - 'auto/**'
+      - 'src/**'
+      - 'test/**'
+      - '.github/workflows/ci-dev-distro-compiler.yaml'
+  pull_request:
+    branches: master
+    paths:
+      - configure
+      - 'auto/**'
+      - 'src/**'
+      - 'test/**'
+      - '.github/workflows/ci-dev-distro-compiler.yaml'
+
+jobs:
+
+  fedora-rawhide:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [ 'gcc', 'clang' ]
+
+    container:
+      image: fedora:rawhide
+
+    steps:
+      - name: Install tools/deps
+        run: |
+          dnf -y update
+          dnf -y install --setopt=install_weak_deps=False \
+              which wget git gcc make pcre2-devel openssl-devel \
+              python-unversioned-command python3 python3-devel \
+              php-devel php-embedded perl-devel perl-ExtUtils-Embed \
+              ruby-devel java-devel nodejs-devel nodejs-npm golang
+          if [ "${{ matrix.compiler }}" = "clang" ]; then
+            dnf -y install --setopt=install_weak_deps=False clang
+          fi
+          npm install -g node-gyp
+
+      - uses: actions/checkout@v4
+
+      - name: configure unit CC=${{ matrix.compiler }}
+        run: |
+          if [ "${{ matrix.compiler }}" = "clang" ]; then
+            ./configure --openssl --cc=clang
+          else
+            ./configure --openssl
+          fi
+
+      - name: make unit
+        run: make -j 4
+
+      - name: configure unit-php
+        run: ./configure php
+
+      - name: make unit-php
+        run: make -j 4 php
+
+      - name: configure unit-python
+        run: ./configure python
+
+      - name: make unit-python
+        run: make -j 4 python
+
+      - name: configure unit-perl
+        run: ./configure perl
+        if: matrix.compiler == 'gcc'
+
+      - name: make unit-perl
+        run: make -j 4 perl
+        if: matrix.compiler == 'gcc'
+
+      - name: configure unit-ruby
+        run: ./configure ruby
+
+      - name: make unit-ruby
+        run: make -j 4 ruby
+
+      - name: configure unit-java
+        run: ./configure java
+
+      - name: make unit-java
+        run: make -j 4 java
+
+      - name: configure unit-nodejs
+        run: ./configure nodejs
+
+      - name: make unit-nodejs
+        run: make node-local-install DESTDIR=node
+
+      - name: configure unit-go
+        run: ./configure go --go-path=
+
+      - name: make unit-go
+        run: make go-install
+
+      - name: Install wasmtime
+        run: |
+          wget -O- https://github.com/bytecodealliance/wasmtime/releases/download/v20.0.0/wasmtime-v20.0.0-x86_64-linux-c-api.tar.xz | tar -xJf -
+
+      - name: configure unit-wasm
+        run: ./configure wasm --include-path=wasmtime-v20.0.0-x86_64-linux-c-api/include --lib-path=wasmtime-v20.0.0-x86_64-linux-c-api/lib --rpath
+
+      - name: make unit-wasm
+        run: make wasm
+
+  alpine-edge:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [ 'gcc', 'clang' ]
+
+    container:
+      image: alpine:edge
+
+    steps:
+      - name: Install tools/deps
+        run: |
+          apk update && apk upgrade
+          apk add gcc make musl-dev openssl-dev pcre2-dev curl \
+              php83-dev php83-embed python3-dev perl-dev ruby-dev openjdk21-jdk
+          if [ "${{ matrix.compiler }}" = "clang" ]; then
+            apk add clang
+          fi
+
+      - uses: actions/checkout@v4
+
+      - name: configure unit CC=${{ matrix.compiler }}
+        run: |
+          if [ "${{ matrix.compiler }}" = "clang" ]; then
+            ./configure --openssl --cc=clang
+          else
+            ./configure --openssl
+          fi
+
+      - name: make unit
+        run: make -j 4
+
+      - name: configure unit-php
+        run: ln -s /usr/lib/libphp83.so /usr/lib/libphp.so && ./configure php
+
+      - name: make unit-php
+        run: make -j 4
+
+      - name: configure unit-python
+        run: ./configure python
+
+      - name: make unit-python
+        run: make -j 4
+
+      - name: configure unit-perl
+        run: ./configure perl
+
+      - name: make unit-perl
+        run: make -j 4 perl
+
+      - name: configure unit-ruby
+        run: ./configure ruby
+
+      - name: make unit-ruby
+        run: make -j 4 ruby
+
+      - name: configure unit-java
+        run: ./configure java
+
+      - name: make unit-java
+        run: make -j 4 java

--- a/.mailmap
+++ b/.mailmap
@@ -6,6 +6,7 @@ Andrei Zeliankou <zelenkov@nginx.com> <xim.andrew@gmail.com>
 Andrew Clayton <a.clayton@nginx.com> <andrew@digital-domain.net>
 Andrew Clayton <a.clayton@nginx.com> <a.clayton@f5.com>
 Artem Konev <artem.konev@nginx.com> <41629299+artemkonev@users.noreply.github.com>
+Ava Hahn <a.hahn@f5.com> <110854134+avahahn@users.noreply.github.com>
 Dan Callahan <d.callahan@f5.com> <dan.callahan@gmail.com>
 Danielle De Leo <d.deleo@f5.com> <danielle@fastmail.net>
 Dylan Arbour <d.arbour@f5.com> <arbourd@users.noreply.github.com>


### PR DESCRIPTION
This adds a workflow for building Unit under Fedora Rawhide and Alpine
Edge with both GCC and Clang.

These are the development branches from which releases are cut.

This usually consists of the latest versions of software and will
hopefully catch new compiler issues and API breakages in the various
languages we support.

With Alpine and Clang that also gives us musl libc + clang coverage.

On Alpine we don't build the wasm and wasm-wasi-component modules,
mainly as this would require messing around with all the rust stuff and
building wasmtime from source (as there's no musl libc based packages)
and the wasm module is pretty small, any new compiler issues would
hopefully show up in the rest.

We _do_ build the wasm module with gcc and clang on Fedora. But not
wasm-wasi-component in the interests of time. Can be added at a later
date if deemed necessary.

We don't build the Perl language module on Fedora with clang due to the
Fedora (and probably Red Hat) Perl CFLAGS having incompatible with clang
flags.

We probably could work around it if we really wanted to, but not sure
it's worth it and on Red Hat/Fedora, GCC _is_ the system compiler.

On Alpine we also don't build the nodejs and go language modules as
there's nothing that actually gets compiled there and the _main_ reason
for building on Alpine is to get musl libc + clang coverage.

We're also not bothering with njs for now... can be revisited at a
later date.

Also no pytests, these should be well covered via other workflows for
example by running on latest Alpine releases.