### PR TITLE
Show loaded modules under '/status'

### DIFF
--- a/src/nxt_application.c
+++ b/src/nxt_application.c
@@ -32,6 +32,7 @@
 
 typedef struct {
     nxt_app_type_t  type;
+    nxt_str_t       name;
     nxt_str_t       version;
     nxt_str_t       file;
     nxt_array_t     *mounts;
@@ -257,12 +258,14 @@ nxt_discovery_modules(nxt_task_t *task, const char *path)
                   module[i].type, &module[i].version, &module[i].file);
 
         size += nxt_length("{\"type\": ,");
+        size += nxt_length(" \"name\": \"\",");
         size += nxt_length(" \"version\": \"\",");
         size += nxt_length(" \"file\": \"\",");
         size += nxt_length(" \"mounts\": []},");
 
         size += NXT_INT_T_LEN
                 + module[i].version.length
+                + module[i].name.length
                 + module[i].file.length;
 
         mounts = module[i].mounts;
@@ -294,9 +297,10 @@ nxt_discovery_modules(nxt_task_t *task, const char *path)
     for (i = 0; i < n; i++) {
         mounts = module[i].mounts;
 
-        p = nxt_sprintf(p, end, "{\"type\": %d, \"version\": \"%V\", "
-                        "\"file\": \"%V\", \"mounts\": [",
-                        module[i].type, &module[i].version, &module[i].file);
+        p = nxt_sprintf(p, end, "{\"type\": %d, \"name\": \"%V\", "
+                        "\"version\": \"%V\", \"file\": \"%V\", \"mounts\": [",
+                        module[i].type, &module[i].name, &module[i].version,
+                        &module[i].file);
 
         mnt = mounts->elts;
         for (j = 0; j < mounts->nelts; j++) {
@@ -409,6 +413,11 @@ nxt_discovery_module(nxt_task_t *task, nxt_mp_t *mp, nxt_array_t *modules,
 
         nxt_str_dup(mp, &module->version, &version);
         if (module->version.start == NULL) {
+            goto fail;
+        }
+
+        nxt_str_dup(mp, &module->name, &app->type);
+        if (module->name.start == NULL) {
             goto fail;
         }
 

--- a/src/nxt_application.h
+++ b/src/nxt_application.h
@@ -35,6 +35,7 @@ typedef nxt_int_t (*nxt_application_setup_t)(nxt_task_t *task,
 
 typedef struct {
     nxt_app_type_t            type;
+    char                      *name;
     u_char                    *version;
     char                      *file;
     nxt_app_module_t          *module;

--- a/src/nxt_main_process.c
+++ b/src/nxt_main_process.c
@@ -1355,6 +1355,12 @@ static nxt_conf_map_t  nxt_app_lang_module_map[] = {
     },
 
     {
+        nxt_string("name"),
+        NXT_CONF_MAP_CSTRZ,
+        offsetof(nxt_app_lang_module_t, name),
+    },
+
+    {
         nxt_string("version"),
         NXT_CONF_MAP_CSTRZ,
         offsetof(nxt_app_lang_module_t, version),

--- a/src/nxt_status.c
+++ b/src/nxt_status.c
@@ -6,18 +6,27 @@
 #include <nxt_main.h>
 #include <nxt_conf.h>
 #include <nxt_status.h>
+#include <nxt_application.h>
 
 
 nxt_conf_value_t *
 nxt_status_get(nxt_status_report_t *report, nxt_mp_t *mp)
 {
-    size_t            i;
-    uint32_t          idx = 0;
-    nxt_str_t         name;
-    nxt_int_t         ret;
-    nxt_status_app_t  *app;
-    nxt_conf_value_t  *status, *obj, *apps, *app_obj;
+    size_t                 i, nr_langs;
+    uint16_t               lang_cnts[NXT_APP_UNKNOWN] = { 1 };
+    uint32_t               idx = 0;
+    nxt_str_t              name;
+    nxt_int_t              ret;
+    nxt_array_t            *langs;
+    nxt_thread_t           *thr;
+    nxt_app_type_t         type, prev_type;
+    nxt_status_app_t       *app;
+    nxt_conf_value_t       *status, *obj, *mods, *apps, *app_obj, *mod_obj;
+    nxt_app_lang_module_t  *modules;
 
+    static const nxt_str_t  modules_str = nxt_string("modules");
+    static const nxt_str_t  version_str = nxt_string("version");
+    static const nxt_str_t  lib_str = nxt_string("lib");
     static const nxt_str_t  conns_str = nxt_string("connections");
     static const nxt_str_t  acc_str = nxt_string("accepted");
     static const nxt_str_t  active_str = nxt_string("active");
@@ -30,9 +39,86 @@ nxt_status_get(nxt_status_report_t *report, nxt_mp_t *mp)
     static const nxt_str_t  run_str = nxt_string("running");
     static const nxt_str_t  start_str = nxt_string("starting");
 
-    status = nxt_conf_create_object(mp, 3);
+    status = nxt_conf_create_object(mp, 4);
     if (nxt_slow_path(status == NULL)) {
         return NULL;
+    }
+
+    thr = nxt_thread();
+    langs = thr->runtime->languages;
+
+    modules = langs->elts;
+    /*
+     * We need to count the number of unique languages to correctly
+     * allocate the below mods object.
+     *
+     * We also need to count how many of each language.
+     *
+     * Start by skipping past NXT_APP_EXTERNAL which is always the
+     * first entry.
+     */
+    for (i = 1, nr_langs = 0, prev_type = NXT_APP_UNKNOWN; i < langs->nelts;
+         i++)
+    {
+        type = modules[i].type;
+
+        lang_cnts[type]++;
+
+        if (type == prev_type) {
+            continue;
+        }
+
+        nr_langs++;
+        prev_type = type;
+    }
+
+    mods = nxt_conf_create_object(mp, nr_langs);
+    if (nxt_slow_path(mods == NULL)) {
+        return NULL;
+    }
+
+    nxt_conf_set_member(status, &modules_str, mods, idx++);
+
+    i = 1;
+    obj = mod_obj = NULL;
+    prev_type = NXT_APP_UNKNOWN;
+    for (size_t l = 0, a = 0; i < langs->nelts; i++) {
+        nxt_str_t  item, mod_name;
+
+        type = modules[i].type;
+        if (type != prev_type) {
+            a = 0;
+
+            if (lang_cnts[type] == 1) {
+                mod_obj = nxt_conf_create_object(mp, 2);
+                obj = mod_obj;
+            } else {
+                mod_obj = nxt_conf_create_array(mp, lang_cnts[type]);
+            }
+
+            if (nxt_slow_path(mod_obj == NULL)) {
+                return NULL;
+            }
+
+            mod_name.start = (u_char *)modules[i].name;
+            mod_name.length = strlen(modules[i].name);
+            nxt_conf_set_member(mods, &mod_name, mod_obj, l++);
+        }
+
+        if (lang_cnts[type] > 1) {
+            obj = nxt_conf_create_object(mp, 2);
+            nxt_conf_set_element(mod_obj, a++, obj);
+        }
+
+        item.start = modules[i].version;
+        item.length = nxt_strlen(modules[i].version);
+        nxt_conf_set_member_string(obj, &version_str, &item, 0);
+
+        item.start = (u_char *)modules[i].file;
+        item.length = strlen(modules[i].file);
+        nxt_conf_set_member_string(obj, &lib_str, &item, 1);
+
+        prev_type = type;
     }
 
     obj = nxt_conf_create_object(mp, 4);

--- a/src/nxt_status.c
+++ b/src/nxt_status.c
@@ -17,17 +17,17 @@ nxt_status_get(nxt_status_report_t *report, nxt_mp_t *mp)
     nxt_status_app_t  *app;
     nxt_conf_value_t  *status, *obj, *apps, *app_obj;
 
-    static nxt_str_t conns_str = nxt_string("connections");
-    static nxt_str_t acc_str = nxt_string("accepted");
-    static nxt_str_t active_str = nxt_string("active");
-    static nxt_str_t idle_str = nxt_string("idle");
-    static nxt_str_t closed_str = nxt_string("closed");
-    static nxt_str_t reqs_str = nxt_string("requests");
-    static nxt_str_t total_str = nxt_string("total");
-    static nxt_str_t apps_str = nxt_string("applications");
-    static nxt_str_t procs_str = nxt_string("processes");
-    static nxt_str_t run_str = nxt_string("running");
-    static nxt_str_t start_str = nxt_string("starting");
+    static const nxt_str_t  conns_str = nxt_string("connections");
+    static const nxt_str_t  acc_str = nxt_string("accepted");
+    static const nxt_str_t  active_str = nxt_string("active");
+    static const nxt_str_t  idle_str = nxt_string("idle");
+    static const nxt_str_t  closed_str = nxt_string("closed");
+    static const nxt_str_t  reqs_str = nxt_string("requests");
+    static const nxt_str_t  total_str = nxt_string("total");
+    static const nxt_str_t  apps_str = nxt_string("applications");
+    static const nxt_str_t  procs_str = nxt_string("processes");
+    static const nxt_str_t  run_str = nxt_string("running");
+    static const nxt_str_t  start_str = nxt_string("starting");
 
     status = nxt_conf_create_object(mp, 3);
     if (nxt_slow_path(status == NULL)) {

--- a/src/nxt_status.c
+++ b/src/nxt_status.c
@@ -12,6 +12,7 @@ nxt_conf_value_t *
 nxt_status_get(nxt_status_report_t *report, nxt_mp_t *mp)
 {
     size_t            i;
+    uint32_t          idx = 0;
     nxt_str_t         name;
     nxt_int_t         ret;
     nxt_status_app_t  *app;
@@ -39,7 +40,7 @@ nxt_status_get(nxt_status_report_t *report, nxt_mp_t *mp)
         return NULL;
     }
 
-    nxt_conf_set_member(status, &conns_str, obj, 0);
+    nxt_conf_set_member(status, &conns_str, obj, idx++);
 
     nxt_conf_set_member_integer(obj, &acc_str, report->accepted_conns, 0);
     nxt_conf_set_member_integer(obj, &active_str, report->accepted_conns
@@ -53,7 +54,7 @@ nxt_status_get(nxt_status_report_t *report, nxt_mp_t *mp)
         return NULL;
     }
 
-    nxt_conf_set_member(status, &reqs_str, obj, 1);
+    nxt_conf_set_member(status, &reqs_str, obj, idx++);
 
     nxt_conf_set_member_integer(obj, &total_str, report->requests, 0);
 
@@ -62,7 +63,7 @@ nxt_status_get(nxt_status_report_t *report, nxt_mp_t *mp)
         return NULL;
     }
 
-    nxt_conf_set_member(status, &apps_str, apps, 2);
+    nxt_conf_set_member(status, &apps_str, apps, idx++);
 
     for (i = 0; i < report->apps_count; i++) {
         app = &report->apps[i];

--- a/test/unit/status.py
+++ b/test/unit/status.py
@@ -6,16 +6,16 @@ class Status:
     control = Control()
 
     def _check_zeros():
-        assert Status.control.conf_get('/status') == {
-            'connections': {
+        status = Status.control.conf_get('/status')
+
+        assert status['connections'] == {
                 'accepted': 0,
                 'active': 0,
                 'idle': 0,
                 'closed': 0,
-            },
-            'requests': {'total': 0},
-            'applications': {},
         }
+        assert status['requests'] == {'total': 0}
+        assert status['applications'] == {}
 
     def init(status=None):
         Status._status = (
@@ -30,6 +30,9 @@ class Status:
                     for k in d1
                     if k in d2
                 }
+
+            if isinstance(d1, str):
+                return d1 == d2
 
             return d1 - d2
 


### PR DESCRIPTION
This pull-request comprises five commits with the overall goal of showing what language modules Unit has loaded _and_ from where, under the `/status` control API endpoint.

E.g

```json
{
    "modules": {
        "python": [
            {
                "version": "3.12.3",
                "lib": "/opt/unit/modules/python.unit.so"
            },
            {
                "version": "3.12.1",
                "lib": "/opt/unit/modules/python-3.12.1.unit.so"
            }
        ],
        "wasm": {
            "version": "0.1",
            "lib": "/opt/unit/modules/wasm.unit.so"
        },
        "wasm-wasi-component": {
            "version": "0.1",
            "lib": "/opt/unit/modules/wasm_wasi_component.unit.so"
        }
    },
...
}
```

This could be a useful debugging aid.

Patches

- status: Constify a bunch of local variables

Preparatory patch that `static const`'s a bunch of nxt_string()'s before I add some more...

- status: Use a variable to represent the status member index

Preparatory patch to use a variable to track the top-level object's index in the JSON rather than hard coding it.

- Flow the language module name into nxt_app_lang_module_t

This stores the language module name in the nxt_app_lang_module_t strcuture.

- status: Show list of loaded language modules

Main patch that adds a new top-level `modules` section.

- tests: Fix `/status' endpoint tests for new 'modules' section

See commit messages for more information...
