### PR TITLE
ci: Various fixes for update to Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,12 +101,18 @@ jobs:
       # https://github.com/actions/runner-images/issues/2821
       - name: Kill mono process
         run: |
-          sudo systemctl stop mono-xsp4.service
-          sudo systemctl mask mono-xsp4.service
-          sudo systemctl status mono-xsp4.service || true
-          PID=$(sudo lsof -t -i :8084)
-          echo "Killing PID $PID"
-          sudo kill -9 $PID
+          set +e
+          sudo systemctl status mono-xsp4.service
+          if [ $? -ne 0 ]; then
+            true
+          else
+            sudo systemctl stop mono-xsp4.service
+            sudo systemctl mask mono-xsp4.service
+            sudo systemctl status mono-xsp4.service
+            PID=$(sudo lsof -t -i :8084)
+            echo "Killing PID $PID"
+            sudo kill -9 $PID
+          fi
 
       ##
       ## njs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,18 +360,15 @@ jobs:
 
       - name: Install pytest
         run: |
-          if [ "${{ matrix.build }}" == "wasm-wasi-component" ]; then
-            pip install pytest
-          else
-            sudo -H pip install pytest
-          fi
+          sudo apt install -y python3-pytest
+
         if: steps.metadata.outputs.module != 'wasm'
 
       - name: Run ${{ steps.metadata.outputs.module }} tests
         run: |
           if [ "${{ matrix.build }}" == "wasm-wasi-component" ]; then
-            pytest --print-log ${{ steps.metadata.outputs.testpath }}
+            pytest-3 --print-log ${{ steps.metadata.outputs.testpath }}
           else
-            sudo -E pytest --print-log ${{ steps.metadata.outputs.testpath }}
+            sudo -E pytest-3 --print-log ${{ steps.metadata.outputs.testpath }}
           fi
         if: steps.metadata.outputs.module != 'wasm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,6 @@ jobs:
             os: ubuntu-latest
           - build: perl
             os: ubuntu-latest
-          - build: php-8.1
-            os: ubuntu-latest
           - build: php-8.2
             os: ubuntu-latest
           - build: php-8.3


### PR DESCRIPTION
This pull-request compreises three patches fixing various issues with the CI due to the runners moving to Ubuntu 24.04 (though they seem to have sinnce reverted back, but we may as well keep these fixes...)

The first patch fixes the disabling of the mono service which may or may not be installed.

The second patch fixes the installation of pytest by installing it via the apt(8) package manager.

The third drops PHP 8.1 from our tests. See the commit message for the gory details.