### PR TITLE
Compile with -funsigned-char

### DIFF
--- a/auto/cc/test
+++ b/auto/cc/test
@@ -67,6 +67,8 @@ case $NXT_CC_NAME in
 
         NXT_CFLAGS="$NXT_CFLAGS -fno-strict-overflow"
 
+        NXT_CFLAGS="$NXT_CFLAGS -funsigned-char"
+
         NXT_CFLAGS="$NXT_CFLAGS -std=gnu11"
 
         NXT_CFLAGS="$NXT_CFLAGS -O"
@@ -108,6 +110,8 @@ case $NXT_CC_NAME in
         NXT_CFLAGS="$NXT_CFLAGS -fvisibility=hidden"
 
         NXT_CFLAGS="$NXT_CFLAGS -fno-strict-overflow"
+
+        NXT_CFLAGS="$NXT_CFLAGS -funsigned-char"
 
         NXT_CFLAGS="$NXT_CFLAGS -std=gnu11"
 


### PR DESCRIPTION
    Due to 'char' (unless explicitly set) being signed or unsigned depending
    on architecture, e.g on x86 it's signed, while on Arm it's unsigned,
    this can lead to subtle bugs such if you use a plain char as a byte
    thinking it's unsigned on all platforms (maybe you live in the world of
    Arm).
    
    What we can do is tell the compiler to treat 'char' as unsigned by
    default, thus it will be consistent across platforms. Seeing as most of
    the time it doesn't matter whether char is signed or unsigned, it
    really only matters when you're dealing with 'bytes', which means it
    makes sense to default char to unsigned.
    
    The Linux Kernel made this change at the end of 2022.
    
    This will also allow in the future to convert our u_char's to char's
    (which will now be unsigned) and pass them directly into the libc
    functions for example, without the need for casting.
    
    Here is what the ISO C standard has to say
    
    From §6.2.5 Types ¶15
    
      The three types char, signed char, and unsigned char are collectively
      called the character types. The implementation shall define char to
      have the same range, representation, and behavior as either signed
      char or unsigned char.[45]
    
    and from Footnote 45)
    
      CHAR_MIN, defined in <limits.h>, will have one of the values 0 or
      SCHAR_MIN, and this can be used to distinguish the two options.
      Irrespective of the choice made, char is a separate type from the
      other two and is not compatible with either.
    
    If you're still unsure why you'd want this change...
    
    It was never clear to me, why we used u_char, perhaps that was used as
    an alternative to -funsigned-char...
    
    But that still leaves the potential for bugs with char being unsigned vs
    signed...
    
    Then because we use u_char but often need to pass such things into libc
    (and perhaps other functions) which normally take a 'char' we need to
    cast these cases.
    
    So this change brings at least two (or more) benefits
    
      1) Removal of potential for char unsigned vs signed bugs.
    
      2) Removal of a bunch of casts. Reducing casting to the bare minimum
         is good. This helps the compiler to do proper type checking.
    
      3) Readability/maintainability, everything is now just char...
    
    What if you want to work with bytes?
    
    Well with char being unsigned (everywhere) you can of course use char.
    
    However it would be much better to use the uint8_t type for that to
    clearly signify that intention.
