### PR TITLE
Fix building the Perl language module with clang (on some systems)

### DIFF
--- a/auto/modules/perl
+++ b/auto/modules/perl
@@ -67,6 +67,12 @@ if /bin/sh -c "$NXT_PERL -MConfig -e 'print \"Perl version: \",
                          | sed -e 's/-arch i386//' -e 's/-arch x86_64//'`
     fi
 
+    if [ "$NXT_CC_NAME" = "clang" ]; then
+        # Perl's CFLAGS has -fwrapv which under clang discards our
+        # -fno-strict-overflow resulting in an unused argument error
+        NXT_PERL_CFLAGS="$NXT_PERL_CFLAGS -Qunused-arguments"
+    fi
+
     nxt_feature="Perl"
     nxt_feature_name=""
     nxt_feature_run=no


### PR DESCRIPTION
When we added -fno-strict-overflow to the CFLAGS back in c1e3f02f9 ("Compile with -fno-strict-overflow") we inadvertently broke building the Perl language module with clang, e.g

```
  $ make
    CC     build/src/perl/nxt_perl_psgi-perl.o
  clang: error: argument unused during compilation: '-fno-strict-overflow' [-Werror,-Wunused-command-line-argument]
```

This is due to for example on Apline

```
  $ perl -MExtUtils::Embed -e ccflags
   -D_REENTRANT -D_GNU_SOURCE -D_GNU_SOURCE -fwrapv -fno-strict-aliasing -pipe -fstack-protector-strong -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
```

Where on clang the -fwrapv causes the -fno-strict-overflow to be discarded resulting in the above error.

We can get around that by simply appending -Qunused-arguments to the Perl CFLAGS.

This fixes things for _some_ systems, as there is actually another issue with building this with clang on Fedora (and probably Red Hat) in that there the Perl ccflags & ldopts have been heavily modified and uses flags simply not only not in clang (which we can work around as above) but also incompatible flags, e.g

```
  $ make perl
    CC     build/src/perl/nxt_perl_psgi-perl.o
  clang: error: optimization flag '-ffat-lto-objects' is not supported [-Werror,-Wignored-optimization-argument]
```

There ddoesn't seem to be an easy workaround like -Qunused-arguments for this.

While we could work around it in some way, I'm not sure it's worth the effort right now. On Red Hat & Fedora GCC _is_ the system compiler.

This could be revisited if we find people trying to build this on Red Hat/Fedora with clang...

For comparison this is the Alpine Perl ccflags & ldops

```
$ perl -MExtUtils::Embed -e ccflags
 -D_REENTRANT -D_GNU_SOURCE -D_GNU_SOURCE -fwrapv -fno-strict-aliasing -pipe -fstack-protector-strong -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 alpine:~$
$ perl -MExtUtils::Embed -e ldopts
-rdynamic -Wl,-rpath,/usr/lib/perl5/core_perl/CORE  -fstack-protector-strong -L/usr/local/lib  -L/usr/lib/perl5/core_perl/CORE -lperl -lpthread -ldl -lm -lcrypt -lutil -lc
```

Fedora

```
$ perl -MExtUtils::Embed -e ccflags
 -D_REENTRANT -D_GNU_SOURCE -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Wno-complain-wrong-lang -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fwrapv -fno-strict-aliasing -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
$ perl -MExtUtils::Embed -e ldopts
-Wl,--enable-new-dtags -Wl,-z,relro -Wl,--as-needed -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -Wl,--build-id=sha1  -Wl,-z,relro -Wl,--as-needed -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -Wl,--build-id=sha1  -fstack-protector-strong -L/usr/local/lib  -L/usr/lib64/perl5/CORE -lperl -lpthread -lresolv -ldl -lm -lcrypt -lutil -lc
```