### PR TITLE
tools/unitctl: make application directory configurable

### DIFF
--- a/tools/unitctl/README.md
+++ b/tools/unitctl/README.md
@@ -112,7 +112,7 @@ The new containers will then be shown in a call to
 $ unitctl instances new /tmp/2 $(pwd) 'unit:wasm'
 Pulling and starting a container from unit:wasm
 Will mount /tmp/2 to /var/run for socket access
-Will READ ONLY mount /home/ava/repositories/nginx/unit/tools/unitctl to /www for application access
+Will mount /home/user/repositories/nginx/unit/tools/unitctl to /www for application access
 Note: Container will be on host network
 
 ```
@@ -131,11 +131,16 @@ To the subcommand `unitctl instances new` the user must provide three arguments:
      For example: `127.0.0.1:7171`.
 2. **A path to an application:**
    In the example, `$(pwd)` is provided. The Unit container will mount
-   this READ ONLY to `/www/`. This will allow the user to configure
-   their Unit container to expose an application stored on the host.
+   this to `/www/`. This will allow the user to configure their
+   Unit container to expose an application stored on the host.
 3. **An image tag:**
    In the example, `unit:wasm` is used. This will be the image that unitctl
    will deploy. Custom repos and images can be deployed in this manner.
+
+In addition to the above arguments, the user may add the `-r` flag. This flag will
+set the Docker volume mount for the application directory to be read only. Do note
+that this flag will break compatibility with WordPress, and other applications
+which store state on the file system.
 
 After deployment the user will have one Unit container running on the host network.
 

--- a/tools/unitctl/unit-client-rs/src/unitd_docker.rs
+++ b/tools/unitctl/unit-client-rs/src/unitd_docker.rs
@@ -249,6 +249,7 @@ impl UnitdContainer {
 pub async fn deploy_new_container(
     socket: ControlSocket,
     application: &String,
+    application_read_only: bool,
     image: &String,
 ) -> Result<Vec<String>, UnitClientError> {
     match Docker::connect_with_local_defaults() {
@@ -269,7 +270,7 @@ pub async fn deploy_new_container(
                 typ: Some(MountTypeEnum::BIND),
                 source: Some(application.clone()),
                 target: Some("/www".to_string()),
-                read_only: Some(true),
+                read_only: Some(application_read_only),
                 ..Default::default()
             });
 

--- a/tools/unitctl/unitctl/src/cmd/instances.rs
+++ b/tools/unitctl/unitctl/src/cmd/instances.rs
@@ -13,6 +13,7 @@ pub(crate) async fn cmd(args: InstanceArgs) -> Result<(), UnitctlError> {
             InstanceCommands::New {
                 ref socket,
                 ref application,
+                ref application_read_only,
                 ref image,
             } => {
                 // validation for application dir
@@ -95,7 +96,12 @@ pub(crate) async fn cmd(args: InstanceArgs) -> Result<(), UnitctlError> {
                     // reflect changes to user
                     // print this to STDERR to avoid polluting deserialized data output
                     eprintln!("> Pulling and starting a container from {}", image);
-                    eprintln!("> Will READ ONLY mount {} to /www for application access", application);
+                    eprintln!("> Will mount {} to /www for application access", application);
+
+                    if *application_read_only {
+                        eprintln!("> Application mount will be read only");
+                    }
+
                     eprintln!("> Container will be on host network");
                     match addr.as_ref().unwrap() {
                         ControlSocket::UnixLocalSocket(path) => eprintln!(
@@ -113,7 +119,7 @@ pub(crate) async fn cmd(args: InstanceArgs) -> Result<(), UnitctlError> {
                     }
 
                     // do the actual deployment
-                    deploy_new_container(addr.unwrap(), application, image)
+                    deploy_new_container(addr.unwrap(), application, *application_read_only, image)
                         .await
                         .map_or_else(
                             |e| Err(UnitctlError::UnitClientError { source: e }),

--- a/tools/unitctl/unitctl/src/unitctl.rs
+++ b/tools/unitctl/unitctl/src/unitctl.rs
@@ -119,12 +119,8 @@ pub(crate) enum Commands {
 
     #[command(about = "Export the current configuration of UNIT")]
     Export {
-        #[arg(
-            required = true,
-            short = 'f',
-            help = "tarball filename to save configuration to"
-        )]
-        filename: String
+        #[arg(required = true, short = 'f', help = "tarball filename to save configuration to")]
+        filename: String,
     },
 }
 
@@ -154,6 +150,9 @@ pub enum InstanceCommands {
 
         #[arg(required = true, help = "Path to mount application into container")]
         application: String,
+
+        #[arg(help = "Mount application directory as read only", short = 'r', long = "read-only")]
+        application_read_only: bool,
 
         #[arg(
             help = "Unitd Image to deploy",


### PR DESCRIPTION
* default behavior is now a read write application mount
* user can specify a flag (-r) to mount app dir as read only
* fixes #1247 