### PR TITLE
Add unitctl build and release CI

### DIFF
--- a/.github/workflows/unitctl.yml
+++ b/.github/workflows/unitctl.yml
@@ -1,0 +1,132 @@
+
+name: unitctl
+
+on:
+  pull_request:
+    paths:
+      - tools/unitctl/**
+  push:
+    branches:
+      - master
+    tags:
+      - unitctl/[0-9]+.[0-9]+.[0-9]+
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: tools/unitctl
+    env:
+      MAKE: make
+      CARGO: cargo
+      VERSION:
+      SHORT_VERSION:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - build: linux-aarch64
+            os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+          - build: linux-x86_64
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - build: macos-aarch64
+            os: macos-latest
+            target: aarch64-apple-darwin
+          - build: macos-x86_64
+            os: macos-latest
+            target: x86_64-apple-darwin
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: rustup update stable
+      - run: rustup target add ${{ matrix.target }}
+
+      - name: Install cross
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: rust-${{ matrix.build }}
+          workspaces: ./tools/unitctl -> target
+          save-if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/unitctl/') }}
+
+      - name: Configure linux arm depedencies
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          cat <<EOF > Cross.toml
+          [target.aarch64-unknown-linux-gnu]
+          pre-build = [
+              "dpkg --add-architecture \$CROSS_DEB_ARCH",
+              "apt-get update && apt-get install --assume-yes libssl-dev:\$CROSS_DEB_ARCH"
+          ]
+          EOF
+
+          cat Cross.toml
+          echo "CARGO=cross" >> $GITHUB_ENV
+
+      - name: Install macOS depedencies
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          brew install make gnu-sed grep gawk
+          echo "MAKE=gmake" >> $GITHUB_ENV
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - run: ${{ env.MAKE }} list-targets
+
+      - name: Make unitctl (${{ env.MAKE }}, ${{ matrix.target }})
+        run: ${{ env.MAKE }} ${{ matrix.target }}
+
+      - name: Get the version from the tag
+        run: |
+          version=${{ github.ref_name }}
+          short="${version#*/}"
+          echo $version; echo $short
+          echo "VERSION=$version" >> $GITHUB_ENV
+          echo "SHORT_VERSION=$short" >> $GITHUB_ENV
+
+      - name: Generate sha256 sum
+        run: |
+          shasum -a 256 ./target/${{ matrix.target }}/release/unitctl > unitctl-${{ env.SHORT_VERSION }}-${{ matrix.target }}.sha256
+          mv ./target/${{ matrix.target }}/release/unitctl unitctl-${{ env.SHORT_VERSION }}-${{ matrix.target }}
+
+      - name: Upload sha256 sum
+        uses: actions/upload-artifact@v4
+        with:
+          name: unitctl-${{ env.SHORT_VERSION }}-${{ matrix.target }}.sha256
+          path: tools/unitctl/unitctl-${{ env.SHORT_VERSION }}-${{ matrix.target }}.sha256
+
+      - name: Upload unitctl
+        uses: actions/upload-artifact@v4
+        with:
+          name: unitctl-${{ env.SHORT_VERSION }}-${{ matrix.target }}
+          path: tools/unitctl/unitctl-${{ env.SHORT_VERSION }}-${{ matrix.target }}
+
+  release:
+    # Create a draft release if a tag
+    if: startsWith(github.ref, 'refs/tags/unitctl/')
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+
+      - name: Create GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "unitctl-*"
+          allowUpdates: true

--- a/tools/unitctl/unit-openapi/README.md
+++ b/tools/unitctl/unit-openapi/README.md
@@ -409,3 +409,4 @@ cargo doc --open
 ## Author
 
 unit-owner@nginx.org
+


### PR DESCRIPTION
Adds a GitHub Actions workflow that builds and releases `unitctl` binaries when a tag prefixed with `unitctl/` is pushed.

Binaries are built on pull-requests that change any files within `tools/unitctl`, on `master` branch pushes and when `unitctl/` prefixed tags are pushed.

<img width="899" alt="Screenshot 2024-05-09 at 2 30 03 PM" src="https://github.com/nginx/unit/assets/7211830/80a6bd91-fdda-41e3-a018-a598127929bd">
