### PR TITLE
Packages: added Ubuntu 24.04 "noble" support.

### DIFF
--- a/pkg/deb/Makefile
+++ b/pkg/deb/Makefile
@@ -19,6 +19,23 @@ BUILD_DEPENDS = $(BUILD_DEPENDS_unit)
 
 MODULES=
 
+# Ubuntu 24.04
+ifeq ($(CODENAME),noble)
+include Makefile.php
+include Makefile.python311
+include Makefile.python312
+include Makefile.go
+include Makefile.perl
+include Makefile.ruby
+include Makefile.jsc-common
+include Makefile.jsc11
+include Makefile.jsc17
+include Makefile.jsc19
+include Makefile.jsc20
+include Makefile.jsc21
+include Makefile.wasm
+endif
+
 # Ubuntu 23.10
 ifeq ($(CODENAME),mantic)
 include Makefile.php


### PR DESCRIPTION
To make it possible to use the official nginx unit packages on the latest LTS from ubuntu, we need to have this packages build.

I searched through the repo and found this Makefile for building the packages. But afterwards we need to change also https://github.com/nginx/unit-docs/edit/master/source/installation.rst and see if the files really apply and are available at 
https://packages.nginx.org/unit/ubuntu/dists/