### PR TITLE
Python: Add 'factory' support

### DIFF
--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -842,6 +842,11 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_python_members[] = {
         .validator  = nxt_conf_vldt_targets_exclusive,
         .u.string   = "callable",
     }, {
+        .name       = nxt_string("factory"),
+        .type       = NXT_CONF_VLDT_BOOLEAN,
+        .validator  = nxt_conf_vldt_targets_exclusive,
+        .u.string   = "factory",
+    }, {
         .name       = nxt_string("prefix"),
         .type       = NXT_CONF_VLDT_STRING,
         .validator  = nxt_conf_vldt_targets_exclusive,
@@ -866,6 +871,9 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_python_target_members[] = {
         .name       = nxt_string("callable"),
         .type       = NXT_CONF_VLDT_STRING,
     }, {
+        .name       = nxt_string("factory"),
+        .type       = NXT_CONF_VLDT_BOOLEAN,
+    }, {
         .name       = nxt_string("prefix"),
         .type       = NXT_CONF_VLDT_STRING,
         .validator  = nxt_conf_vldt_python_prefix,
@@ -883,6 +891,9 @@ static nxt_conf_vldt_object_t  nxt_conf_vldt_python_notargets_members[] = {
     }, {
         .name       = nxt_string("callable"),
         .type       = NXT_CONF_VLDT_STRING,
+    }, {
+        .name       = nxt_string("factory"),
+        .type       = NXT_CONF_VLDT_BOOLEAN,
     }, {
         .name       = nxt_string("prefix"),
         .type       = NXT_CONF_VLDT_STRING,

--- a/test/python/factory/wsgi.py
+++ b/test/python/factory/wsgi.py
@@ -1,0 +1,23 @@
+def wsgi_a(env, start_response):
+    start_response("200", [("Content-Length", "1")])
+    return [b"1"]
+
+
+def wsgi_b(env, start_response):
+    start_response("200", [("Content-Length", "1")])
+    return [b"2"]
+
+
+def wsgi_a_factory():
+    return wsgi_a
+
+
+def wsgi_b_factory():
+    return wsgi_b
+
+
+wsgi_invalid_callable = None
+
+
+def wsgi_factory_returning_invalid_callable():
+    return wsgi_invalid_callable

--- a/test/test_python_factory.py
+++ b/test/test_python_factory.py
@@ -1,0 +1,140 @@
+from unit.applications.lang.python import ApplicationPython
+from unit.option import option
+
+prerequisites = {"modules": {"python": "all"}}
+
+client = ApplicationPython()
+
+
+def test_python_factory_targets():
+    python_dir = f"{option.test_dir}/python"
+
+    assert "success" in client.conf(
+        {
+            "listeners": {
+                "*:8080": {"pass": "applications/targets/1"},
+                "*:8081": {"pass": "applications/targets/2"},
+                "*:8082": {"pass": "applications/targets/factory-1"},
+                "*:8083": {"pass": "applications/targets/factory-2"},
+            },
+            "applications": {
+                "targets": {
+                    "type": client.get_application_type(),
+                    "working_directory": f"{python_dir}/factory/",
+                    "path": f"{python_dir}/factory/",
+                    "targets": {
+                        "1": {
+                            "module": "wsgi",
+                            "callable": "wsgi_a",
+                            "factory": False,
+                        },
+                        "2": {
+                            "module": "wsgi",
+                            "callable": "wsgi_b",
+                            "factory": False,
+                        },
+                        "factory-1": {
+                            "module": "wsgi",
+                            "callable": "wsgi_a_factory",
+                            "factory": True,
+                        },
+                        "factory-2": {
+                            "module": "wsgi",
+                            "callable": "wsgi_b_factory",
+                            "factory": True,
+                        },
+                    },
+                }
+            },
+        }
+    )
+
+    resp = client.get(port=8080)
+    assert resp["status"] == 200
+    assert resp["body"] == "1"
+
+    resp = client.get(port=8081)
+    assert resp["status"] == 200
+    assert resp["body"] == "2"
+
+    resp = client.get(port=8082)
+    assert resp["status"] == 200
+    assert resp["body"] == "1"
+
+    resp = client.get(port=8083)
+    assert resp["status"] == 200
+    assert resp["body"] == "2"
+
+
+def test_python_factory_without_targets():
+    python_dir = f"{option.test_dir}/python"
+
+    assert "success" in client.conf(
+        {
+            "listeners": {
+                "*:8080": {"pass": "applications/python-app-factory"},
+                "*:8081": {"pass": "applications/python-app"},
+            },
+            "applications": {
+                "python-app-factory": {
+                    "type": client.get_application_type(),
+                    "working_directory": f"{python_dir}/factory/",
+                    "path": f"{python_dir}/factory/",
+                    "module": "wsgi",
+                    "callable": "wsgi_a_factory",
+                    "factory": True,
+                },
+                "python-app": {
+                    "type": client.get_application_type(),
+                    "working_directory": f"{python_dir}/factory/",
+                    "path": f"{python_dir}/factory/",
+                    "module": "wsgi",
+                    "callable": "wsgi_b",
+                    "factory": False,
+                },
+            },
+        }
+    )
+
+    resp = client.get(port=8080)
+    assert resp["status"] == 200
+    assert resp["body"] == "1"
+
+    resp = client.get(port=8081)
+    assert resp["status"] == 200
+    assert resp["body"] == "2"
+
+
+def test_python_factory_invalid_callable_value(skip_alert):
+    skip_alert(
+        r"failed to apply new conf",
+        r"did not return callable object",
+        r"can not be called to fetch callable",
+    )
+    python_dir = f"{option.test_dir}/python"
+
+    invalid_callable_values = [
+        "wsgi_factory_returning_invalid_callable",
+        "wsgi_invalid_callable",
+    ]
+
+    for callable_value in invalid_callable_values:
+        assert "error" in client.conf(
+            {
+                "listeners": {"*:8080": {"pass": "applications/targets/1"}},
+                "applications": {
+                    "targets": {
+                        "type": client.get_application_type(),
+                        "working_directory": f"{python_dir}/factory/",
+                        "path": f"{python_dir}/factory/",
+                        "targets": {
+                            "1": {
+                                "module": "wsgi",
+                                "callable": callable_value,
+                                "factory": True,
+                            },
+                        },
+                    }
+                },
+            }
+        )


### PR DESCRIPTION
This pr adds the factory support in python languange. By introducing new option as "factory" which can be set as true or false, if true, the callable will be interpreted as factory otherwise not