### PR TITLE
Added .gitignore for pkg/contrib/tarballs

### DIFF
--- a/pkg/contrib/tarballs/.gitignore
+++ b/pkg/contrib/tarballs/.gitignore
@@ -1,0 +1,2 @@
+*.tar.*
+*.githash


### PR DESCRIPTION
This directory is needed for contribs to function.