### PR TITLE
mkdir -p $runstatedir at run time, not install time

### DIFF
--- a/auto/make
+++ b/auto/make
@@ -434,8 +434,6 @@ ${NXT_DAEMON}-install: $NXT_DAEMON install-check
 		|| install -d \$(DESTDIR)$NXT_STATEDIR
 	test -d \$(DESTDIR)$NXT_LOGDIR \
 		|| install -d \$(DESTDIR)$NXT_LOGDIR
-	test -d \$(DESTDIR)$NXT_RUNSTATEDIR \
-		|| install -d \$(DESTDIR)$NXT_RUNSTATEDIR
 
 manpage-install: manpage install-check
 	test -d \$(DESTDIR)$NXT_MANDIR/man8 \

--- a/configure
+++ b/configure
@@ -67,7 +67,6 @@ mkdir -p $NXT_BUILD_DIR/src
 mkdir -p $NXT_BUILD_DIR/src/test
 mkdir -p $NXT_BUILD_DIR/var/lib/unit
 mkdir -p $NXT_BUILD_DIR/var/log/unit
-mkdir -p $NXT_BUILD_DIR/var/run/unit
 
 
 > $NXT_AUTOCONF_ERR

--- a/src/nxt_controller.c
+++ b/src/nxt_controller.c
@@ -695,7 +695,7 @@ nxt_runtime_controller_socket(nxt_task_t *task, nxt_runtime_t *rt)
     if (ls->sockaddr->u.sockaddr.sa_family == AF_UNIX) {
         const char *path = ls->sockaddr->u.sockaddr_un.sun_path;
 
-        nxt_fs_mkdir_parent((const u_char *) path, 0755);
+        nxt_fs_mkdir_parents_dirname((const u_char *) path, 0755);
     }
 #endif
 

--- a/src/nxt_fs.c
+++ b/src/nxt_fs.c
@@ -62,11 +62,14 @@ nxt_fs_mkdir_parent(const u_char *path, mode_t mode)
     ret = NXT_OK;
 
     ptr = strrchr(dir, '/');
-    if (nxt_fast_path(ptr != NULL)) {
-        *ptr = '\0';
-        ret = nxt_fs_mkdir((const u_char *) dir, mode);
+    if (nxt_slow_path(ptr == NULL)) {
+        goto out_free;
     }
 
+    *ptr = '\0';
+    ret = nxt_fs_mkdir((const u_char *) dir, mode);
+
+out_free:
     nxt_free(dir);
 
     return ret;

--- a/src/nxt_fs.c
+++ b/src/nxt_fs.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) NGINX, Inc.
+ * Copyright 2024, Alejandro Colomar <alx@kernel.org>
  */
 
 #include <nxt_main.h>
@@ -62,7 +63,7 @@ nxt_fs_mkdir_parent(const u_char *path, mode_t mode)
     ret = NXT_OK;
 
     ptr = strrchr(dir, '/');
-    if (nxt_slow_path(ptr == NULL)) {
+    if (nxt_slow_path(ptr == NULL || ptr == dir)) {
         goto out_free;
     }
 

--- a/src/nxt_fs.h
+++ b/src/nxt_fs.h
@@ -6,7 +6,7 @@
 #define _NXT_FS_H_INCLUDED_
 
 
-nxt_int_t nxt_fs_mkdir_parent(const u_char *path, mode_t mode);
+nxt_int_t nxt_fs_mkdir_parents_dirname(const u_char *path, mode_t mode);
 nxt_int_t nxt_fs_mkdir_all(const u_char *dir, mode_t mode);
 
 

--- a/src/nxt_runtime.c
+++ b/src/nxt_runtime.c
@@ -1490,7 +1490,7 @@ nxt_runtime_pid_file_create(nxt_task_t *task, nxt_file_name_t *pid_file)
 
     file.name = pid_file;
 
-    nxt_fs_mkdir_parent(pid_file, 0755);
+    nxt_fs_mkdir_parents_dirname(pid_file, 0755);
 
     n = nxt_file_open(task, &file, O_WRONLY, O_CREAT | O_TRUNC,
                       NXT_FILE_DEFAULT_ACCESS);


### PR DESCRIPTION
Not tested.  I just built it.

Closes: https://github.com/nginx/unit/issues/742
Fixes: 5a37171f733fa8c7326161cc49af3df0be5dfae4 ("Added default values for pathnames.")
Fixes: 57fc9201cb91e3d8901a64e3daaaf31684ee5bf5 ("Socket: Created control socket & pid file directories.")
Reported-by: @andypost
Cc: @ac000 
Cc: @thresheek 
Cc: @lcrilly 