### PR TITLE
python: Don't decrement a reference to a borrowed object

### DIFF
--- a/src/python/nxt_python.c
+++ b/src/python/nxt_python.c
@@ -462,6 +462,7 @@ nxt_python_set_target(nxt_task_t *task, nxt_python_target_t *target,
                       "factory \"%s\" in module \"%s\" "
                       "can not be called to fetch callable",
                       callable, module_name);
+            Py_INCREF(obj);     /* borrowed reference */
             goto fail;
         }
 


### PR DESCRIPTION
On some Python 3.11 systems, 3.11.9 & 3.11.10, we were seeing a crash
    triggered by Py_Finalize() in nxt_python_atexit() when running one of
    our pytests, namely
    test/test_python_factory.py::test_python_factory_invalid_callable_value
    
      2024/09/12 15:07:29 [alert] 5452#5452 factory "wsgi_invalid_callable" in module "wsgi" can not be called to fetch callable
      Fatal Python error: none_dealloc: deallocating None: bug likely caused by a refcount error in a C extension
      Python runtime state: finalizing (tstate=0x00007f560b88a718)
    
      Current thread 0x00007f560bde7ad0 (most recent call first):
        <no Python frame>
      2024/09/12 15:07:29 [alert] 5451#5451 app process 5452 exited on signal 6 (core dumped)
    
This was due to

```c
obj = PyDict_GetItemString(PyModule_GetDict(module), callable);
```
  in nxt_python_set_target() which returns a *borrowed* reference, then
  due to the test meaning this is a `None` object we `goto fail` and call

```c
Py_DECREF(obj);
```    
  which then causes `Py_Finalize()` to blow up.
    
  The simple fix is to just increment its reference count before the `goto fail`.
    
  Note: This problem only showed up under (the various versions of Python
  we test on); 3.11.9 & 3.11.10. It doesn't show up under; 3.6, 3.7, 3.9,
  3.10, 3.12
