### PR TITLE
tools/unitctl: change reload to restart

### DIFF
--- a/tools/unitctl/README.md
+++ b/tools/unitctl/README.md
@@ -163,7 +163,7 @@ $ unitctl apps list
 
 Restarting an application:
 ```
-$ unitctl apps reload wasm
+$ unitctl apps restart wasm
 {
   "success": "Ok"
 }

--- a/tools/unitctl/unitctl/src/cmd/applications.rs
+++ b/tools/unitctl/unitctl/src/cmd/applications.rs
@@ -12,7 +12,7 @@ pub(crate) async fn cmd(cli: &UnitCtl, args: &ApplicationArgs) -> Result<(), Uni
 
     for client in clients {
         let _ = match &args.command {
-            ApplicationCommands::Reload { ref name } => client
+            ApplicationCommands::Restart { ref name } => client
                 .restart_application(name)
                 .await
                 .map_err(|e| UnitctlError::UnitClientError { source: *e })

--- a/tools/unitctl/unitctl/src/unitctl.rs
+++ b/tools/unitctl/unitctl/src/unitctl.rs
@@ -194,8 +194,8 @@ pub struct ApplicationArgs {
 #[derive(Debug, Subcommand)]
 #[command(args_conflicts_with_subcommands = true)]
 pub enum ApplicationCommands {
-    #[command(about = "reload a running application")]
-    Reload {
+    #[command(about = "restart a running application")]
+    Restart {
         #[arg(required = true, help = "name of application")]
         name: String,
     },


### PR DESCRIPTION
This renames the 'app reload' subcommand to 'app restart'

Fixes #1426
