### PR TITLE
Support chunked request bodies

### DIFF
--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -368,6 +368,9 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_http_members[] = {
     }, {
         .name       = nxt_string("server_version"),
         .type       = NXT_CONF_VLDT_BOOLEAN,
+    }, {
+        .name       = nxt_string("chunked_transform"),
+        .type       = NXT_CONF_VLDT_BOOLEAN,
     },
 
     NXT_CONF_VLDT_END

--- a/src/nxt_http.h
+++ b/src/nxt_http.h
@@ -157,6 +157,7 @@ struct nxt_http_request_s {
     nxt_list_t                      *fields;
     nxt_http_field_t                *content_type;
     nxt_http_field_t                *content_length;
+    nxt_http_field_t                *chunked_field;
     nxt_http_field_t                *cookie;
     nxt_http_field_t                *referer;
     nxt_http_field_t                *user_agent;
@@ -204,6 +205,7 @@ struct nxt_http_request_s {
     uint8_t                         inconsistent; /* 1 bit  */
     uint8_t                         error;        /* 1 bit  */
     uint8_t                         websocket_handshake;  /* 1 bit */
+    uint8_t                         chunked;  /* 1 bit */
 };
 
 

--- a/src/nxt_http_chunk_parse.c
+++ b/src/nxt_http_chunk_parse.c
@@ -48,9 +48,7 @@ nxt_http_chunk_parse(nxt_task_t *task, nxt_http_chunk_parse_t *hcp,
 
     for (b = in; b != NULL; b = next) {
 
-        hcp->pos = b->mem.pos;
-
-        while (hcp->pos < b->mem.free) {
+        while (b->mem.pos < b->mem.free) {
             /*
              * The sw_chunk state is tested outside the switch
              * to preserve hcp->pos and to not touch memory.
@@ -76,7 +74,7 @@ nxt_http_chunk_parse(nxt_task_t *task, nxt_http_chunk_parse_t *hcp,
                 /* ret == NXT_HTTP_CHUNK_END */
             }
 
-            ch = *hcp->pos++;
+            ch = *b->mem.pos++;
 
             switch (state) {
 
@@ -203,7 +201,7 @@ nxt_http_chunk_buffer(nxt_http_chunk_parse_t *hcp, nxt_buf_t ***tail,
     size_t     size;
     nxt_buf_t  *b;
 
-    p = hcp->pos;
+    p = in->mem.pos;
     size = in->mem.free - p;
 
     b = nxt_buf_mem_alloc(hcp->mem_pool, 0, 0);
@@ -224,7 +222,7 @@ nxt_http_chunk_buffer(nxt_http_chunk_parse_t *hcp, nxt_buf_t ***tail,
 
     if (hcp->chunk_size < size) {
         p += hcp->chunk_size;
-        hcp->pos = p;
+        in->mem.pos = p;
 
         b->mem.free = p;
         b->mem.end = p;

--- a/src/nxt_http_parse.h
+++ b/src/nxt_http_parse.h
@@ -96,11 +96,8 @@ struct nxt_http_field_s {
 
 
 typedef struct {
-    u_char                    *pos;
     nxt_mp_t                  *mem_pool;
-
     uint64_t                  chunk_size;
-
     uint8_t                   state;
     uint8_t                   last;         /* 1 bit */
     uint8_t                   chunk_error;  /* 1 bit */

--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -1575,6 +1575,12 @@ static nxt_conf_map_t  nxt_router_http_conf[] = {
         NXT_CONF_MAP_INT8,
         offsetof(nxt_socket_conf_t, server_version),
     },
+
+    {
+        nxt_string("chunked_transform"),
+        NXT_CONF_MAP_INT8,
+        offsetof(nxt_socket_conf_t, chunked_transform),
+    },
 };
 
 
@@ -1994,6 +2000,7 @@ nxt_router_conf_create(nxt_task_t *task, nxt_router_temp_conf_t *tmcf,
             skcf->proxy_read_timeout = 30 * 1000;
 
             skcf->server_version = 1;
+            skcf->chunked_transform = 0;
 
             skcf->websocket_conf.max_frame_size = 1024 * 1024;
             skcf->websocket_conf.read_timeout = 60 * 1000;

--- a/src/nxt_router.h
+++ b/src/nxt_router.h
@@ -208,6 +208,7 @@ typedef struct {
     uint8_t                discard_unsafe_fields;  /* 1 bit */
 
     uint8_t                server_version;         /* 1 bit */
+    uint8_t                chunked_transform;      /* 1 bit */
 
     nxt_http_forward_t     *forwarded;
     nxt_http_forward_t     *client_ip;


### PR DESCRIPTION
A draft patch for the MVP of this feature.

Internally, I transferred the chunked request to content-length request since the application process can't handle chunked request now.

### Test
conf.json
```
{
    "listeners": {
        "*:8080": {
            "pass": "routes"
        }
    },
    "routes": [
        {
            "action": {
                "pass": "applications/app"
            }
        }
    ],
    "applications": {
        "app": {
            "type": "python",
            "path": "/www",
            "module": "wsgi"
        }
    }
}
```
/www/wsgi.py
```
def application(environ, start_response):
    content_length = int(environ.get('CONTENT_LENGTH', 0))
    body = bytes(environ['wsgi.input'].read(content_length))
    start_response(
        '200', [],
    )
    return [body]
```
```
> curl -X POST -d 'hello' -H "Transfer-Encoding: chunked" http://127.0.0.1:8080 -v
Note: Unnecessary use of -X or --request, POST is already inferred.
* Rebuilt URL to: http://127.0.0.1:8080/
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 8080 (#0)
> POST / HTTP/1.1
> Host: 127.0.0.1:8080
> User-Agent: curl/7.61.1
> Accept: */*
> Transfer-Encoding: chunked
> Content-Type: application/x-www-form-urlencoded
>
> 5
* upload completely sent off: 12 out of 5 bytes
< HTTP/1.1 200 OK
< Server: Unit/1.33.0
< Date: Wed, 29 May 2024 09:04:27 GMT
< Transfer-Encoding: chunked
<
* Connection #0 to host 127.0.0.1 left intact
hello
```