### PR TITLE
ci: Limit when to run checks on pull-requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,13 @@ name: ci
 
 on:
   pull_request:
+    paths:
+      - configure
+      - 'auto/**'
+      - 'go/**'
+      - 'src/**'
+      - 'test/**'
+      - '.github/workflows/ci.yml'
   push:
     branches: master
     paths:


### PR DESCRIPTION
Commit 4fc50258b ("ci: Be more specific when to run the main Unit checks") limited when the checks for the main ci run, on pushes to master.

It should have done the same for pull-requests.
