### PR TITLE
Fix a comment typo for 'Memory-only buffers' in src/nxt_buf.h

### DIFF
--- a/src/nxt_buf.h
+++ b/src/nxt_buf.h
@@ -13,7 +13,7 @@
  * should be allocated by appropriate nxt_buf_XXX_alloc() function.
  *
  * 1) Memory-only buffers, their size is less than nxt_buf_t size, it
- *    is equal to offsetof(nxt_buf_t, file_pos), that is it is nxt_buf_t
+ *    is equal to offsetof(nxt_buf_t, file), that is it is nxt_buf_t
  *    without file and mmap part.  The buffers are frequently used, so
  *    the reduction allows to save 20-32 bytes depending on platform.
  *


### PR DESCRIPTION
As the comment for 'Memory-only buffers' says

  "... it is equal to offsetof(nxt_buf_t, file.pos)"

and

  "... that is it is nxt_buf_t without file and mmap part"

Those are at odds with each other, 'file.pos' comes _after_ 'file' in the nxt_buf_t structure.

Fix the 'offset()' bit of the comment to reflect that and to match the relevant macro

```c
#define NXT_BUF_MEM_SIZE        offsetof(nxt_buf_t, file)
```