### PR TITLE
Update Openapi specification for new /status/modules endpoint

### DIFF
--- a/docs/unit-openapi.yaml
+++ b/docs/unit-openapi.yaml
@@ -3906,7 +3906,7 @@ paths:
       operationId: getStatus
       summary: "Retrieve the status object"
       description: "Retrieves the entire `/status` section that represents
-        Unit's [usage statistics](https://unit.nginx.org/usagestats/)."
+        Unit's [usage statistics and list of loaded modules](https://unit.nginx.org/statusapi/)."
 
       tags:
         - status
@@ -3930,7 +3930,7 @@ paths:
       operationId: getStatusConnections
       summary: "Retrieve the connections status object"
       description: "Retrieves the `connections` status object that represents
-        Unit's [connection statistics](https://unit.nginx.org/usagestats/)."
+        Unit's [connection statistics](https://unit.nginx.org/statusapi/)."
 
       tags:
         - status
@@ -3955,7 +3955,7 @@ paths:
       operationId: getStatusConnectionsAccepted
       summary: "Retrieve the accepted connections number"
       description: "Retrieves the `accepted` connections number that represents
-        Unit's [connection statistics](https://unit.nginx.org/usagestats/)."
+        Unit's [connection statistics](https://unit.nginx.org/statusapi/)."
 
       tags:
         - status
@@ -3979,7 +3979,7 @@ paths:
       operationId: getStatusConnectionsActive
       summary: "Retrieve the active connections number"
       description: "Retrieves the `active` connections number that represents
-        Unit's [connection statistics](https://unit.nginx.org/usagestats/)."
+        Unit's [connection statistics](https://unit.nginx.org/statusapi/)."
 
       tags:
         - status
@@ -4003,7 +4003,7 @@ paths:
       operationId: getStatusConnectionsIdle
       summary: "Retrieve the idle connections number"
       description: "Retrieves the `idle` connections number that represents
-        Unit's [connection statistics](https://unit.nginx.org/usagestats/)."
+        Unit's [connection statistics](https://unit.nginx.org/statusapi/)."
       tags:
         - status
 
@@ -4026,7 +4026,7 @@ paths:
       operationId: getStatusConnectionsClosed
       summary: "Retrieve the closed connections number"
       description: "Retrieves the `closed` connections number that represents
-        Unit's [connection statistics](https://unit.nginx.org/usagestats/)."
+        Unit's [connection statistics](https://unit.nginx.org/statusapi/)."
 
       tags:
         - status
@@ -4051,7 +4051,7 @@ paths:
       summary: "Retrieve the requests status object"
       description: "Retrieves the `requests` status object that represents
         Unit's instance [request statistics]
