### PR TITLE
contrib: be quiet on unpack

### DIFF
--- a/pkg/contrib/Makefile
+++ b/pkg/contrib/Makefile
@@ -89,10 +89,10 @@ checksum = \
 		(cd $(TARBALLS) && $(1))
 CHECK_SHA512 = $(call checksum,$(SHA512SUM),SHA512,.sum-)
 UNPACK = $(RM) -R $@ \
-	$(foreach f,$(filter %.tar.gz %.tgz,$^), && tar xvzfo $(f)) \
-	$(foreach f,$(filter %.tar.bz2,$^), && tar xvjfo $(f)) \
-	$(foreach f,$(filter %.tar.xz,$^), && tar xvJfo $(f)) \
-	$(foreach f,$(filter %.zip,$^), && unzip $(f))
+	$(foreach f,$(filter %.tar.gz %.tgz,$^), && tar xzfo $(f)) \
+	$(foreach f,$(filter %.tar.bz2,$^), && tar xjfo $(f)) \
+	$(foreach f,$(filter %.tar.xz,$^), && tar xJfo $(f)) \
+	$(foreach f,$(filter %.zip,$^), && unzip -q $(f))
 UNPACK_DIR = $(patsubst %.tar,%,$(basename $(notdir $<)))
 APPLY = (cd $(UNPACK_DIR) && patch -fp1) <
 MOVE = mv $(UNPACK_DIR) $@ && touch $@


### PR DESCRIPTION
The lists of files being unpacked are mostly useless but take a significant amount of lines and bytes in e.g. CI jobs.  E.g. in rhel9 packaging job, it's 39680 lines just for the unpacking of wasmtime-v11.0.1-src, as compared to total 48945 lines of output.