### PR TITLE
tests: Fix `/status' endpoint to cater for lists

### DIFF
--- a/test/unit/status.py
+++ b/test/unit/status.py
@@ -31,7 +31,7 @@ class Status:
                     if k in d2
                 }
 
-            if isinstance(d1, str):
+            if isinstance(d1, str) or isinstance(d1, list):
                 return d1 == d2
 
             return d1 - d2


### PR DESCRIPTION
    We can now get list objects from the /status endpoint in the case of
    having different versions of the same language module.
    
    That led to this error
    
      >       return d1 - d2
      E       TypeError: unsupported operand type(s) for -: 'list' and 'list'
    
    We already cover a similar case for when we have simple strings so add
    this to that.