### PR TITLE
Make a couple of things 'const'

### DIFF
--- a/src/nxt_tstr.c
+++ b/src/nxt_tstr.c
@@ -81,7 +81,7 @@ nxt_tstr_state_new(nxt_mp_t *mp, nxt_bool_t test)
 
 
 nxt_tstr_t *
-nxt_tstr_compile(nxt_tstr_state_t *state, nxt_str_t *str,
+nxt_tstr_compile(nxt_tstr_state_t *state, const nxt_str_t *str,
     nxt_tstr_flags_t flags)
 {
     u_char      *p;

--- a/src/nxt_tstr.h
+++ b/src/nxt_tstr.h
@@ -38,7 +38,7 @@ typedef enum {
 
 
 nxt_tstr_state_t *nxt_tstr_state_new(nxt_mp_t *mp, nxt_bool_t test);
-nxt_tstr_t *nxt_tstr_compile(nxt_tstr_state_t *state, nxt_str_t *str,
+nxt_tstr_t *nxt_tstr_compile(nxt_tstr_state_t *state, const nxt_str_t *str,
     nxt_tstr_flags_t flags);
 nxt_int_t nxt_tstr_test(nxt_tstr_state_t *state, nxt_str_t *str, u_char *error);
 nxt_int_t nxt_tstr_state_done(nxt_tstr_state_t *state, u_char *error);

--- a/src/wasm/nxt_wasm.c
+++ b/src/wasm/nxt_wasm.c
@@ -246,7 +246,7 @@ nxt_wasm_setup(nxt_task_t *task, nxt_process_t *process,
     nxt_conf_value_t         *dirs = NULL;
     nxt_wasm_app_conf_t      *c;
     nxt_wasm_func_handler_t  *fh;
-    static nxt_str_t         filesystem_str = nxt_string("filesystem");
+    static const nxt_str_t   filesystem_str = nxt_string("filesystem");
 
     c = &conf->u.wasm;
 


### PR DESCRIPTION
- `tstr: Constify the 'str' parameter to nxt_tstr_compile()`

Just as the commit subject says, this constifies the `str` parameter to `nxt_tstr_compile()`

I have some code like

```c
    static nxt_str_t        accept_enc_str =                                    
                                    nxt_string("$header_accept_encoding");      
    static const nxt_str_t  comps_str = nxt_string("compressors");              
    static const nxt_str_t  mimes_str = nxt_string("types");
```

Looking at it, you may wonder why the first one isn't `static const`, well it can be after this patch...

- `wasm: Add a missing 'const' qualifier in nxt_wasm_setup()`

`filesystem_str` can be defined as `static const` rather than just `static`