### PR TITLE
unitctl: clean up output format text

### DIFF
--- a/tools/unitctl/unitctl/src/unitctl.rs
+++ b/tools/unitctl/unitctl/src/unitctl.rs
@@ -51,7 +51,7 @@ pub(crate) enum Commands {
             short = 't',
             long = "output-format",
             default_value = "json-pretty",
-            help = "Output format: yaml, json, json-pretty (default)"
+            help = "Output format: yaml, json, json-pretty"
         )]
         output_format: OutputFormat,
     },
@@ -68,7 +68,7 @@ pub(crate) enum Commands {
             short = 't',
             long = "output-format",
             default_value = "json-pretty",
-            help = "Output format: yaml, json, json-pretty (default)"
+            help = "Output format: yaml, json, json-pretty"
         )]
         output_format: OutputFormat,
         #[arg(
@@ -98,7 +98,7 @@ pub(crate) enum Commands {
             short = 't',
             long = "output-format",
             default_value = "json-pretty",
-            help = "Output format: yaml, json, json-pretty (default)"
+            help = "Output format: yaml, json, json-pretty"
         )]
         output_format: OutputFormat,
     },
@@ -110,7 +110,7 @@ pub(crate) enum Commands {
             short = 't',
             long = "output-format",
             default_value = "json-pretty",
-            help = "Output format: yaml, json, json-pretty (default)"
+            help = "Output format: yaml, json, json-pretty"
         )]
         output_format: OutputFormat,
     },
@@ -136,7 +136,7 @@ pub struct InstanceArgs {
         short = 't',
         long = "output-format",
         default_value = "text",
-        help = "Output format: text, yaml, json, json-pretty (default)"
+        help = "Output format: text, yaml, json, json-pretty"
     )]
     pub output_format: OutputFormat,
 
@@ -171,7 +171,7 @@ pub struct ApplicationArgs {
         short = 't',
         long = "output-format",
         default_value = "text",
-        help = "Output format: text, yaml, json, json-pretty (default)"
+        help = "Output format: text, yaml, json, json-pretty"
     )]
     pub output_format: OutputFormat,
 

--- a/tools/unitctl/unitctl/src/unitctl.rs
+++ b/tools/unitctl/unitctl/src/unitctl.rs
@@ -51,7 +51,7 @@ pub(crate) enum Commands {
             short = 't',
             long = "output-format",
             default_value = "json-pretty",
-            help = "Output format: yaml, json, json-pretty"
+            help = "Output format of the result"
         )]
         output_format: OutputFormat,
     },
@@ -68,7 +68,7 @@ pub(crate) enum Commands {
             short = 't',
             long = "output-format",
             default_value = "json-pretty",
-            help = "Output format: yaml, json, json-pretty"
+            help = "Output format of the result"
         )]
         output_format: OutputFormat,
         #[arg(
@@ -98,7 +98,7 @@ pub(crate) enum Commands {
             short = 't',
             long = "output-format",
             default_value = "json-pretty",
-            help = "Output format: yaml, json, json-pretty"
+            help = "Output format of the result"
         )]
         output_format: OutputFormat,
     },
@@ -110,7 +110,7 @@ pub(crate) enum Commands {
             short = 't',
             long = "output-format",
             default_value = "json-pretty",
-            help = "Output format: yaml, json, json-pretty"
+            help = "Output format of the result"
         )]
         output_format: OutputFormat,
     },
@@ -136,7 +136,7 @@ pub struct InstanceArgs {
         short = 't',
         long = "output-format",
         default_value = "json-pretty",
-        help = "Output format: text, yaml, json, json-pretty"
+        help = "Output format of the result"
     )]
     pub output_format: OutputFormat,
 
@@ -171,7 +171,7 @@ pub struct ApplicationArgs {
         short = 't',
         long = "output-format",
         default_value = "json-pretty",
-        help = "Output format: text, yaml, json, json-pretty"
+        help = "Output format of the result"
     )]
     pub output_format: OutputFormat,
 

--- a/tools/unitctl/unitctl/src/unitctl.rs
+++ b/tools/unitctl/unitctl/src/unitctl.rs
@@ -135,7 +135,7 @@ pub struct InstanceArgs {
         global = true,
         short = 't',
         long = "output-format",
-        default_value = "text",
+        default_value = "json-pretty",
         help = "Output format: text, yaml, json, json-pretty"
     )]
     pub output_format: OutputFormat,
@@ -170,7 +170,7 @@ pub struct ApplicationArgs {
         global = true,
         short = 't',
         long = "output-format",
-        default_value = "text",
+        default_value = "json-pretty",
         help = "Output format: text, yaml, json, json-pretty"
     )]
     pub output_format: OutputFormat,


### PR DESCRIPTION
After figuring out what and how clap deals with input enums and how those enums end up being serialised to the terminal, I reworded the output format message. Both the `default` and the `possible values` are programmatic and clap will print them anyways, there is no reason to include the same detail again in the help message.

This helps us avoid inconsistencies between functionality, code that clap makes use of, and freeform description that clap doesn't have knowledge about.

I alsoi changed the default output format of two other subcommands to be `json-pretty` rather than `text` to align with the rest of the subcommands.

Now every subcommand has the exact same output format help:

```
Options:
  -t, --output-format <OUTPUT_FORMAT>  Output format of the result [default: json-pretty] [possible values: yaml, json, json-pretty, text]
```

Closes #1375

