### PR TITLE
tests: unmount related fixes

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -429,6 +429,7 @@ def _clear_temp_dir():
     temporary_dir = unit_instance['temp_dir']
 
     if is_findmnt and not waitforunmount(temporary_dir, timeout=600):
+        Log.print_log()
         sys.exit(f'Could not unmount filesystems in tmpdir ({temporary_dir}).')
 
     for item in Path(temporary_dir).iterdir():

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -429,7 +429,7 @@ def _clear_temp_dir():
     temporary_dir = unit_instance['temp_dir']
 
     if is_findmnt and not waitforunmount(temporary_dir, timeout=600):
-        sys.exit('Could not unmount filesystems in tmpdir ({temporary_dir}).')
+        sys.exit(f'Could not unmount filesystems in tmpdir ({temporary_dir}).')
 
     for item in Path(temporary_dir).iterdir():
         if item.name not in [


### PR DESCRIPTION
First patch needed to format error string message to show temporary dir path, while second patch needed to print unit.log in case of unmount error.