### PR TITLE
ci: Fix wasmtime paths in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
       - 'go/**'
       - 'src/**'
       - 'test/**'
+      - 'pkg/contrib/**'
       - '.github/workflows/ci.yml'
   push:
     branches: master
@@ -17,6 +18,7 @@ on:
       - 'go/**'
       - 'src/**'
       - 'test/**'
+      - 'pkg/contrib/**'
       - '.github/workflows/ci.yml'
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,7 +303,7 @@ jobs:
 
       - name: Configure wasm
         run: |
-          ./configure wasm --include-path=pkg/contrib/wasmtime/crates/c-api/include --lib-path=pkg/contrib/wasmtime/target/release
+          ./configure wasm --include-path=pkg/contrib/wasmtime/artifacts/include --lib-path=pkg/contrib/wasmtime/artifacts/lib
         if: steps.metadata.outputs.module == 'wasm'
 
       - name: Make wasm


### PR DESCRIPTION
This comprises a couple of fixes to the CI.

1) Fix the wasmtime C API include/lib paths which recently changed with the update to wasmtime v24.

2) Run the CI when anything under src/contrib is changed (which _would_ have caught the above).