### PR TITLE
Better available CPU count determination on Linux

### DIFF
--- a/auto/sched
+++ b/auto/sched
@@ -1,0 +1,19 @@
+# Copyright (C) Andrew Clayton
+# Copyright (C) NGINX, Inc.
+
+
+nxt_feature="Linux sched_getaffinity()"
+nxt_feature_name=NXT_HAVE_LINUX_SCHED_GETAFFINITY
+nxt_feature_run=no
+nxt_feature_incs=
+nxt_feature_libs=
+nxt_feature_test="#define _GNU_SOURCE
+                  #include <sched.h>
+
+                  int main(void) {
+                      cpu_set_t set;
+
+                      sched_getaffinity(0, sizeof(set), &set);
+                      return 0;
+                  }"
+. auto/feature

--- a/configure
+++ b/configure
@@ -135,6 +135,7 @@ fi
 . auto/cgroup
 . auto/isolation
 . auto/capability
+. auto/sched
 
 
 case "$NXT_SYSTEM_PLATFORM" in


### PR DESCRIPTION
This pull-request enhances how we determine the number of CPU's available to Unit to run on under Linux.

In a recent [discussion](https://github.com/nginx/unit/issues/1042#issuecomment-2282308293) it became clear there are cases whereby we can end up creating way too many router threads (these are what handle client connections).

We currently try to create a number of router threads (not incl the main one) that match the number of on-line CPU's. This is currently determined with

```c
n = sysconf(_SC_NPROCESSORS_ONLN);
```

While that generally works, there are cases where it can give the wrong answer, for us anyway. I'll use the nproc(1) utility to demonstrate

```sh
$ nproc 
4
# 4 cpu system, 4 on-line cpu's
# Let's limit nproc to just 2 cpu's
$ taskset -c 0-1 nproc 
2
# Let's ignore the cpu allowed mask
$ taskset -c 0-1 nproc --all
4
```

nproc with no arguments will (on Linux) use sched_getaffinity(2) to determine the number of CPU's that it's allowed to run on. Passing `--all` makes it use sysconf(3) as above.

That last example is what currently happens with Unit, even if it's been limited in the number of CPU's it's actually allowed to run on it will still create a number of router threads matching the result of the sysconf(3) call.

This pull-request thus comprises two patches to remedy this situation

The first adds a new auto check for the sched_getaffinity(2) system call on Linux.

The second uses this to determine the number of router threads to create, on Linux we still use sysconf(3) as a fallback.

This could also help with containers, whereby they are being limited in the number of CPU's they can use on high cpu count machines.