### PR TITLE
Proxy HTTP: Added standard port for inet and inet6

### DIFF
--- a/src/nxt_sockaddr.c
+++ b/src/nxt_sockaddr.c
@@ -667,7 +667,7 @@ nxt_sockaddr_inet6_parse(nxt_mp_t *mp, nxt_str_t *addr)
         p = NULL;
     }
 
-    port = 0;
+    port = 80;
 
     if (p != NULL) {
         length = (start + length) - p;
@@ -742,7 +742,7 @@ nxt_sockaddr_inet_parse(nxt_mp_t *mp, nxt_str_t *addr)
         }
     }
 
-    port = 0;
+    port = 80;
 
     if (p != NULL) {
         p++;


### PR DESCRIPTION
Added a standard port for IPv4 and IPv6 addresses when using proxy and HTTP, eliminating the need to specify an additional port 80. This is defined by the RFC standards for HTTP. Currently Nginx Unit only uses HTTP connections for proxying, version 1.1.

https://datatracker.ietf.org/doc/html/rfc2616#page-12
> HTTP communication usually takes place over TCP/IP connections. The default port is TCP 80 