-        (https://unit.nginx.org/usagestats/)."
+        (https://unit.nginx.org/statusapi/)."
 
       tags:
         - status
@@ -4075,7 +4075,7 @@ paths:
       operationId: getStatusRequestsTotal
       summary: "Retrieve the total requests number"
       description: "Retrieves the `total` requests number that represents Unit's
-        instance [request statistics](https://unit.nginx.org/usagestats/)."
+        instance [request statistics](https://unit.nginx.org/statusapi/)."
 
       tags:
         - status
@@ -4100,7 +4100,7 @@ paths:
       summary: "Retrieve the applications status object"
       description: "Retrieves the `applications` status object that represents
         Unit's per-app
-        [process and request statistics](https://unit.nginx.org/usagestats/)."
+        [process and request statistics](https://unit.nginx.org/statusapi/)."
       tags:
         - status
 
@@ -4125,7 +4125,7 @@ paths:
       summary: "Retrieve the app status object"
       description: "Retrieves the app status object that represents
         Unit's per-app
-        [process and request statistics](https://unit.nginx.org/usagestats/)."
+        [process and request statistics](https://unit.nginx.org/statusapi/)."
 
       tags:
         - status
@@ -4156,7 +4156,7 @@ paths:
       summary: "Retrieve the processes app status object"
       description: "Retrieves the `processes` app status object that represents
         Unit's per-app
-        [process statistics](https://unit.nginx.org/usagestats/)."
+        [process statistics](https://unit.nginx.org/statusapi/)."
       tags:
         - status
 
@@ -4186,7 +4186,7 @@ paths:
       summary: "Retrieve the running processes app status number"
       description: "Retrieves the `running` processes number that represents
         Unit's per-app
-        [process statistics](https://unit.nginx.org/usagestats/)."
+        [process statistics](https://unit.nginx.org/statusapi/)."
 
       tags:
         - status
@@ -4217,7 +4217,7 @@ paths:
       summary: "Retrieve the starting processes app status number"
       description: "Retrieves the `starting` processes number that represents
         Unit's per-app
-        [process statistics](https://unit.nginx.org/usagestats/)."
+        [process statistics](https://unit.nginx.org/statusapi/)."
 
       tags:
         - status
@@ -4248,7 +4248,7 @@ paths:
       summary: "Retrieve the idle processes app status number"
       description: "Retrieves the `idle` processes number that represents
         Unit's per-app
-        [process statistics](https://unit.nginx.org/usagestats/)."
+        [process statistics](https://unit.nginx.org/statusapi/)."
 
       tags:
         - status
@@ -4278,7 +4278,7 @@ paths:
       summary: "Retrieve the requests app status object"
       description: "Retrieves the `requests` app status object that represents
         Unit's per-app
-        [request statistics](https://unit.nginx.org/usagestats/)."
+        [request statistics](https://unit.nginx.org/statusapi/)."
 
       tags:
         - status
@@ -4306,7 +4306,7 @@ paths:
       summary: "Retrieve the active requests app status number"
       description: "Retrieves the `active` requests number that represents
         Unit's per-app
-        [request statistics](https://unit.nginx.org/usagestats/)."
+        [request statistics](https://unit.nginx.org/statusapi/)."
 
       tags:
         - status
@@ -6455,7 +6455,7 @@ tags:
   - name: status
     description: Everything about the /status section in Unit's control API
     externalDocs:
-      url: https://unit.nginx.org/usagestats/
+      url: https://unit.nginx.org/statusapi/
 
   - name: tls
     description: Everything about SSL/TLS in Unit's control API

--- a/docs/unit-openapi.yaml
+++ b/docs/unit-openapi.yaml
@@ -3924,6 +3924,114 @@ paths:
                 example1:
                   $ref: "#/components/examples/status"
 
+  /status/modules:
+    summary: "Endpoint for the `modules` status object"
+    get:
+      operationId: getStatusModules
+      summary: "Retrieve the modules status object"
+      description: "Retrieves the `modules` status object that represents
+        Unit's [loaded language modules](https://unit.nginx.org/statusapi/)."
+
+      tags:
+        - status
+
+      responses:
+        "200":
+          description: "OK; the `modules` object exists in the configuration."
+
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/statusModules"
+
+              examples:
+                example1:
+                  $ref: "#/components/examples/statusModules"
+
+                example2:
+                  $ref: "#/components/examples/statusModulesArray"
+
+  /status/modules/{langMod}:
+    summary: "Endpoint for the loaded language `module` object"
+    get:
+      operationId: getStatusModulesLang
+      summary: "Retrieve the language module object"
+      description: "Retrieves the language `module` object that represents a
+        currently loaded language module."
+
+    tags:
+      - status
+
+    responses:
+      "200":
+        description: "OK; the language `module` object exists."
+
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/StatusModulesLang"
+
+          examples:
+            example1:
+              $ref: "#/components/examples/statusModulesLang
+
+      "404":
+        $ref: "#/components/responses/responseNotFound"
+
+  /status/modules/{langMod}/version:
+    summary: "Endpoint for the loaded language module `version` object"
+    get:
+      operationId: getStatusModulesLangVersion
+      summary: "Retrieve the language module version object"
+      description: "Retrieves the language module `version` object that
+        represents the version of a currently loaded language module."
+
+    tags:
+      - status
+
+    responses:
+      "200":
+        description: "OK; the language module `version` object exists."
+
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/StatusModulesLangVersion"
+
+          examples:
+            example1:
+              $ref: "#/components/examples/statusModulesLangVersion
+
+      "404":
+        $ref: "#/components/responses/responseNotFound"
+
+  /status/modules/{langMod}/lib:
+    summary: "Endpoint for the loaded language module `lib` object"
+    get:
+      operationId: getStatusModulesLangLib
+      summary: "Retrieves the language module lib object"
+      description: "Retrieves the language module `lib` object that represents
+        the file path to the loaded language module."
+
+    tags:
+      - status
+
+    responses:
+      "200":
+        description: "OK; the language module `lib` object exists."
+
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/StatusModulesLangLib"
+
+          examples:
+            example1:
+              $ref: "#/components/examples/statusModulesLangLib
+
+      "404":
+        $ref: "#/components/responses/responseNotFound"
+
   /status/connections:
     summary: "Endpoint for the `connections` status object"
     get:
@@ -4993,6 +5101,10 @@ components:
     status:
       summary: "Regular status object"
       value:
+        modules:
+          php:
+            version: "8.3.4"
+            lib: "/opt/unit/modules/php.unit.so"
         connections:
           accepted: 1067
           active: 13
@@ -5008,6 +5120,45 @@ components:
               idle: 0
             requests:
               active: 15
+
+    # /status/modules
+    statusModules:
+      summary: "Loaded language modules status object"
+      value:
+        php:
+          version: "8.3.4"
+          lib: "/opt/unit/modules/php.unit.so"
+
+    statusModulesArray:
+      summary: "Loaded language modules status array"
+      value:
+        php:
+          version: "8.3.4"
+          lib: "/opt/unit/modules/php.unit.so"
+        python:
+          - { version: "3.12.3", lib: "/opt/unit/modules/python.unit.so" }
+          - { version: "3.11.1", lib: "/opt/unit/modules/python-3.11.1.unit.so" }
+        wasm:
+          version: "0.2"
+          lib: "/opt/unit/modules/wasm.unit.so"
+
+    # /status/modules/{langMod}
+    statusModulesLang:
+      summary: "Object or array of objects of specified language module"
+      value:
+        python:
+          version: "3.12.3"
+          lib: "/opt/unit/modules/python.unit.so"
+
+    # /status/modules/{langMod}/version
+    statusModulesLangVersion:
+      summary: "String describing the version of the language module"
+      value: "3.12.3"
+
+    # /status/modules/{langMod}/lib
+    statusModulesLangLib:
+      summary: "String describing the path to the loaded language module"
+      value: "/opt/unit/modules/python.unit.so"
 
     # /status/connections
     statusConnections:
@@ -6319,9 +6470,13 @@ components:
 
     # /status
     status:
-      description: "Represents Unit's usage statistics."
+      description: "Represents Unit's loaded language modules and usage
+        statistics."
       type: object
       properties:
+        modules:
+          $ref: "#/components/schemas/statusModules"
+
         connections:
           $ref: "#/components/schemas/statusConnections"
 
@@ -6330,6 +6485,27 @@ components:
 
         applications:
           $ref: "#/components/schemas/statusApplications"
+
+    # /status/modules
+    statusModules:
+      description: "Lists currently loaded language modules."
+      type: object
+
+    # /status/modules/{langMod}
+    statusModulesLang:
+      description: "Lists currently loaded versions of the specified language
+        module."
+      type: array or object
+
+    # /status/modules/{langMod}/version
+    statusModulesLangVersion:
+      description: "Describes the version of the specified language module."
+      type: string
+
+    # /status/modules/{langMod}/lib
+    statusModulesLangLib:
+      description: "Describes the path to the specified language module."
+      type: string
 
     # /status/applications
     statusApplications:


### PR DESCRIPTION
The first patch updates the URL as it was renamed to be more accurate in what /status represents.

The second patch add entries for the new /status/modules endpoint which lists the currently loaded language modules.

[ This work was instigated by @Jcahilltorre hence the authorship of the patches... ]

