### PR TITLE
socket: Use a default listen backlog of -1 on Linux

### DIFF
--- a/src/nxt_listen_socket.h
+++ b/src/nxt_listen_socket.h
@@ -35,16 +35,16 @@ typedef struct {
 } nxt_listen_socket_t;
 
 
-#if (NXT_FREEBSD || NXT_MACOSX || NXT_OPENBSD)
+#if (NXT_LINUX || NXT_FREEBSD || NXT_MACOSX || NXT_OPENBSD)
 /*
- * A backlog is limited by system-wide sysctl kern.ipc.somaxconn.
- * This is supported by FreeBSD 2.2, OpenBSD 2.0, and MacOSX.
+ * A backlog is limited by system-wide sysctl {net.core,kern.ipc}.somaxconn.
+ * This is supported by Linux, FreeBSD 2.2, OpenBSD 2.0, and MacOSX.
  */
 #define NXT_LISTEN_BACKLOG    -1
 
 #else
 /*
- * Linux, Solaris, and NetBSD treat negative value as 0.
+ * Solaris and NetBSD treat negative value as 0.
  * 511 is a safe default.
  */
 #define NXT_LISTEN_BACKLOG    511


### PR DESCRIPTION
On FreeBSD, OpenBSD & macOS we use a default listen(2) backlog of -1 which means use the OS's default value.

On Linux (and others) we used a hard coded value of 511, presumably due to this comment

```c
  /* Linux, Solaris, and NetBSD treat negative value as 0. */
```
On Linux (at least since 2.4), this is wrong, Linux treats -1 (and so on) as use the OS's default (net.core.somaxconn). See this code in net/socket.c::__sys_listen()

```c
                if ((unsigned int)backlog > somaxconn)
                        backlog = somaxconn;
```

On Linux prior to 5.4 somaxconn defaulted to 128, since 5.4 it defaults to 4096.

We've had complaints that a listen backlog of 511 is too small. This would help in those cases.

Unless they are on an old Kernel, in which case it's worse, but then the plan is to also make this configurable. This would effect RHEL 8, which is based on 4.10, however they seem to set somaxconn to 2048, so that's fine.

Another advantage of using -1 is that we will automatically keep up to date with the kernels default value.

Before this change

```
  $ ss -tunxlp | grep unit
  Netid State  Recv-Q Send-Q                                                  Local Address:Port     Peer Address:Port           Process
  u_str LISTEN 0      511                                   /opt/unit/control.unit.sock.tmp 4302333            * 0    users:(("unitd",pid=18290,fd=6),("unitd",pid=18289,fd=6),("unitd",pid=18287,fd=6))
  tcp   LISTEN 0      511                                                         127.0.0.1:8080         0.0.0.0:*    users:(("unitd",pid=18290,fd=12))
  tcp   LISTEN 0      511                                                             [::1]:8080            [::]:*    users:(("unitd",pid=18290,fd=11))
```

After

```
  $ ss -tunxlp | grep unit
  Netid State  Recv-Q Send-Q                                                  Local Address:Port     Peer Address:Port           Process
  u_str LISTEN 0      4096                                  /opt/unit/control.unit.sock.tmp 5408464            * 0    users:(("unitd",pid=132442,fd=6),("unitd",pid=132441,fd=6),("unitd",pid=132439,fd=6))
  tcp   LISTEN 0      4096                                                        127.0.0.1:8080         0.0.0.0:*    users:(("unitd",pid=132442,fd=12))
  tcp   LISTEN 0      4096                                                            [::1]:8080            [::]:*    users:(("unitd",pid=132442,fd=11))
```