### PR TITLE
fuzzing: added new target, fixed harness bug and beautified

### DIFF
--- a/fuzzing/nxt_basic_fuzz.c
+++ b/fuzzing/nxt_basic_fuzz.c
@@ -3,9 +3,15 @@
  */
 
 #include <nxt_main.h>
+#include <nxt_sha1.h>
+#include <nxt_websocket.h>
+#include <nxt_websocket_header.h>
+
+/* DO NOT TRY THIS AT HOME! */
+#include <nxt_websocket_accept.c>
 
 
-#define KMININPUTLENGTH 2
+#define KMININPUTLENGTH 4
 #define KMAXINPUTLENGTH 128
 
 
@@ -13,9 +19,17 @@ extern int LLVMFuzzerInitialize(int *argc, char ***argv);
 extern int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
 
 void nxt_base64_fuzz(const u_char *data, size_t size);
+void nxt_djb_hash_fuzz(const u_char *data, size_t size);
+void nxt_murmur_hash2_fuzz(const u_char *data, size_t size);
+void nxt_parse_fuzz(const u_char *data, size_t size);
+void nxt_sha1_fuzz(const u_char *data, size_t size);
+void nxt_sha1_update_fuzz(const u_char *data, size_t size);
 void nxt_term_fuzz(const u_char *data, size_t size);
 void nxt_time_fuzz(const u_char *data, size_t size);
+void nxt_uri_fuzz(const u_char *data, size_t size);
 void nxt_utf8_fuzz(const u_char *data, size_t size);
+void nxt_websocket_base64_fuzz(const u_char *data, size_t size);
+void nxt_websocket_frame_fuzz(const u_char *data, size_t size);
 
 
 extern char  **environ;
@@ -40,9 +54,17 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     }
 
     nxt_base64_fuzz(data, size);
+    nxt_djb_hash_fuzz(data, size);
+    nxt_murmur_hash2_fuzz(data, size);
+    nxt_parse_fuzz(data, size);
+    nxt_sha1_fuzz(data, size);
+    nxt_sha1_update_fuzz(data, size);
     nxt_term_fuzz(data, size);
     nxt_time_fuzz(data, size);
+    nxt_uri_fuzz(data, size);
     nxt_utf8_fuzz(data, size);
+    nxt_websocket_base64_fuzz(data, size);
+    nxt_websocket_frame_fuzz(data, size);
 
     return 0;
 }
@@ -67,6 +89,64 @@ nxt_base64_fuzz(const u_char *data, size_t size)
 
 
 void
+nxt_djb_hash_fuzz(const u_char *data, size_t size)
+{
+    nxt_djb_hash(data, size);
+    nxt_djb_hash_lowcase(data, size);
+}
+
+
+void
+nxt_murmur_hash2_fuzz(const u_char *data, size_t size)
+{
+    nxt_murmur_hash2(data, size);
+    nxt_murmur_hash2_uint32(data);
+}
+
+
+void
+nxt_parse_fuzz(const u_char *data, size_t size)
+{
+    nxt_str_t  input;
+
+    input.start = (u_char *)data;
+    input.length = size;
+
+    nxt_int_parse(data, size);
+    nxt_size_t_parse(data, size);
+    nxt_size_parse(data, size);
+    nxt_off_t_parse(data, size);
+    nxt_str_int_parse(&input);
+    nxt_number_parse(&data, data + size);
+}
+
+
+void
+nxt_sha1_fuzz(const u_char *data, size_t size)
+{
+    u_char      bin_accept[20];
+    nxt_sha1_t  ctx;
+
+    nxt_sha1_init(&ctx);
+    nxt_sha1_update(&ctx, data, size);
+    nxt_sha1_final(bin_accept, &ctx);
+}
+
+
+void
+nxt_sha1_update_fuzz(const u_char *data, size_t size)
+{
+    u_char      bin_accept[20];
+    nxt_sha1_t  ctx;
+
+    nxt_sha1_init(&ctx);
+    nxt_sha1_update(&ctx, data, size);
+    nxt_sha1_update(&ctx, data, size);
+    nxt_sha1_final(bin_accept, &ctx);
+}
+
+
+void
 nxt_term_fuzz(const u_char *data, size_t size)
 {
     nxt_term_parse(data, size, 0);
@@ -82,10 +162,75 @@ nxt_time_fuzz(const u_char *data, size_t size)
 
 
 void
+nxt_uri_fuzz(const u_char *data, size_t size)
+{
+    u_char  *dst;
+
+    dst = nxt_zalloc(size * 3);
+    if (dst == NULL) {
+        return;
+    }
+
+    nxt_decode_uri(dst, (u_char *)data, size);
+    nxt_decode_uri_plus(dst, (u_char *)data, size);
+
+    nxt_memzero(dst, size * 3);
+    nxt_encode_uri(NULL, (u_char *)data, size);
+    nxt_encode_uri(dst, (u_char *)data, size);
+
+    nxt_free(dst);
+}
+
+
+void
 nxt_utf8_fuzz(const u_char *data, size_t size)
 {
     const u_char  *in;
 
     in = data;
     nxt_utf8_decode(&in, data + size);
+
+    nxt_utf8_casecmp((const u_char *)"ABC АБВ ΑΒΓ",
+                    data,
+                    nxt_length("ABC АБВ ΑΒΓ"),
+                    size);
+}
+
+
+void
+nxt_websocket_base64_fuzz(const u_char *data, size_t size)
+{
+    u_char  *out;
+
+    out = nxt_zalloc(size * 2);
+    if (out == NULL) {
+        return;
+    }
+
+    nxt_websocket_base64_encode(out, data, size);
+
+    nxt_free(out);
+}
+
+
+void
+nxt_websocket_frame_fuzz(const u_char *data, size_t size)
+{
+    u_char  *input;
+
+    /*
+     * Resolve overwrites-const-input by using a copy of the data.
+     */
+    input = nxt_malloc(size);
+    if (input == NULL) {
+        return;
+    }
+
+    nxt_memcpy(input, data, size);
+
+    nxt_websocket_frame_init(input, 0);
+    nxt_websocket_frame_header_size(input);
+    nxt_websocket_frame_payload_len(input);
+
+    nxt_free(input);
 }

--- a/fuzzing/nxt_http_h1p_fuzz.c
+++ b/fuzzing/nxt_http_h1p_fuzz.c
@@ -61,12 +61,28 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         goto failed;
     }
 
