### PR TITLE
Copy the wasm-wasi-component module into build/lib/unit/modules/ as part of the build process

### DIFF
--- a/auto/modules/wasm-wasi-component
+++ b/auto/modules/wasm-wasi-component
@@ -110,6 +110,8 @@ ${NXT_WCM_MODULE}:	${NXT_WCM_MOD_CARGO}
 
 ${NXT_WCM_MOD_CARGO}: ${NXT_WCM_DEPS}
 	$NXT_CARGO_CMD
+	@install -p $NXT_WCM_MOD_CARGO \\
+		build/lib/unit/modules/${NXT_WCM_MOD_NAME}
 
 install: ${NXT_WCM_MODULE}-install
 

--- a/auto/modules/wasm-wasi-component
+++ b/auto/modules/wasm-wasi-component
@@ -85,9 +85,9 @@ $echo " + $NXT_WCM_MODULE module: $NXT_WCM_MOD_NAME"
 NXT_OS=$(uname -s)
 
 if [ $NXT_OS = "Darwin" ]; then
-	NXT_CARGO_CMD="cargo rustc --release --manifest-path src/wasm-wasi-component/Cargo.toml -- --emit link=target/release/libwasm_wasi_component.so -C link-args='-undefined dynamic_lookup'"
+    NXT_CARGO_CMD="cargo rustc --release --manifest-path src/wasm-wasi-component/Cargo.toml -- --emit link=target/release/libwasm_wasi_component.so -C link-args='-undefined dynamic_lookup'"
 else
-	NXT_CARGO_CMD="cargo build --release --manifest-path src/wasm-wasi-component/Cargo.toml"
+    NXT_CARGO_CMD="cargo build --release --manifest-path src/wasm-wasi-component/Cargo.toml"
 fi
 
 


### PR DESCRIPTION
The first patch is just a clean up patch that fixes some indentation.

The second patch copies the wasm-wasi-component .so into `build/lib/unit/modules/` with the right name. This matches the behaviour of the other language modules and is needed by things like the pytests.