### PR TITLE
http: Fix router process crash whilst using proxy

### DIFF
--- a/src/nxt_h1proto.c
+++ b/src/nxt_h1proto.c
@@ -2869,6 +2869,11 @@ nxt_h1p_peer_body_process(nxt_task_t *task, nxt_http_peer_t *peer,
     } else if (h1p->remainder > 0) {
         length = nxt_buf_chain_length(out);
         h1p->remainder -= length;
+
+        if (h1p->remainder == 0) {
+            nxt_buf_chain_add(&out, nxt_http_buf_last(peer->request));
+            peer->closed = 1;
+        }
     }
 
     peer->body = out;

--- a/src/nxt_http_proxy.c
+++ b/src/nxt_http_proxy.c
@@ -381,9 +381,10 @@ nxt_http_proxy_error(nxt_task_t *task, void *obj, void *data)
     r = obj;
     peer = r->peer;
 
-    nxt_http_proto[peer->protocol].peer_close(task, peer);
-
-    nxt_mp_release(r->mem_pool);
+    if (!peer->closed) {
+        nxt_http_proto[peer->protocol].peer_close(task, peer);
+        nxt_mp_release(r->mem_pool);
+    }
 
     nxt_http_request_error(&r->task, r, peer->status);
 }


### PR DESCRIPTION
When the client closes the connection before the upstream, the proxy's error handler was calling cleanup operation like peer close and requestclose twice, this fix ensures the cleanup is performed only once, improving proxy stability.

Closes: https://github.com/nginx/unit/issues/828