### PR TITLE
perl: Remove unused module constructor

### DIFF
--- a/src/perl/nxt_perl_psgi.c
+++ b/src/perl/nxt_perl_psgi.c
@@ -409,9 +409,6 @@ nxt_perl_psgi_module_create(const char *script)
 
     static const nxt_str_t  prefix = nxt_string(
         "package NGINX::Unit::Sandbox;"
-        "sub new {"
-        "   return bless {}, $_[0];"
-        "}"
         "{my $app = do \""
     );
 


### PR DESCRIPTION
In the perl language module we create a new perl *module* on the fly comprised of some preamble, the specified perl script and some post-amble.

In the preamble we create a constructor called new(), however this can clash with other constructors also called new.

While this can be worked around by instead of doing

  ... new CLASS

rather do

  ... CLASS->new()

While this constructor was added in commit 3b2c1d0e ("Perl: added implementation delayed response and streaming body."), I don't see that we actually use it anywhere (nor is it seemingly something we document) and if we simply remove it then things still seem to work, including the Perl pytests

  ...
  test/test_perl_application.py::test_perl_streaming_body_multiple_responses[5.38.2] PASSED
  ...
  test/test_perl_application.py::test_perl_delayed_response[5.38.2] PASSED
  test/test_perl_application.py::test_perl_streaming_body[5.38.2] PASSED
  ...
