### PR TITLE
unitctl: rename app to apps

### DIFF
--- a/tools/unitctl/README.md
+++ b/tools/unitctl/README.md
@@ -63,6 +63,7 @@ Commands:
   execute    Sends raw JSON payload to Unit
   status     Get the current status of Unit
   listeners  List active listeners
+  apps       List all configured Unit applications
   help       Print this message or the help of the given subcommand(s)
 
 Options:
@@ -150,7 +151,7 @@ Unitctl can also request from the API that an application be restarted.
 
 Listing applications:
 ```
-$ unitctl app list
+$ unitctl apps list
 {
   "wasm": {
     "type": "wasm-wasi-component",
@@ -161,7 +162,7 @@ $ unitctl app list
 
 Restarting an application:
 ```
-$ unitctl app reload wasm
+$ unitctl apps reload wasm
 {
   "success": "Ok"
 }

--- a/tools/unitctl/unitctl/src/main.rs
+++ b/tools/unitctl/unitctl/src/main.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<(), UnitctlError> {
     match cli.command {
         Commands::Instances(args) => instances::cmd(args).await,
 
-        Commands::App(ref args) => applications::cmd(&cli, args).await,
+        Commands::Apps(ref args) => applications::cmd(&cli, args).await,
 
         Commands::Edit { output_format } => edit::cmd(&cli, output_format).await,
 

--- a/tools/unitctl/unitctl/src/unitctl.rs
+++ b/tools/unitctl/unitctl/src/unitctl.rs
@@ -17,6 +17,7 @@ pub(crate) struct UnitCtl {
         help = "Path (unix:/var/run/unit/control.sock), tcp address with port (127.0.0.1:80), or URL"
     )]
     pub(crate) control_socket_addresses: Option<Vec<ControlSocket>>,
+
     #[arg(
         required = false,
         default_missing_value = "1",
@@ -26,6 +27,7 @@ pub(crate) struct UnitCtl {
         help = "Number of seconds to wait for control socket to become available"
     )]
     pub(crate) wait_time_seconds: Option<u8>,
+
     #[arg(
         required = false,
         default_value = "3",
@@ -35,6 +37,7 @@ pub(crate) struct UnitCtl {
         help = "Number of times to try to access control socket when waiting"
     )]
     pub(crate) wait_max_tries: Option<u8>,
+
     #[command(subcommand)]
     pub(crate) command: Commands,
 }
@@ -43,6 +46,7 @@ pub(crate) struct UnitCtl {
 pub(crate) enum Commands {
     #[command(about = "List all running Unit processes")]
     Instances(InstanceArgs),
+
     #[command(about = "Open current Unit configuration in editor")]
     Edit {
         #[arg(
@@ -55,11 +59,13 @@ pub(crate) enum Commands {
         )]
         output_format: OutputFormat,
     },
+
     #[command(about = "Import configuration from a directory")]
     Import {
         #[arg(required = true, help = "Directory to import from")]
         directory: PathBuf,
     },
+
     #[command(about = "Sends raw JSON payload to Unit")]
     Execute {
         #[arg(
@@ -71,6 +77,7 @@ pub(crate) enum Commands {
             help = "Output format of the result"
         )]
         output_format: OutputFormat,
+
         #[arg(
             required = false,
             global = true,
@@ -79,17 +86,20 @@ pub(crate) enum Commands {
             help = "Input file (json, json5, cjson, hjson yaml, pem) to send to unit when applicable use - for stdin"
         )]
         input_file: Option<String>,
+
         #[arg(
-        help = "HTTP method to use (GET, POST, PUT, DELETE)",
-        required = true,
-        short = 'm',
-        long = "http-method",
-        value_parser = parse_http_method,
+            required = true,
+            short = 'm',
+            long = "http-method",
+            value_parser = parse_http_method,
+            help = "HTTP method to use (GET, POST, PUT, DELETE)",
         )]
         method: String,
+
         #[arg(required = true, short = 'p', long = "path")]
         path: String,
     },
+
     #[command(about = "Get the current status of Unit")]
     Status {
         #[arg(
@@ -102,6 +112,7 @@ pub(crate) enum Commands {
         )]
         output_format: OutputFormat,
     },
+
     #[command(about = "List active listeners")]
     Listeners {
         #[arg(
@@ -114,6 +125,7 @@ pub(crate) enum Commands {
         )]
         output_format: OutputFormat,
     },
+
     #[command(about = "List all configured Unit applications")]
     App(ApplicationArgs),
 

--- a/tools/unitctl/unitctl/src/unitctl.rs
+++ b/tools/unitctl/unitctl/src/unitctl.rs
@@ -127,7 +127,7 @@ pub(crate) enum Commands {
     },
 
     #[command(about = "List all configured Unit applications")]
-    App(ApplicationArgs),
+    Apps(ApplicationArgs),
 
     #[command(about = "Export the current configuration of UNIT")]
     Export {


### PR DESCRIPTION
This PR achieves three separate things:
* cleans up some grouping of args with its commands to separate it from the next commands
* renamed the app to apps. Clap picks up the name of the enum as the subcommand name absent a command argument. I chose to rename the enum rather than add an option
* adds the apps line to the readme

It does not fix the whole of the readme, that's a separate issue and PR.

Closes #1423