### PR TITLE
fuzzing: fixed harness bug

### DIFF
--- a/fuzzing/nxt_http_h1p_peer_fuzz.c
+++ b/fuzzing/nxt_http_h1p_peer_fuzz.c
@@ -62,6 +62,16 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         goto failed;
     }
 
+    req->peer = nxt_mp_zalloc(mp, sizeof(nxt_http_peer_t));
+    if (req->peer == NULL) {
+        goto failed;
+    }
+
+    req->peer->proto.h1 = nxt_mp_zalloc(mp, sizeof(nxt_h1proto_t));
+    if (req->peer->proto.h1 == NULL) {
+        goto failed;
+    }
+
     buf.start = (u_char *)data;
     buf.end = (u_char *)data + size;
     buf.pos = buf.start;

--- a/src/nxt_sockaddr.c
+++ b/src/nxt_sockaddr.c
@@ -732,6 +732,11 @@ nxt_sockaddr_inet_parse(nxt_mp_t *mp, nxt_str_t *addr)
         length = p - addr->start;
     }
 
+    if (length == 0) {
+        nxt_thread_log_error(NXT_LOG_ERR, "invalid address \"%V\"", addr);
+        return NULL;
+    }
+
     inaddr = INADDR_ANY;
 
     if (length != 1 || addr->start[0] != '*') {


### PR DESCRIPTION
The first patch is straightforward; https://github.com/nginx/unit/pull/1393/commits/69b830bf75b0c0d40c0cde003b45b87a78170ba7 [70961](https://oss-fuzz.com/testcase-detail/4875165201137664).


The second patch, on the other hand, is quite suspicious. It works now, but I have no idea what I am doing.
I think it does require some changes to the JSON parsing and JSON after parsing.
https://github.com/nginx/unit/pull/1393/commits/0d581e81f4a873fedebb8289e3af2267c6392f28 [70961](https://oss-fuzz.com/testcase-detail/4875165201137664)




### Report:
The `addr->length` is `0`. It does make my job easy, so I added a check: if the length is zero, return null.
But `addr->start` holds 303 bytes.

```patch
diff --git a/src/nxt_sockaddr.c b/src/nxt_sockaddr.c
index 32941893..c48e0662 100644
--- a/src/nxt_sockaddr.c
+++ b/src/nxt_sockaddr.c
@@ -734,6 +734,9 @@ nxt_sockaddr_inet_parse(nxt_mp_t *mp, nxt_str_t *addr)
 
     inaddr = INADDR_ANY;
 
+    printf("%c\n", addr->start[303]);
+    printf("%c\n", addr->start[304]); // Crash.
+
     if (length != 1 || addr->start[0] != '*') {
         inaddr = nxt_inet_addr(addr->start, length);
         if (nxt_slow_path(inaddr == INADDR_NONE)) {
```

Bytes in `addr->start` 
```hex
3A20 2020 FFFF FFFF FFFF FFFF FFFF FFFF
FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF
FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF
FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF
FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF
FFFF FFFF FFFF 2020 2020 2020 2020 2020
2020 2020 2020 2020 2020 2020 2020 2020
2020 2020 FFFF FFFF FFFF FFFF FFFF FFFF
FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF
FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF
FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF
FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF
FFFF FFFF FFFF FFFF FF20 2020 2020 2020
2020 2020 2020 2020 2020 2020 2020 2020
2020 2020 2020 2020 2020 2020 2020 2020
2020 2020 2020 2020 2020 2020 2020 2020
20BE BEBE BEBE BEBE C003 0000 E050 0000
C003 0000 E050 0000 B002 0000 D050 0000
0102 00BE 0101 0000 4009 0000 2051 00
```

`xxd clusterfuzz-testcase-minimized-fuzz_json-4875165201137664`
```hex
00000000: 7b22 6c69 7374 656e 6572 7322 3a7b 223a  {"listeners":{":
00000010: 2020 20ff ffff ffff ffff ffff ffff ffff     .............
00000020: ffff ffff ffff ffff ffff ffff ffff ffff  ................
00000030: ffff ffff ffff ffff ffff ffff ffff ffff  ................
00000040: ffff ffff ffff ffff ffff ffff ffff ffff  ................
00000050: ffff ffff ffff ffff ffff ffff ffff ffff  ................
00000060: ffff ffff ff20 2020 2020 2020 2020 2020  .....           
00000070: 2020 2020 2020 2020 2020 2020 2020 2020                  
00000080: 2020 20ff ffff ffff ffff ffff ffff ffff     .............
00000090: ffff ffff ffff ffff ffff ffff ffff ffff  ................
000000a0: ffff ffff ffff ffff ffff ffff ffff ffff  ................
000000b0: ffff ffff ffff ffff ffff ffff ffff ffff  ................
000000c0: ffff ffff ffff ffff ffff ffff ffff ffff  ................
000000d0: ffff ffff ffff ffff 2020 2020 2020 2020  ........        
000000e0: 2020 2020 2020 2020 2020 2020 2020 2020                  
000000f0: 2020 2020 2020 2020 2020 2020 2020 2020                  
00000100: 2020 2020 2020 2020 2020 2020 2020 2020                  
00000110: 223a 2222 7d7d                           ":""}}
```

I believe the second patch does require some fine-tuning, nonetheless.