+    req->proto.h1 = nxt_mp_zget(mp, sizeof(nxt_h1proto_t));
+    if (req->proto.h1 == NULL) {
+        goto failed;
+    }
+
+    req->conf = nxt_mp_zget(mp, sizeof(nxt_socket_conf_joint_t));
+    if (req->conf == NULL) {
+        goto failed;
+    }
+
+    req->conf->socket_conf = nxt_mp_zget(mp, sizeof(nxt_socket_conf_t));
+    if (req->conf->socket_conf == NULL) {
+        goto failed;
+    }
+
     buf.start = (u_char *)data;
     buf.end = (u_char *)data + size;
     buf.pos = buf.start;
     buf.free = buf.end;
 
     req->mem_pool = mp;
+    req->conf->socket_conf->max_body_size = 8 * 1024 * 1024;
 
     nxt_memzero(&rp, sizeof(nxt_http_request_parse_t));
 

--- a/fuzzing/nxt_json_fuzz.c
+++ b/fuzzing/nxt_json_fuzz.c
@@ -31,12 +31,13 @@ LLVMFuzzerInitialize(int *argc, char ***argv)
 int
 LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-    nxt_mp_t               *mp;
-    nxt_str_t              input;
-    nxt_thread_t           *thr;
-    nxt_runtime_t          *rt;
-    nxt_conf_value_t       *conf;
-    nxt_conf_validation_t  vldt;
+    nxt_mp_t                *mp;
+    nxt_str_t               input;
+    nxt_thread_t            *thr;
+    nxt_runtime_t           *rt;
+    nxt_conf_value_t        *conf;
+    nxt_conf_validation_t   vldt;
+    nxt_conf_json_pretty_t  pretty;
 
     if (size < KMININPUTLENGTH || size > KMAXINPUTLENGTH) {
         return 0;
@@ -65,12 +66,16 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     thr->runtime = rt;
     rt->mem_pool = mp;
 
+    nxt_memzero(&pretty, sizeof(nxt_conf_json_pretty_t));
     nxt_memzero(&vldt, sizeof(nxt_conf_validation_t));
 
     conf = nxt_conf_json_parse_str(mp, &input);
     if (conf == NULL) {
         goto failed;
     }
+
+    nxt_conf_json_length(conf, NULL);
+    nxt_conf_json_length(conf, &pretty);
 
     vldt.pool = nxt_mp_create(1024, 128, 256, 32);
     if (vldt.pool == NULL) {

--- a/fuzzing/nxt_json_fuzz.c
+++ b/fuzzing/nxt_json_fuzz.c
@@ -54,18 +54,23 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         goto failed;
     }
 
-    thr->runtime = rt;
-    rt->mem_pool = mp;
+    rt->languages = nxt_array_create(mp, 1, sizeof(nxt_app_lang_module_t));
+    if (rt->languages == NULL) {
+        goto failed;
+    }
 
     input.start = (u_char *)data;
     input.length = size;
+
+    thr->runtime = rt;
+    rt->mem_pool = mp;
+
+    nxt_memzero(&vldt, sizeof(nxt_conf_validation_t));
 
     conf = nxt_conf_json_parse_str(mp, &input);
     if (conf == NULL) {
         goto failed;
     }
-
-    nxt_memzero(&vldt, sizeof(nxt_conf_validation_t));
 
     vldt.pool = nxt_mp_create(1024, 128, 256, 32);
     if (vldt.pool == NULL) {
@@ -76,13 +81,7 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     vldt.conf_pool = mp;
     vldt.ver = NXT_VERNUM;
 
-    rt->languages = nxt_array_create(mp, 1, sizeof(nxt_app_lang_module_t));
-    if (rt->languages == NULL) {
-        goto failed;
-    }
-
     nxt_conf_validate(&vldt);
-
     nxt_mp_destroy(vldt.pool);
 
 failed:


### PR DESCRIPTION
### New target in basic `nxt_basic_fuzz.c`:

* djb hash
* murmur hash2
* parse
* sha1
* uri decode, uri encode
* utf8 casecmp
* websocket base64 encode
* websocket frame

### Beautified:

* nxt_http_controller_fuzz.c
* nxt_http_h1p_peer_fuzz.c
* nxt_http_h1p_fuzz.c
* nxt_json_fuzz.c

### Fix Bug:

[Null  dereference](https://oss-fuzz.com/testcase-detail/4522566136430592) in `nxt_http_h1p_fuzz.c`. https://github.com/nginx/unit/pull/1372/commits/5945e2bbfe610b699cd143871ce8a90b5c70226c

### Fuzzer hit coverage update:

Added extra surface for fuzzer in `nxt_json_fuzz.c` by using `nxt_conf_json_length` API.