### PR TITLE
Fix an unused variable issue in nxt_term_parse() as found by clang-analyzer and coverity

### DIFF
--- a/src/nxt_time_parse.c
+++ b/src/nxt_time_parse.c
@@ -317,7 +317,6 @@ nxt_term_parse(const u_char *p, size_t len, nxt_bool_t seconds)
     enum {
         st_first_digit = 0,
         st_digit,
-        st_letter,
         st_space,
     } state;
 
@@ -354,22 +353,17 @@ nxt_term_parse(const u_char *p, size_t len, nxt_bool_t seconds)
             state = st_first_digit;
         }
 
-        if (state != st_letter) {
+        /* Values below '0' become >= 208. */
+        c = ch - '0';
 
-            /* Values below '0' become >= 208. */
-            c = ch - '0';
+        if (c <= 9) {
+            val = val * 10 + c;
+            state = st_digit;
+            continue;
+        }
 
-            if (c <= 9) {
-                val = val * 10 + c;
-                state = st_digit;
-                continue;
-            }
-
-            if (state == st_first_digit) {
-                return -1;
-            }
-
-            state = st_letter;
+        if (state == st_first_digit) {
+            return -1;
         }
 
         switch (ch) {

--- a/src/test/nxt_term_parse_test.c
+++ b/src/test/nxt_term_parse_test.c
@@ -23,6 +23,7 @@ static const nxt_term_parse_test_t  terms[] = {
     { nxt_string("1w  d"),                 0,  -1 },
     { nxt_string("w"),                     0,  -1 },
     { nxt_string("1d 1w"),                 0,  -1 },
+    { nxt_string("1 "),                    1,   1 },
     { nxt_string("25d"),                   0,  -2 },
     { nxt_string("300"),                   1,  300 },
     { nxt_string("300"),                   0,  300000 },


### PR DESCRIPTION
```
The following changes since commit ba234b4db2d137b7dcf63188cc19e0493ebbc01a:

  Version bump (2024-09-17 22:42:09 +0100)

are available in the Git repository at:

  git@github.com:ac000/unit.git ca-fix

for you to fetch changes up to bba84a73a259b7cb93e3c0a52a0aa7253e53042c:

  src/test: Add an extra test case to nxt_term_parse_test.c (2024-09-24 14:55:04 +0100)

----------------------------------------------------------------

The first patch fixes a clang-analyzer and coverity issue where we assign
a value and then assign again without using it inbetween.

The second patch adds a test case for strings with trailing whitespace.

----------------------------------------------------------------
Andrew Clayton (2):
      Resolve unused assignment in nxt_term_parse()
      src/test: Add an extra test case to nxt_term_parse_test.c

 src/nxt_time_parse.c           | 24 +++++++++---------------
 src/test/nxt_term_parse_test.c |  1 +
 2 files changed, 10 insertions(+), 15 deletions(-)
