### PR TITLE
ci: Fix tags on ad hoc unitctl releases

### DIFF
--- a/.github/workflows/unitctl.yml
+++ b/.github/workflows/unitctl.yml
@@ -185,10 +185,8 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           artifacts: "unitctl-*"
-          # false if triggered by a tag
-          prerelease: ${{github.event_name == 'workflow_dispatch' && true}}
-          tag: ${{(github.event_name == 'workflow_dispatch' && inputs.version) || github.ref_name}}
-          name: unitctl/${{(github.event_name=='workflow_dispatch' && inputs.version) || github.ref_name}}
+          prerelease: ${{ github.event_name == 'workflow_dispatch' }}
+          tag: ${{ inputs.version && format('unitctl/{0}', inputs.version) || github.ref_name }}
           body: >
             ## Unitctl
 


### PR DESCRIPTION
- Adds `unitctl/` prefix to tags generated by manual workflow runs. Previously, only release titles (but not tags) were prefixed.

- Omits superfluous `name` field; falls back to `tag` when absent.

- Removes unnecessary conditional from `prelease` field.

This results in the following tagging / releasing behavior:

1. Running manually creates a pre-release and tags it `unitctl/VERSION`
2. Pushing a tag formatted like `x.y.z` creates a normal release

Refines: 3501a50ffb93756e145295021ff9313ac77f1ba9