### PR TITLE
No need to explicitly set -fno-strict-aliasing in the wasm module now

### DIFF
--- a/auto/modules/wasm
+++ b/auto/modules/wasm
@@ -63,8 +63,7 @@ NXT_WASM_LDFLAGS=
 if [ "$NXT_WASM_RUNTIME" = "wasmtime" ]; then
     NXT_WASM_LDFLAGS=-lwasmtime
 fi
-NXT_WASM_ADDITIONAL_FLAGS="-fno-strict-aliasing \
- -Wno-missing-field-initializers \
+NXT_WASM_ADDITIONAL_FLAGS="-Wno-missing-field-initializers \
  -DNXT_HAVE_WASM_$(echo ${NXT_WASM_RUNTIME} | tr 'a-z' 'A-Z') \
 "
 


### PR DESCRIPTION
Since commit 0b5223e1c ("Disable strict-aliasing in clang by default") we explicitly always build with -fno-strict-aliasing so there's no need to set it independently in auto/modules/wasm