### PR TITLE
Docker via CLI

### DIFF
--- a/tools/unitctl/Cargo.lock
+++ b/tools/unitctl/Cargo.lock
@@ -27,6 +27,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,6 +144,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+
+[[package]]
 name = "bindgen"
 version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,6 +194,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "bollard"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aed08d3adb6ebe0eff737115056652670ae290f177759aac19c30456135f94c"
+dependencies = [
+ "base64 0.22.0",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http 1.1.0",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-named-pipe",
+ "hyper-util",
+ "hyperlocal-next",
+ "log",
+ "pin-project-lite",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.44.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709d9aa1c37abb89d40f19f5d0ad6f0d88cb1581264e571c9350fc5bb89cf1c5"
+dependencies = [
+ "serde",
+ "serde_repr",
+ "serde_with",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
 name = "bytes"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,6 +274,19 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-targets 0.52.0",
+]
 
 [[package]]
 name = "clang-sys"
@@ -356,6 +440,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f8a51dd197fa6ba5b4dc98a990a43cc13693c23eb0089ebb0fcc1f04152bca6"
 
 [[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+ "serde",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,6 +470,12 @@ name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -569,6 +669,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,13 +716,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.8",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -642,8 +782,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.8",
+ "http-body 0.4.5",
  "httparse",
  "httpdate",
  "itoa",
@@ -656,16 +796,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper 1.3.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.27",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.3.1",
+ "pin-project-lite",
+ "socket2 0.5.5",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -676,9 +870,47 @@ checksum = "0fafdf7b2b2de7c9784f76e02c0935e65a8117ec3b768644379983ab333ac98c"
 dependencies = [
  "futures-util",
  "hex",
- "hyper",
+ "hyper 0.14.27",
  "pin-project",
  "tokio",
+]
+
+[[package]]
+name = "hyperlocal-next"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acf569d43fa9848e510358c07b80f4adf34084ddc28c6a4a651ee8474c070dcc"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -698,7 +930,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.3",
+ "serde",
 ]
 
 [[package]]
@@ -723,6 +967,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -882,6 +1135,12 @@ dependencies = [
  "num-traits",
  "serde",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-traits"
@@ -1054,6 +1313,12 @@ name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1238,7 +1503,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35e4980fa29e4c4b212ffb3db068a564cbf560e51d3944b7c88bd8bf5bec64f4"
 dependencies = [
- "base64",
+ "base64 0.21.5",
  "rustls-pki-types",
 ]
 
@@ -1316,22 +1581,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1340,10 +1605,50 @@ version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.1",
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c85f8e96d1d6857f13768fcbd895fcb06225510022a2774ed8b5150581847b0"
+dependencies = [
+ "base64 0.22.0",
+ "chrono",
+ "hex",
+ "indexmap 1.9.1",
+ "indexmap 2.2.6",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
 ]
 
 [[package]]
@@ -1352,7 +1657,7 @@ version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d232d893b10de3eb7258ff01974d6ee20663d8e833263c99409d4b13a0209da"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.1",
  "itoa",
  "ryu",
  "serde",
@@ -1384,6 +1689,12 @@ checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
@@ -1494,6 +1805,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1515,6 +1857,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
 dependencies = [
  "backtrace",
+ "bytes",
  "libc",
  "mio",
  "num_cpus",
@@ -1546,6 +1889,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1558,6 +1937,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
  "tracing-core",
 ]
@@ -1614,13 +1994,15 @@ dependencies = [
 name = "unit-client-rs"
 version = "0.4.0-beta"
 dependencies = [
+ "bollard",
  "custom_error",
  "futures",
  "hex",
- "hyper",
+ "hyper 0.14.27",
  "hyper-tls",
  "hyperlocal",
  "rand",
+ "regex",
  "rustls",
  "serde",
  "serde_json",
@@ -1634,10 +2016,10 @@ dependencies = [
 name = "unit-openapi"
 version = "0.4.0-beta"
 dependencies = [
- "base64",
+ "base64 0.21.5",
  "futures",
- "http",
- "hyper",
+ "http 0.2.8",
+ "hyper 0.14.27",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1652,7 +2034,7 @@ dependencies = [
  "colored_json",
  "custom_error",
  "futures",
- "hyper",
+ "hyper 0.14.27",
  "hyper-tls",
  "hyperlocal",
  "json5",
@@ -1734,6 +2116,60 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "which"

--- a/tools/unitctl/Cargo.lock
+++ b/tools/unitctl/Cargo.lock
@@ -391,6 +391,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,12 +425,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.12"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
-dependencies = [
- "cfg-if",
-]
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crypto-common"
@@ -1227,6 +1233,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
+name = "pbr"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5827dfa0d69b6c92493d6c38e633bbaa5937c153d0d7c28bf12313f8c6d514"
+dependencies = [
+ "crossbeam-channel",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2001,6 +2018,7 @@ dependencies = [
  "hyper 0.14.27",
  "hyper-tls",
  "hyperlocal",
+ "pbr",
  "rand",
  "regex",
  "rustls",

--- a/tools/unitctl/README.md
+++ b/tools/unitctl/README.md
@@ -36,9 +36,9 @@ desired.
 
 ## Features (Current)
 
-### Consumes alternative configuration formats Like YAML and converts them
-### Syntactic highlighting of JSON output
-### Interpretation of UNIT errors with (arguably more) useful error messages
+- Consumes alternative configuration formats Like YAML and converts them
+- Syntactic highlighting of JSON output
+- Interpretation of UNIT errors with (arguably more) useful error messages
 
 ### Lists all running UNIT processes and provides details about each process.
 ```
@@ -51,6 +51,30 @@ unitd instance [pid: 79489, version: 1.32.0]:
   Runtime flags: --no-daemon
   Configure options: --prefix=/opt/unit --user=elijah --group=elijah --openssl
 ```
+
+### Start a new UNIT process via docker
+```
+$ unitctl instances new /tmp/2 $(pwd) 'unit:wasm'
+Pulling and starting a container from unit:wasm
+Will mount /tmp/2 to /var/run for socket access
+Will READ ONLY mount /home/ava/repositories/nginx/unit/tools/unitctl to /www for application access
+Note: Container will be on host network
+
+```
+
+To the subcommand `unitctl instances new` the user must provide three things:
+1. **A directory such as `/tmp/2`.**
+   The UNIT container will mount this to `/var/run` internally.
+   Thus, the control socket and pid file will be accessible from the host.
+2. **A path to an application.**
+   In the example, `$(pwd)` is provided. The UNIT container will mount
+   this READ ONLY to `/www/`. This will allow the user to configure
+   their UNIT container to expose an application stored on the host.
+3. **An image tag.**
+   In the example, `unit:wasm` is used. This will be the image that unitctl
+   will deploy. Custom repos and images can be deployed in this manner.
+
+After deployment the user will have one UNIT container running on the host network.
 
 ### Lists active listeners from running UNIT processes
 ```
@@ -109,13 +133,6 @@ $ unitctl edit
 }
 ```
 
-### Display interactive OpenAPI control panel
-```
-$ unitctl ui
-Starting UI server on http://127.0.0.1:3000/control-ui/
-Press Ctrl-C to stop the server
-```
-
 ### Import configuration, certificates, and NJS modules from directory
 ```
 $ unitctl import /opt/unit/config
@@ -124,6 +141,7 @@ Imported /opt/unit/config/hello.js -> /js_modules/hello.js
 Imported /opt/unit/config/put.json -> /config
 Imported 3 files
 ```
+
 ### Wait for socket to become available
 ```
 $ unitctl --wait-timeout-seconds=3 --wait-max-tries=4 import /opt/unit/config`

--- a/tools/unitctl/README.md
+++ b/tools/unitctl/README.md
@@ -1,7 +1,7 @@
-# NGINX UNIT Rust SDK and CLI
+# NGINX Unit Rust SDK and CLI
 
 This project provides a Rust SDK interface to the
-[NGINX UNIT](https://unit.nginx.org/)
+[NGINX Unit](https://unit.nginx.org/)
 [control API](https://unit.nginx.org/howto/source/#source-startup)
 and a CLI (`unitctl`) that exposes the functionality provided by the SDK.
 
@@ -38,9 +38,9 @@ desired.
 
 - Consumes alternative configuration formats Like YAML and converts them
 - Syntactic highlighting of JSON output
-- Interpretation of UNIT errors with (arguably more) useful error messages
+- Interpretation of Unit errors with (arguably more) useful error messages
 
-### Lists all running UNIT processes and provides details about each process.
+### Lists all running Unit processes and provides details about each process.
 ```
 $ unitctl instances
 No socket path provided - attempting to detect from running instance
@@ -52,7 +52,7 @@ unitd instance [pid: 79489, version: 1.32.0]:
   Configure options: --prefix=/opt/unit --user=elijah --group=elijah --openssl
 ```
 
-### Start a new UNIT process via docker
+### Start a new Unit process via docker
 ```
 $ unitctl instances new /tmp/2 $(pwd) 'unit:wasm'
 Pulling and starting a container from unit:wasm
@@ -64,19 +64,19 @@ Note: Container will be on host network
 
 To the subcommand `unitctl instances new` the user must provide three things:
 1. **A directory such as `/tmp/2`.**
-   The UNIT container will mount this to `/var/run` internally.
+   The Unit container will mount this to `/var/run` internally.
    Thus, the control socket and pid file will be accessible from the host.
 2. **A path to an application.**
-   In the example, `$(pwd)` is provided. The UNIT container will mount
+   In the example, `$(pwd)` is provided. The Unit container will mount
    this READ ONLY to `/www/`. This will allow the user to configure
-   their UNIT container to expose an application stored on the host.
+   their Unit container to expose an application stored on the host.
 3. **An image tag.**
    In the example, `unit:wasm` is used. This will be the image that unitctl
    will deploy. Custom repos and images can be deployed in this manner.
 
-After deployment the user will have one UNIT container running on the host network.
+After deployment the user will have one Unit container running on the host network.
 
-### Lists active listeners from running UNIT processes
+### Lists active listeners from running Unit processes
 ```
 unitctl listeners
 No socket path provided - attempting to detect from running instance
@@ -87,7 +87,7 @@ No socket path provided - attempting to detect from running instance
 }
 ```
 
-### Get the current status of NGINX UNIT processes
+### Get the current status of NGINX Unit processes
 ```
 $ unitctl status -t yaml
 No socket path provided - attempting to detect from running instance
@@ -101,7 +101,7 @@ requests:
 applications: {}
 ```
 
-### Send arbitrary configuration payloads to UNIT
+### Send arbitrary configuration payloads to Unit
 ```
 $ echo '{
     "listeners": {

--- a/tools/unitctl/README.md
+++ b/tools/unitctl/README.md
@@ -6,10 +6,23 @@ This project provides a Rust SDK interface to the
 and a CLI (`unitctl`) that exposes the functionality provided by the SDK.
 
 ## Installation and Use
-In order to build and use `unitctl` one needs a working installation of Maven
-and Cargo. It is recommended to procure Cargo with Rustup. Rustup is packaged
+In order to build and use `unitctl` one needs a working installation of
+Cargo. It is recommended to procure Cargo with Rustup. Rustup is packaged
 for use in many systems, but you can also find it at its
-[Official Site](https://rustup.rs/).
+[Official Site](https://rustup.rs/). Additionally, Macintosh users will
+need to install GNU core utilities using brew (see the following command)
+
+```
+$ brew install make gnu-sed grep gawk maven
+```
+
+After installing a modern distribution of Make, Macintosh users can invoke
+the makefile commands using `gmake`. For example: `gmake clean` or `gmake all`.
+
+Finally, in order to run the OpenAPI code generation tooling, Users will
+need a working
+[Java runtime](https://www.java.com/en/)
+as well as Maven. Macintosh users can install Maven from Brew.
 
 With a working installation of Cargo it is advised to build unitctl with the
 provided makefile. The `list-targets` target will inform the user of what
@@ -20,8 +33,10 @@ built with `make all`. See the below example for illustration:
 ```
 [ava@calliope cli]$ make list-targets
 x86_64-unknown-linux-gnu
+
 [ava@calliope cli]$ make x86_64-unknown-linux-gnu
 ▶ building unitctl with flags [--quiet --release --bin unitctl --target x86_64-unknown-linux-gnu]
+
 [ava@calliope cli]$ file ./target/x86_64-unknown-linux-gnu/release/unitctl
 ./target/x86_64-unknown-linux-gnu/release/unitctl: ELF 64-bit LSB pie executable,
 x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2,

--- a/tools/unitctl/unit-client-rs/Cargo.toml
+++ b/tools/unitctl/unit-client-rs/Cargo.toml
@@ -29,6 +29,7 @@ unit-openapi = { path = "../unit-openapi" }
 rustls = "0.23.5"
 bollard = "0.16.1"
 regex = "1.10.4"
+pbr = "1.1.1"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/tools/unitctl/unit-client-rs/Cargo.toml
+++ b/tools/unitctl/unit-client-rs/Cargo.toml
@@ -27,6 +27,8 @@ which = "5.0"
 
 unit-openapi = { path = "../unit-openapi" }
 rustls = "0.23.5"
+bollard = "0.16.1"
+regex = "1.10.4"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/tools/unitctl/unit-client-rs/src/lib.rs
+++ b/tools/unitctl/unit-client-rs/src/lib.rs
@@ -10,6 +10,7 @@ mod runtime_flags;
 pub mod unit_client;
 mod unitd_cmd;
 pub mod unitd_configure_options;
+pub mod unitd_docker;
 pub mod unitd_instance;
 pub mod unitd_process;
 mod unitd_process_user;

--- a/tools/unitctl/unit-client-rs/src/unit_client.rs
+++ b/tools/unitctl/unit-client-rs/src/unit_client.rs
@@ -66,6 +66,9 @@ custom_error! {pub UnitClientError
         executable_path: String,
         pid: u64
     } = "{message} for [pid={pid}, executable_path={executable_path}]: {source}",
+    UnitdDockerError {
+        message: String
+    } = "Failed to communicate with docker daemon: {message}",
 }
 
 impl UnitClientError {

--- a/tools/unitctl/unit-client-rs/src/unit_client.rs
+++ b/tools/unitctl/unit-client-rs/src/unit_client.rs
@@ -250,7 +250,7 @@ impl UnitClient {
                 Err(Box::new(UnitClientError::new(
                     hyper_error,
                     self.control_socket.to_string(),
-                    "".to_string(),
+                    "/listeners".to_string(),
                 )))
             } else {
                 Err(Box::new(UnitClientError::OpenAPIError { source: err }))
@@ -268,7 +268,7 @@ impl UnitClient {
                 Err(Box::new(UnitClientError::new(
                     hyper_error,
                     self.control_socket.to_string(),
-                    "".to_string(),
+                    "/status".to_string(),
                 )))
             } else {
                 Err(Box::new(UnitClientError::OpenAPIError { source: err }))

--- a/tools/unitctl/unit-client-rs/src/unitd_cmd.rs
+++ b/tools/unitctl/unit-client-rs/src/unitd_cmd.rs
@@ -28,11 +28,13 @@ impl UnitdCmd {
             .expect("Unable to parse cmd")
             .splitn(2, " [")
             .collect::<Vec<&str>>();
+
         if parts.len() != 2 {
             let msg = format!("cmd does not have the expected format: {}", process_cmd);
             return Err(IoError::new(ErrorKind::InvalidInput, msg).into());
         }
-        let version: Option<String> = Some(parts[0].to_string());
+
+        let version = Some(parts[0].to_string());
         let executable_path = UnitdCmd::parse_executable_path_from_cmd(parts[1], binary_name);
         let flags = UnitdCmd::parse_runtime_flags_from_cmd(parts[1]);
 
@@ -69,6 +71,7 @@ impl UnitdCmd {
         if cmd.is_empty() {
             return None;
         }
+
         // Split out everything in between the brackets [ and ]
         let split = cmd.trim_end_matches(']').splitn(2, '[').collect::<Vec<&str>>();
         if split.is_empty() {

--- a/tools/unitctl/unit-client-rs/src/unitd_docker.rs
+++ b/tools/unitctl/unit-client-rs/src/unitd_docker.rs
@@ -1,0 +1,282 @@
+use std::collections::HashMap;
+use std::fs::read_to_string;
+use std::path::PathBuf;
+
+use crate::unitd_process::UnitdProcess;
+
+use bollard::secret::ContainerInspectResponse;
+use regex::Regex;
+use serde::ser::SerializeMap;
+use serde::{Serialize, Serializer};
+
+use bollard::{models::ContainerSummary, Docker};
+
+#[derive(Clone, Debug)]
+pub struct UnitdContainer {
+    pub container_id: Option<String>,
+    pub container_image: String,
+    pub command: Option<String>,
+    pub mounts: HashMap<PathBuf, PathBuf>,
+    pub platform: String,
+    details: Option<ContainerInspectResponse>,
+}
+
+impl From<&ContainerSummary> for UnitdContainer {
+    fn from(ctr: &ContainerSummary) -> Self {
+        // we assume paths from the docker api are absolute
+        // they certainly have to be later...
+        let mut mounts = HashMap::new();
+        if let Some(mts) = &ctr.mounts {
+            for i in mts {
+                if let Some(ref src) = i.source {
+                    if let Some(ref dest) = i.destination {
+                        mounts.insert(PathBuf::from(dest.clone()), PathBuf::from(src.clone()));
+                    }
+                }
+            }
+        }
+
+        UnitdContainer {
+            container_id: ctr.id.clone(),
+            container_image: format!(
+                "{} (docker)",
+                ctr.image.clone().unwrap_or(String::from("unknown container")),
+            ),
+            command: ctr.command.clone(),
+            mounts: mounts,
+            platform: String::from("Docker"),
+            details: None,
+        }
+    }
+}
+
+impl From<&UnitdContainer> for UnitdProcess {
+    fn from(ctr: &UnitdContainer) -> Self {
+        let version = ctr.details.as_ref().and_then(|details| {
+            details.config.as_ref().and_then(|conf| {
+                conf.labels.as_ref().and_then(|labels| {
+                    labels
+                        .get("org.opencontainers.image.version")
+                        .and_then(|version| Some(version.clone()))
+                })
+            })
+        });
+        let command = ctr.command.clone().and_then(|cmd| {
+            Some(format!(
+                "{}{} [{}{}]",
+                "unit: main v",
+                version.or(Some(String::from(""))).unwrap(),
+                ctr.container_image,
+                ctr.rewrite_socket(
+                    cmd.strip_prefix("/usr/local/bin/docker-entrypoint.sh")
+                        .or_else(|| Some(""))
+                        .unwrap()
+                        .to_string())
+            ))
+        });
+        let mut cmds = vec![];
+        let _ = command.map_or((), |cmd| cmds.push(cmd));
+        UnitdProcess {
+            all_cmds: cmds,
+            binary_name: ctr.container_image.clone(),
+            process_id: ctr
+                .details
+                .as_ref()
+                .and_then(|details| {
+                    details
+                        .state
+                        .as_ref()
+                        .and_then(|state| state.pid.and_then(|pid| Some(pid.clone() as u64)))
+                })
+                .or(Some(0 as u64))
+                .unwrap(),
+            executable_path: None,
+            environ: vec![],
+            working_dir: ctr.details.as_ref().and_then(|details| {
+                details.config.as_ref().and_then(|conf| {
+                    Some(
+                        PathBuf::from(
+                            conf.working_dir
+                                .as_ref()
+                                .map_or(String::new(), |dir| ctr.host_path(dir.clone())),
+                        )
+                        .into_boxed_path(),
+                    )
+                })
+            }),
+            child_pids: vec![],
+            user: None,
+            effective_user: None,
+            container: Some(ctr.clone()),
+        }
+    }
+}
+
+impl Serialize for UnitdContainer {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_map(Some(5))?;
+        state.serialize_entry("container_id", &self.container_id)?;
+        state.serialize_entry("container_image", &self.container_image)?;
+        state.serialize_entry("command", &self.command)?;
+        state.serialize_entry("mounts", &self.mounts)?;
+        state.serialize_entry("platform", &self.platform)?;
+        state.end()
+    }
+}
+
+impl UnitdContainer {
+    pub async fn find_unitd_containers() -> Vec<UnitdContainer> {
+        if let Ok(docker) = Docker::connect_with_local_defaults() {
+            match docker.list_containers::<String>(None).await {
+                Err(e) => {
+                    eprintln!("{}", e);
+                    vec![]
+                }
+                Ok(summary) => {
+                    // cant do this functionally because of the async call
+                    let mut mapped = vec![];
+                    for ctr in summary {
+                        if ctr.clone().image.or(Some(String::new())).unwrap().contains("unit") {
+                            let mut c = UnitdContainer::from(&ctr);
+                            if let Some(names) = ctr.names {
+                                if names.len() > 0 {
+                                    let name = names[0].strip_prefix("/").or(Some(names[0].as_str())).unwrap();
+                                    if let Ok(cir) = docker.inspect_container(name, None).await {
+                                        c.details = Some(cir);
+                                    }
+                                }
+                            }
+                            mapped.push(c);
+                        }
+                    }
+                    mapped
+                }
+            }
+        } else {
+            vec![]
+        }
+    }
+
+    pub fn host_path(&self, container_path: String) -> String {
+        let cp = PathBuf::from(container_path);
+
+        // get only possible mount points
+        // sort to deepest mountpoint first
+        // assumed deepest possible mount point takes precedence
+        let mut keys = self
+            .mounts
+            .clone()
+            .into_keys()
+            .filter(|mp| cp.as_path().starts_with(mp))
+            .collect::<Vec<_>>();
+        keys.sort_by_key(|a| 0 as isize - a.ancestors().count() as isize);
+
+        // either return translated path or original prefixed with "container"
+        if keys.len() > 0 {
+            self.mounts[&keys[0]]
+                .clone()
+                .join(
+                    cp.as_path()
+                        .strip_prefix(keys[0].clone())
+                        .expect("error checking path prefix"),
+                )
+                .to_string_lossy()
+                .to_string()
+        } else {
+            format!("<container>:{}", cp.display())
+        }
+    }
+
+    pub fn rewrite_socket(&self, command: String) -> String {
+        command
+            .split(" ")
+            .map(|tok| if tok.starts_with("unix:") {
+                format!("unix:{}", self.host_path(
+                    tok.strip_prefix("unix:")
+                        .unwrap()
+                        .to_string()))
+            } else {
+                tok.to_string()
+            })
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    pub fn container_is_running(&self) -> Option<bool> {
+        self.details
+            .as_ref()
+            .and_then(|details| details.state.as_ref().and_then(|state| state.running))
+    }
+}
+
+/* Returns either 64 char docker container ID or None */
+pub fn pid_is_dockerized(pid: u64) -> bool {
+    let cg_filepath = format!("/proc/{}/cgroup", pid);
+    match read_to_string(cg_filepath) {
+        Err(e) => {
+            eprintln!("{}", e);
+            false
+        }
+        Ok(contents) => {
+            let docker_re = Regex::new(r"docker-([a-zA-Z0-9]{64})").unwrap();
+            docker_re.is_match(contents.as_str())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_path_translation() {
+        let mut mounts = HashMap::new();
+        mounts.insert("/1/2/3/4/5/6/7".into(), "/0".into());
+        mounts.insert("/root".into(), "/1".into());
+        mounts.insert("/root/mid".into(), "/2".into());
+        mounts.insert("/root/mid/child".into(), "/3".into());
+        mounts.insert("/mid/child".into(), "/4".into());
+        mounts.insert("/child".into(), "/5".into());
+
+        let ctr = UnitdContainer {
+            container_id: None,
+            container_image: String::from(""),
+            command: None,
+            platform: "test".to_string(),
+            details: None,
+            mounts: mounts,
+        };
+
+        assert_eq!(
+            "/3/c2/test".to_string(),
+            ctr.host_path("/root/mid/child/c2/test".to_string())
+        );
+        assert_eq!(
+            "<container>:/path/to/conf".to_string(),
+            ctr.host_path("/path/to/conf".to_string())
+        );
+    }
+
+    #[test]
+    fn test_unix_sock_path_translate() {
+        let mut mounts = HashMap::new();
+        mounts.insert("/var/run".into(), "/tmp".into());
+
+        let ctr = UnitdContainer {
+            container_id: None,
+            container_image: String::from(""),
+            command: None,
+            platform: "test".to_string(),
+            details: None,
+            mounts: mounts,
+        };
+
+        assert_eq!(
+            ctr.rewrite_socket("unitd --no-daemon --control unix:/var/run/control.unit.sock".to_string()),
+            "unitd --no-daemon --control unix:/tmp/control.unit.sock".to_string());
+
+    }
+}

--- a/tools/unitctl/unit-client-rs/src/unitd_docker.rs
+++ b/tools/unitctl/unit-client-rs/src/unitd_docker.rs
@@ -3,6 +3,7 @@ use std::fs::read_to_string;
 use std::path::PathBuf;
 
 use crate::unitd_process::UnitdProcess;
+use crate::unit_client::UnitClientError;
 
 use bollard::secret::ContainerInspectResponse;
 use regex::Regex;
@@ -210,6 +211,17 @@ impl UnitdContainer {
             .as_ref()
             .and_then(|details| details.state.as_ref().and_then(|state| state.running))
     }
+}
+
+/* deploys a new docker image of tag $image_tag.
+ * mounts $socket to /var/run in the new container.
+ * mounts $application to /www in the new container. */
+pub fn deploy_new_container(
+    _socket: &String,
+    _application: &String,
+    _image: &String
+) -> Result<(), UnitClientError> {
+    todo!()
 }
 
 /* Returns either 64 char docker container ID or None */

--- a/tools/unitctl/unit-client-rs/src/unitd_instance.rs
+++ b/tools/unitctl/unit-client-rs/src/unitd_instance.rs
@@ -26,6 +26,7 @@ impl Serialize for UnitdInstance {
     where
         S: Serializer,
     {
+        // 11 = fields to serialize
         let mut state = serializer.serialize_map(Some(11))?;
         let runtime_flags = self
             .process

--- a/tools/unitctl/unit-client-rs/src/unitd_instance.rs
+++ b/tools/unitctl/unit-client-rs/src/unitd_instance.rs
@@ -121,13 +121,10 @@ impl UnitdInstance {
                 Ok(_) if process.container.is_some() => {
                     let mut err = vec![];
                     // double check that it is running
-                    let running = process.container
-                        .as_ref()
-                        .unwrap()
-                        .container_is_running();
+                    let running = process.container.as_ref().unwrap().container_is_running();
 
                     if running.is_none() || !running.unwrap() {
-                        err.push(UnitClientError::UnitdProcessParseError{
+                        err.push(UnitClientError::UnitdProcessParseError {
                             message: "process container is not running".to_string(),
                             pid: process.process_id,
                         });
@@ -138,10 +135,8 @@ impl UnitdInstance {
                         configure_options: None,
                         errors: err,
                     }
-                },
-                Ok(unitd_path) => match UnitdConfigureOptions::new(
-                    &unitd_path.clone()
-                        .into_path_buf()) {
+                }
+                Ok(unitd_path) => match UnitdConfigureOptions::new(&unitd_path.clone().into_path_buf()) {
                     Ok(configure_options) => UnitdInstance {
                         process: process.to_owned(),
                         configure_options: Some(configure_options),

--- a/tools/unitctl/unit-client-rs/src/unitd_process.rs
+++ b/tools/unitctl/unit-client-rs/src/unitd_process.rs
@@ -64,12 +64,11 @@ impl UnitdProcess {
                 #[cfg(target_os = "linux")]
                 if pid_is_dockerized(p.0.as_u32().into()) {
                     false
-                } else {
-                    let parent_pid = p.1.parent();
-                    match parent_pid {
-                        Some(pid) => !unitd_processes.contains_key(&pid),
-                        None => false,
-                    }
+                }
+                let parent_pid = p.1.parent();
+                match parent_pid {
+                    Some(pid) => !unitd_processes.contains_key(&pid),
+                    None => false,
                 }
             })
             .map(|p| {

--- a/tools/unitctl/unit-client-rs/src/unitd_process.rs
+++ b/tools/unitctl/unit-client-rs/src/unitd_process.rs
@@ -27,6 +27,7 @@ impl Serialize for UnitdProcess {
     where
         S: Serializer,
     {
+        // 6 = fields to serialize
         let mut state = serializer.serialize_map(Some(6))?;
         state.serialize_entry("pid", &self.process_id)?;
         state.serialize_entry("user", &self.user)?;

--- a/tools/unitctl/unit-client-rs/src/unitd_process.rs
+++ b/tools/unitctl/unit-client-rs/src/unitd_process.rs
@@ -63,7 +63,7 @@ impl UnitdProcess {
             .filter(|p| {
                 #[cfg(target_os = "linux")]
                 if pid_is_dockerized(p.0.as_u32().into()) {
-                    false
+                    return false;
                 }
                 let parent_pid = p.1.parent();
                 match parent_pid {

--- a/tools/unitctl/unit-openapi/.gitattributes
+++ b/tools/unitctl/unit-openapi/.gitattributes
@@ -1,0 +1,1 @@
+README.md       whitespace=-blank-at-eof

--- a/tools/unitctl/unitctl/src/cmd/edit.rs
+++ b/tools/unitctl/unitctl/src/cmd/edit.rs
@@ -18,11 +18,11 @@ const EDITOR_KNOWN_LIST: [&str; 8] = [
     "emacs",
 ];
 
-pub(crate) fn cmd(cli: &UnitCtl, output_format: OutputFormat) -> Result<(), UnitctlError> {
-    let control_socket = wait::wait_for_socket(cli)?;
+pub(crate) async fn cmd(cli: &UnitCtl, output_format: OutputFormat) -> Result<(), UnitctlError> {
+    let control_socket = wait::wait_for_socket(cli).await?;
     let client = UnitClient::new(control_socket);
     // Get latest configuration
-    let current_config = send_empty_body_deserialize_response(&client, "GET", "/config")?;
+    let current_config = send_empty_body_deserialize_response(&client, "GET", "/config").await?;
 
     // Write JSON to temporary file - this file will automatically be deleted by the OS when
     // the last file handle to it is removed.
@@ -54,6 +54,7 @@ pub(crate) fn cmd(cli: &UnitCtl, output_format: OutputFormat) -> Result<(), Unit
 
     // Send edited file to UNIT to overwrite current configuration
     send_and_validate_config_deserialize_response(&client, "PUT", "/config", Some(&inputfile))
+        .await
         .and_then(|status| output_format.write_to_stdout(&status))
 }
 

--- a/tools/unitctl/unitctl/src/cmd/execute.rs
+++ b/tools/unitctl/unitctl/src/cmd/execute.rs
@@ -8,14 +8,14 @@ use crate::wait;
 use crate::{OutputFormat, UnitctlError};
 use unit_client_rs::unit_client::UnitClient;
 
-pub(crate) fn cmd(
+pub(crate) async fn cmd(
     cli: &UnitCtl,
     output_format: &OutputFormat,
     input_file: &Option<String>,
     method: &str,
     path: &str,
 ) -> Result<(), UnitctlError> {
-    let control_socket = wait::wait_for_socket(cli)?;
+    let control_socket = wait::wait_for_socket(cli).await?;
     let client = UnitClient::new(control_socket);
 
     let path_trimmed = path.trim();
@@ -28,10 +28,10 @@ pub(crate) fn cmd(
         eprintln!("Cannot use GET method with input file - ignoring input file");
     }
 
-    send_and_deserialize(client, method_upper, input_file_arg, path_trimmed, output_format)
+    send_and_deserialize(client, method_upper, input_file_arg, path_trimmed, output_format).await
 }
 
-fn send_and_deserialize(
+async fn send_and_deserialize(
     client: UnitClient,
     method: String,
     input_file: Option<InputFile>,
@@ -43,7 +43,8 @@ fn send_and_deserialize(
     // If we are sending a GET request to a JS modules directory, we want to print the contents of the JS file
     // instead of the JSON response
     if method.eq("GET") && is_js_modules_dir && path.ends_with(".js") {
-        let script = send_body_deserialize_response::<String>(&client, method.as_str(), path, input_file.as_ref())?;
+        let script =
+            send_body_deserialize_response::<String>(&client, method.as_str(), path, input_file.as_ref()).await?;
         println!("{}", script);
         return Ok(());
     }
@@ -52,17 +53,17 @@ fn send_and_deserialize(
     match input_file {
         Some(input_file) => {
             if input_file.is_config() {
-                send_and_validate_config_deserialize_response(&client, method.as_str(), path, Some(&input_file))
+                send_and_validate_config_deserialize_response(&client, method.as_str(), path, Some(&input_file)).await
                 // TLS certificate data
             } else if input_file.is_pem_bundle() {
-                send_and_validate_pem_data_deserialize_response(&client, method.as_str(), path, &input_file)
+                send_and_validate_pem_data_deserialize_response(&client, method.as_str(), path, &input_file).await
                 // This is unknown data
             } else {
                 panic!("Unknown input file type")
             }
         }
         // A none value for an input file can be considered a request to send an empty body
-        None => send_empty_body_deserialize_response(&client, method.as_str(), path),
+        None => send_empty_body_deserialize_response(&client, method.as_str(), path).await,
     }
     .and_then(|status| output_format.write_to_stdout(&status))
 }

--- a/tools/unitctl/unitctl/src/cmd/instances.rs
+++ b/tools/unitctl/unitctl/src/cmd/instances.rs
@@ -1,16 +1,37 @@
 use crate::{OutputFormat, UnitctlError};
+use crate::unitctl::{InstanceArgs, InstanceCommands};
 use unit_client_rs::unitd_instance::UnitdInstance;
+use unit_client_rs::unitd_docker::deploy_new_container;
+use std::path::PathBuf;
 
-pub(crate) async fn cmd(output_format: OutputFormat) -> Result<(), UnitctlError> {
-    let instances = UnitdInstance::running_unitd_instances().await;
-    if instances.is_empty() {
-        Err(UnitctlError::NoUnitInstancesError)
-    } else if output_format.eq(&OutputFormat::Text) {
-        instances.iter().for_each(|instance| {
-            println!("{}", instance);
-        });
-        Ok(())
+pub(crate) async fn cmd(args: InstanceArgs) -> Result<(), UnitctlError> {
+    if let Some(cmd) = args.command {
+        match cmd {
+            InstanceCommands::New{
+                ref socket,
+                ref application,
+                ref image
+            } => {
+                if !PathBuf::from(socket).is_dir() || !PathBuf::from(application).is_dir() {
+                    eprintln!("application and socket paths must be directories");
+                    Err(UnitctlError::NoFilesImported)
+                } else {
+                    deploy_new_container(socket, application, image)
+                        .or_else(|e| Err(UnitctlError::UnitClientError{source: e}))
+                }
+            }
+        }
     } else {
-        output_format.write_to_stdout(&instances)
+        let instances = UnitdInstance::running_unitd_instances().await;
+        if instances.is_empty() {
+            Err(UnitctlError::NoUnitInstancesError)
+        } else if args.output_format.eq(&OutputFormat::Text) {
+            instances.iter().for_each(|instance| {
+                println!("{}", instance);
+            });
+            Ok(())
+        } else {
+            args.output_format.write_to_stdout(&instances)
+        }
     }
 }

--- a/tools/unitctl/unitctl/src/cmd/instances.rs
+++ b/tools/unitctl/unitctl/src/cmd/instances.rs
@@ -1,8 +1,8 @@
 use crate::{OutputFormat, UnitctlError};
 use unit_client_rs::unitd_instance::UnitdInstance;
 
-pub(crate) fn cmd(output_format: OutputFormat) -> Result<(), UnitctlError> {
-    let instances = UnitdInstance::running_unitd_instances();
+pub(crate) async fn cmd(output_format: OutputFormat) -> Result<(), UnitctlError> {
+    let instances = UnitdInstance::running_unitd_instances().await;
     if instances.is_empty() {
         Err(UnitctlError::NoUnitInstancesError)
     } else if output_format.eq(&OutputFormat::Text) {

--- a/tools/unitctl/unitctl/src/cmd/instances.rs
+++ b/tools/unitctl/unitctl/src/cmd/instances.rs
@@ -1,16 +1,16 @@
-use crate::{OutputFormat, UnitctlError};
 use crate::unitctl::{InstanceArgs, InstanceCommands};
-use unit_client_rs::unitd_instance::UnitdInstance;
-use unit_client_rs::unitd_docker::deploy_new_container;
+use crate::{OutputFormat, UnitctlError};
 use std::path::PathBuf;
+use unit_client_rs::unitd_docker::deploy_new_container;
+use unit_client_rs::unitd_instance::UnitdInstance;
 
 pub(crate) async fn cmd(args: InstanceArgs) -> Result<(), UnitctlError> {
     if let Some(cmd) = args.command {
         match cmd {
-            InstanceCommands::New{
+            InstanceCommands::New {
                 ref socket,
                 ref application,
-                ref image
+                ref image,
             } => {
                 println!("Pulling and starting a container from {}", image);
                 println!("Will mount {} to /var/run for socket access", socket);
@@ -20,15 +20,15 @@ pub(crate) async fn cmd(args: InstanceArgs) -> Result<(), UnitctlError> {
                     eprintln!("application and socket paths must be directories");
                     Err(UnitctlError::NoFilesImported)
                 } else {
-                    deploy_new_container(socket, application, image)
-                        .await
-                        .map_or_else(|e| Err(UnitctlError::UnitClientError{source: e}),
-                                     |warn| {
-                                         for i in warn {
-                                             println!("warning from docker: {}", i);
-                                         }
-                                         Ok(())
-                                     })
+                    deploy_new_container(socket, application, image).await.map_or_else(
+                        |e| Err(UnitctlError::UnitClientError { source: e }),
+                        |warn| {
+                            for i in warn {
+                                println!("warning from docker: {}", i);
+                            }
+                            Ok(())
+                        },
+                    )
                 }
             }
         }

--- a/tools/unitctl/unitctl/src/cmd/instances.rs
+++ b/tools/unitctl/unitctl/src/cmd/instances.rs
@@ -1,8 +1,11 @@
 use crate::unitctl::{InstanceArgs, InstanceCommands};
 use crate::{OutputFormat, UnitctlError};
+use crate::unitctl_error::ControlSocketErrorKind;
+
 use std::path::PathBuf;
 use unit_client_rs::unitd_docker::deploy_new_container;
 use unit_client_rs::unitd_instance::UnitdInstance;
+use unit_client_rs::control_socket_address::ControlSocket;
 
 pub(crate) async fn cmd(args: InstanceArgs) -> Result<(), UnitctlError> {
     if let Some(cmd) = args.command {
@@ -12,19 +15,104 @@ pub(crate) async fn cmd(args: InstanceArgs) -> Result<(), UnitctlError> {
                 ref application,
                 ref image,
             } => {
-                println!("Pulling and starting a container from {}", image);
-                println!("Will mount {} to /var/run for socket access", socket);
-                println!("Will READ ONLY mount {} to /www for application access", application);
-                println!("Note: Container will be on host network");
-                if !PathBuf::from(socket).is_dir() || !PathBuf::from(application).is_dir() {
-                    eprintln!("application and socket paths must be directories");
+                // validation for application dir
+                if !PathBuf::from(application).is_dir() {
+                    eprintln!("application path must be a directory");
                     Err(UnitctlError::NoFilesImported)
+                } else if !PathBuf::from(application).as_path().exists() {
+                    eprintln!("application path must exist");
+                    Err(UnitctlError::NoFilesImported)
+
                 } else {
-                    deploy_new_container(socket, application, image).await.map_or_else(
+                    let addr = ControlSocket::parse_address(socket);
+                    if let Err(e) = addr {
+                        return Err(UnitctlError::UnitClientError{source: e});
+                    }
+
+                    // validate we arent processing an abstract socket
+                    if let ControlSocket::UnixLocalAbstractSocket(_) = addr.as_ref().unwrap() {
+                        return Err(UnitctlError::ControlSocketError{
+                            kind: ControlSocketErrorKind::General,
+                            message: "cannot pass abstract socket to docker container".to_string(),
+                        })
+                    }
+
+                    // warn user of OSX docker limitations
+                    if let ControlSocket::UnixLocalSocket(ref sock_path) = addr.as_ref().unwrap() {
+                        if cfg!(target_os = "macos") {
+                            return Err(UnitctlError::ControlSocketError{
+                                kind: ControlSocketErrorKind::General,
+                                message: format!("Docker on OSX will break unix sockets mounted {} {}",
+                                                 "in containers, see the following link for more information",
+                                                 "https://github.com/docker/for-mac/issues/483"),
+                            })
+                        }
+
+                        if !sock_path.is_dir() {
+                          return Err(UnitctlError::ControlSocketError{
+                                kind: ControlSocketErrorKind::General,
+                                message: format!("user must specify a directory of UNIX socket directory"),
+                            })
+                        }
+                    }
+
+                    // validate a TCP URI
+                    if let ControlSocket::TcpSocket(uri) = addr.as_ref().unwrap() {
+                        if let Some(host) = uri.host() {
+                            if host != "127.0.0.1" {
+                                return Err(UnitctlError::ControlSocketError{
+                                    kind: ControlSocketErrorKind::General,
+                                    message: "TCP URI must point to 127.0.0.1".to_string(),
+                                })
+                            }
+                        } else {
+                            return Err(UnitctlError::ControlSocketError{
+                                kind: ControlSocketErrorKind::General,
+                                message: "TCP URI must point to a host".to_string(),
+                            })
+                        }
+
+                        if let Some(port) = uri.port_u16() {
+                            if port < 1025 {
+                                eprintln!("warning! you are asking docker to forward a privileged port. {}",
+                                          "please make sure docker has access to it");
+                            }
+                        } else {
+                            return Err(UnitctlError::ControlSocketError{
+                                kind: ControlSocketErrorKind::General,
+                                message: "TCP URI must specify a port".to_string(),
+                            })
+                        }
+
+                        if uri.path() != "/" {
+                            eprintln!("warning! path {} will be ignored", uri.path())
+                        }
+                    }
+
+                    // reflect changes to user
+                    // print this to STDERR to avoid polluting deserialized data output
+                    eprintln!("> Pulling and starting a container from {}", image);
+                    eprintln!("> Will READ ONLY mount {} to /www for application access", application);
+                    eprintln!("> Container will be on host network");
+                    match addr.as_ref().unwrap() {
+                        ControlSocket::UnixLocalSocket(path) =>
+                            eprintln!("> Will mount directory containing {} to /var/www for control API",
+                                      path.as_path().to_string_lossy()),
+                        ControlSocket::TcpSocket(uri) =>
+                            eprintln!("> Will forward port {} for control API", uri.port_u16().unwrap()),
+                        _ => unimplemented!(), // abstract socket case ruled out previously
+                    }
+
+                    if cfg!(target_os = "macos") {
+                        eprintln!("> mac users: enable host networking in docker desktop");
+                    }
+
+                    // do the actual deployment
+                    deploy_new_container(addr.unwrap(), application, image).await.map_or_else(
                         |e| Err(UnitctlError::UnitClientError { source: e }),
                         |warn| {
                             for i in warn {
-                                println!("warning from docker: {}", i);
+                                eprintln!("warning! from docker: {}", i);
                             }
                             Ok(())
                         },

--- a/tools/unitctl/unitctl/src/cmd/listeners.rs
+++ b/tools/unitctl/unitctl/src/cmd/listeners.rs
@@ -3,11 +3,12 @@ use crate::wait;
 use crate::{OutputFormat, UnitctlError};
 use unit_client_rs::unit_client::UnitClient;
 
-pub fn cmd(cli: &UnitCtl, output_format: OutputFormat) -> Result<(), UnitctlError> {
-    let control_socket = wait::wait_for_socket(cli)?;
+pub async fn cmd(cli: &UnitCtl, output_format: OutputFormat) -> Result<(), UnitctlError> {
+    let control_socket = wait::wait_for_socket(cli).await?;
     let client = UnitClient::new(control_socket);
     client
         .listeners()
+        .await
         .map_err(|e| UnitctlError::UnitClientError { source: *e })
         .and_then(|response| output_format.write_to_stdout(&response))
 }

--- a/tools/unitctl/unitctl/src/cmd/status.rs
+++ b/tools/unitctl/unitctl/src/cmd/status.rs
@@ -3,11 +3,12 @@ use crate::wait;
 use crate::{OutputFormat, UnitctlError};
 use unit_client_rs::unit_client::UnitClient;
 
-pub fn cmd(cli: &UnitCtl, output_format: OutputFormat) -> Result<(), UnitctlError> {
-    let control_socket = wait::wait_for_socket(cli)?;
+pub async fn cmd(cli: &UnitCtl, output_format: OutputFormat) -> Result<(), UnitctlError> {
+    let control_socket = wait::wait_for_socket(cli).await?;
     let client = UnitClient::new(control_socket);
     client
         .status()
+        .await
         .map_err(|e| UnitctlError::UnitClientError { source: *e })
         .and_then(|response| output_format.write_to_stdout(&response))
 }

--- a/tools/unitctl/unitctl/src/main.rs
+++ b/tools/unitctl/unitctl/src/main.rs
@@ -23,26 +23,27 @@ mod unitctl;
 mod unitctl_error;
 mod wait;
 
-fn main() -> Result<(), UnitctlError> {
+#[tokio::main]
+async fn main() -> Result<(), UnitctlError> {
     let cli = UnitCtl::parse();
 
     match cli.command {
-        Commands::Instances { output_format } => instances::cmd(output_format),
+        Commands::Instances { output_format } => instances::cmd(output_format).await,
 
-        Commands::Edit { output_format } => edit::cmd(&cli, output_format),
+        Commands::Edit { output_format } => edit::cmd(&cli, output_format).await,
 
-        Commands::Import { ref directory } => import::cmd(&cli, directory),
+        Commands::Import { ref directory } => import::cmd(&cli, directory).await,
 
         Commands::Execute {
             ref output_format,
             ref input_file,
             ref method,
             ref path,
-        } => execute_cmd::cmd(&cli, output_format, input_file, method, path),
+        } => execute_cmd::cmd(&cli, output_format, input_file, method, path).await,
 
-        Commands::Status { output_format } => status::cmd(&cli, output_format),
+        Commands::Status { output_format } => status::cmd(&cli, output_format).await,
 
-        Commands::Listeners { output_format } => listeners::cmd(&cli, output_format),
+        Commands::Listeners { output_format } => listeners::cmd(&cli, output_format).await,
     }
     .map_err(|error| {
         eprint_error(&error);

--- a/tools/unitctl/unitctl/src/main.rs
+++ b/tools/unitctl/unitctl/src/main.rs
@@ -30,9 +30,9 @@ async fn main() -> Result<(), UnitctlError> {
     match cli.command {
         Commands::Instances(args) => instances::cmd(args).await,
 
-        Commands::Edit{output_format} => edit::cmd(&cli, output_format).await,
+        Commands::Edit { output_format } => edit::cmd(&cli, output_format).await,
 
-        Commands::Import{ref directory} => import::cmd(&cli, directory).await,
+        Commands::Import { ref directory } => import::cmd(&cli, directory).await,
 
         Commands::Execute {
             ref output_format,
@@ -41,9 +41,9 @@ async fn main() -> Result<(), UnitctlError> {
             ref path,
         } => execute_cmd::cmd(&cli, output_format, input_file, method, path).await,
 
-        Commands::Status{output_format} => status::cmd(&cli, output_format).await,
+        Commands::Status { output_format } => status::cmd(&cli, output_format).await,
 
-        Commands::Listeners{output_format}=> listeners::cmd(&cli, output_format).await,
+        Commands::Listeners { output_format } => listeners::cmd(&cli, output_format).await,
     }
     .map_err(|error| {
         eprint_error(&error);

--- a/tools/unitctl/unitctl/src/main.rs
+++ b/tools/unitctl/unitctl/src/main.rs
@@ -28,11 +28,11 @@ async fn main() -> Result<(), UnitctlError> {
     let cli = UnitCtl::parse();
 
     match cli.command {
-        Commands::Instances { output_format } => instances::cmd(output_format).await,
+        Commands::Instances(args) => instances::cmd(args).await,
 
-        Commands::Edit { output_format } => edit::cmd(&cli, output_format).await,
+        Commands::Edit{output_format} => edit::cmd(&cli, output_format).await,
 
-        Commands::Import { ref directory } => import::cmd(&cli, directory).await,
+        Commands::Import{ref directory} => import::cmd(&cli, directory).await,
 
         Commands::Execute {
             ref output_format,
@@ -41,9 +41,9 @@ async fn main() -> Result<(), UnitctlError> {
             ref path,
         } => execute_cmd::cmd(&cli, output_format, input_file, method, path).await,
 
-        Commands::Status { output_format } => status::cmd(&cli, output_format).await,
+        Commands::Status{output_format} => status::cmd(&cli, output_format).await,
 
-        Commands::Listeners { output_format } => listeners::cmd(&cli, output_format).await,
+        Commands::Listeners{output_format}=> listeners::cmd(&cli, output_format).await,
     }
     .map_err(|error| {
         eprint_error(&error);

--- a/tools/unitctl/unitctl/src/unitctl.rs
+++ b/tools/unitctl/unitctl/src/unitctl.rs
@@ -2,7 +2,7 @@ extern crate clap;
 
 use crate::output_format::OutputFormat;
 use clap::error::ErrorKind::ValueValidation;
-use clap::{Error as ClapError, Parser, Subcommand, Args};
+use clap::{Args, Error as ClapError, Parser, Subcommand};
 use std::path::PathBuf;
 use unit_client_rs::control_socket_address::ControlSocket;
 
@@ -137,16 +137,10 @@ pub struct InstanceArgs {
 pub enum InstanceCommands {
     #[command(about = "deploy a new docker instance of unitd")]
     New {
-        #[arg(
-            required = true,
-            help = "Path to mount control socket to host",
-        )]
+        #[arg(required = true, help = "Path to mount control socket to host")]
         socket: String,
 
-        #[arg(
-            required = true,
-            help = "Path to mount application into container",
-        )]
+        #[arg(required = true, help = "Path to mount application into container")]
         application: String,
 
         #[arg(
@@ -154,7 +148,7 @@ pub enum InstanceCommands {
             default_value = env!("CARGO_PKG_VERSION"),
         )]
         image: String,
-    }
+    },
 }
 
 fn parse_control_socket_address(s: &str) -> Result<ControlSocket, ClapError> {


### PR DESCRIPTION
This PR adds functionality to the CLI to support its existing functionality used with Docker deployments of Unit. In addition to that, a new subcommand is added that offers a procedure to deploy any unit docker image with user defined mounts for the control socket and any application of choice. Finally, unitctl codebase is refactored to simply handling of async futures, relying on a standard provided runtime instead of attempting to maintain a custom future executor. Tests are added and updated as well.