### PR TITLE
Packaging: fix build-depends on multiarch debian systems

### DIFF
--- a/pkg/deb/Makefile
+++ b/pkg/deb/Makefile
@@ -203,9 +203,12 @@ check-build-depends-%:
 	esac ; \
 	not_installed= ; \
 	for pkg in $${pkgs}; do \
-		i=$$(dpkg-query -f '$${db:Status-Status}' -W $${pkg} 2>/dev/null) ; \
+		i=$$(dpkg-query -f '$${db:Status-Status}' -W $${pkg}:$$(dpkg --print-architecture) 2>/dev/null) ; \
 		if [ $$? -ne 0 -o "$${i}" != "installed" ]; then \
-			not_installed="$${not_installed} $${pkg}" ; \
+			i=$$(dpkg-query -f '$${db:Status-Status}' -W $${pkg}:all 2>/dev/null) ; \
+			if [ $$? -ne 0 -o "$${i}" != "installed" ]; then \
+				not_installed="$${not_installed} $${pkg}" ; \
+			fi; \
 		fi ; \
 	done ; \
 	if test -n "$${not_installed}" ; then \


### PR DESCRIPTION
It's possible to have two versions of the same package installed on debian-based multiarch systems - e.g. i386 alongside amd64.  This means that when getting the package status through dpkg-query we'd get a duplicated string:

% dpkg-query -f '$${db:Status-Status}' -W libssl-dev $installed$installed

% dpkg -l | grep libssl-dev
ii  libssl-dev:amd64                 3.0.11-1~deb12u2               amd64        Secure Sockets Layer toolkit - development files
ii  libssl-dev:i386                  3.0.11-1~deb12u2               i386         Secure Sockets Layer toolkit - development files

The fix is to explicitely check for the main architecture and, in case for noarch (or rather all-arch in debian terms) packages, check for special :all architecture as well.