### PR TITLE
Packaging: fix build-depends detection on debian-based systems

### DIFF
--- a/pkg/deb/Makefile
+++ b/pkg/deb/Makefile
@@ -203,8 +203,8 @@ check-build-depends-%:
 	esac ; \
 	not_installed= ; \
 	for pkg in $${pkgs}; do \
-		dpkg-query -W $${pkg} >/dev/null 2>&1 ; \
-		if [ $$? -ne 0 ]; then \
+		i=$$(dpkg-query -f '$${db:Status-Status}' -W $${pkg} 2>/dev/null) ; \
+		if [ $$? -ne 0 -o "$${i}" != "installed" ]; then \
 			not_installed="$${not_installed} $${pkg}" ; \
 		fi ; \
 	done ; \


### PR DESCRIPTION
dpkg-query -W will show information about the package if any other package references it, even when the queried package is not installed. The fix is to query for an actual status of a needed build dependency.