### PR TITLE
Constify some missed static local variables (in src/perl, src/test)

### DIFF
--- a/src/perl/nxt_perl_psgi.c
+++ b/src/perl/nxt_perl_psgi.c
@@ -407,7 +407,7 @@ nxt_perl_psgi_module_create(const char *script)
     char    *buf, *p;
     size_t  length;
 
-    static nxt_str_t  prefix = nxt_string(
+    static const nxt_str_t  prefix = nxt_string(
         "package NGINX::Unit::Sandbox;"
         "sub new {"
         "   return bless {}, $_[0];"
@@ -415,7 +415,7 @@ nxt_perl_psgi_module_create(const char *script)
         "{my $app = do \""
     );
 
-    static nxt_str_t  suffix = nxt_string_zero(
+    static const nxt_str_t  suffix = nxt_string_zero(
         "\";"
         "unless ($app) {"
         "    if($@ || $1) {die $@ || $1}"

--- a/src/test/nxt_clone_test.c
+++ b/src/test/nxt_clone_test.c
@@ -560,9 +560,9 @@ nxt_clone_test_parse_map(nxt_task_t *task, nxt_str_t *map_str,
     nxt_runtime_t     *rt;
     nxt_conf_value_t  *array, *obj, *value;
 
-    static nxt_str_t  host_name = nxt_string("host");
-    static nxt_str_t  cont_name = nxt_string("container");
-    static nxt_str_t  size_name = nxt_string("size");
+    static const nxt_str_t  host_name = nxt_string("host");
+    static const nxt_str_t  cont_name = nxt_string("container");
+    static const nxt_str_t  size_name = nxt_string("size");
 
     rt = task->thread->runtime;
 


### PR DESCRIPTION
These somehow got missed in my previous set of patches to constify the likes of

```c
static nxt_str_t  foo_str = nxt_string("foobar");
```

**NOTE:**  There is a also a [patch](https://github.com/ac000/unit/commit/cae58b4b57a528f99791f8670a79756c76342021) do similar in the Python language module which is waiting for https://github.com/nginx/unit/pull/1336 to be merged.