### PR TITLE
Docker-related updates

### DIFF
--- a/pkg/docker/Makefile
+++ b/pkg/docker/Makefile
@@ -9,6 +9,7 @@ VERSION ?= $(DEFAULT_VERSION)
 PATCHLEVEL ?= 1
 
 MODULES ?= go jsc node perl php python ruby wasm
+MODULES_SLIM ?= python
 
 VARIANT ?= bookworm
 
@@ -62,6 +63,7 @@ MODULE_PREBUILD_php ?= /bin/true
 VERSIONS_python ?=  3.11 3.12
 VARIANT_python ?=	$(VARIANT)
 $(foreach pythonversion, $(VERSIONS_python), $(eval CONTAINER_python$(pythonversion) = python:$(pythonversion)-$(VARIANT_python)))
+$(foreach pythonversion, $(VERSIONS_python), $(eval CONTAINER_python$(pythonversion)-slim = python:$(pythonversion)-slim-$(VARIANT_python)))
 CONFIGURE_python ?=	python --config=/usr/local/bin/python3-config
 INSTALL_python ?=	python3-install
 RUN_python ?=		/bin/true
@@ -109,9 +111,11 @@ endef
 default:
 	@echo "valid targets: all build dockerfiles library clean"
 
-MODVERSIONS = $(foreach module, $(MODULES), $(foreach modversion, $(shell for v in $(VERSIONS_$(module)); do echo $$v; done | sort -r), $(module)$(modversion))) wasm minimal
+MODVERSIONS = $(foreach module, $(MODULES), $(foreach modversion, $(shell for v in $(VERSIONS_$(module)); do echo $$v; done | sort -r), $(module)$(modversion)))
+MODVERSIONS += $(foreach module, $(MODULES_SLIM), $(foreach modversion, $(shell for v in $(VERSIONS_$(module)); do echo $$v; done | sort -r), $(module)$(modversion)-slim))
+MODVERSIONS += wasm minimal
 
-modname = $(shell echo $1 | /usr/bin/tr -d '.01234567890-')
+modname = $(shell echo $1 | /usr/bin/tr -d '.01234567890-' | sed 's/slim//')
 
 dockerfiles: $(addprefix Dockerfile., $(MODVERSIONS))
 build: $(addprefix build-, $(MODVERSIONS))
@@ -141,10 +145,14 @@ library:
 	@previous=""; \
 	 for mod in $(MODVERSIONS); do \
 		echo ""; \
-		modname="$$( echo $$mod | tr -d '.0123456789-' )"; \
-		TAGS="$$mod $${mod%%.*} $$modname" ; \
+		modname="$$( echo $$mod | tr -d '.0123456789')"; \
+		modmajor="$${mod%%.*}"; \
+		if test "$${mod#*slim}" != "$$mod"; then \
+			modmajor="$${modmajor}-slim"; \
+		fi; \
+		TAGS="$$mod $$modmajor $$modname"; \
 		TAGS="$$(echo $$TAGS | tr " " "\n" | sort -u -r | tr "\n" "," | sed "s/,/, /g")"; \
-		if [ "$$previous" = "$$modname" ]; then \
+		if test "$${previous#*"$$modname"}" != "$$previous"; then \
 			echo "Tags: $(VERSION)-$$mod, $$mod"; \
 		else \
 			if [ "$$mod" = "minimal" ]; then \
@@ -158,7 +166,7 @@ library:
 		echo "GitCommit: $(shell git describe --always --abbrev=0 HEAD)"; \
 		echo "Directory: pkg/docker"; \
 		echo "File: Dockerfile.$$mod"; \
-		previous=$$(echo $$mod | tr -d '.0123456789-'); \
+		previous="$$previous $$modname"; \
 	done
 
 diff: $(addprefix diff-, $(MODVERSIONS))

--- a/pkg/docker/Makefile
+++ b/pkg/docker/Makefile
@@ -136,6 +136,7 @@ Dockerfile.%: ../../version template.Dockerfile
 build-%: Dockerfile.%
 	docker pull $(CONTAINER_$*)
 	docker build --no-cache -t unit:$(VERSION)-$* -f Dockerfile.$* .
+	touch $@
 
 library:
 	@echo "# this file is generated via https://github.com/nginx/unit/blob/$(shell git describe --always --abbrev=0 HEAD)/pkg/docker/Makefile"
@@ -178,5 +179,6 @@ all: $(addprefix Dockerfile., $(MODVERSIONS))
 
 clean:
 	rm -f Dockerfile.*
+	rm -f build-*
 
 .PHONY: default build dockerfiles clean library

--- a/pkg/docker/Makefile
+++ b/pkg/docker/Makefile
@@ -83,7 +83,7 @@ RUN_wasm ?=       /bin/true
 
 define MODULE_PREBUILD_wasm
 apt-get install --no-install-recommends --no-install-suggests -y libclang-dev \\\n \
-\ \ \ \&\& export RUST_VERSION=1.79.0 \\\n \
+\ \ \ \&\& export RUST_VERSION=1.80.1 \\\n \
 \ \ \ \&\& export RUSTUP_HOME=/usr/src/unit/rustup \\\n \
 \ \ \ \&\& export CARGO_HOME=/usr/src/unit/cargo \\\n    \
 \ \ \ \&\& export PATH=/usr/src/unit/cargo/bin:\$$PATH \\\n \

--- a/pkg/docker/Makefile
+++ b/pkg/docker/Makefile
@@ -19,7 +19,7 @@ INSTALL_minimal ?=	version
 RUN_minimal ?=		/bin/true
 MODULE_PREBUILD_minimal ?= /bin/true
 
-VERSIONS_go ?=		1.21 1.22
+VERSIONS_go ?=		1.22 1.23
 VARIANT_go ?=		$(VARIANT)
 $(foreach goversion, $(VERSIONS_go), $(eval CONTAINER_go$(goversion) = golang:$(goversion)-$(VARIANT_go)))
 CONFIGURE_go ?=		go --go-path=$$GOPATH


### PR DESCRIPTION
This patchset adds pre-release docker-related changes:

- Bumped Go versions
- Updated Rust version used in Dockerfiles
- Introduced "slim" Python images
- Make build-% targets create files to track if builds succeded or not