### PR TITLE
ci/unitctl: Update paths

### DIFF
--- a/.github/workflows/unitctl.yml
+++ b/.github/workflows/unitctl.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - tools/unitctl/**
+      - docs/unit-openapi.yaml
   push:
     branches:
       - master


### PR DESCRIPTION
unitctl makes use of 'docs/unit-openapi.yaml' so be sure to run these checks if that file changes.
