### PR TITLE
contrib: make sha512sum check compatible with FreeBSD implementation

### DIFF
--- a/pkg/contrib/Makefile
+++ b/pkg/contrib/Makefile
@@ -51,7 +51,7 @@ XZ ?= $(error XZ (LZMA) compressor not found)
 endif
 
 ifeq ($(shell sha512sum --version >/dev/null 2>&1 || echo FAIL),)
-SHA512SUM = sha512sum --check
+SHA512SUM = sha512sum -c -
 else ifeq ($(shell shasum --version >/dev/null 2>&1 || echo FAIL),)
 SHA512SUM = shasum -a 512 --check
 else ifeq ($(shell openssl version >/dev/null 2>&1 || echo FAIL),)


### PR DESCRIPTION
FreeBSD introduced sha512sum binary in version 14, but with slightly incompatible flags as compared to Linux version.  This change makes it work in both worlds.