### PR TITLE
http: JSON format access logging support

### DIFF
--- a/src/nxt_router.h
+++ b/src/nxt_router.h
@@ -16,12 +16,13 @@ typedef struct nxt_http_request_s  nxt_http_request_t;
 #include <nxt_application.h>
 
 
-typedef struct nxt_http_action_s        nxt_http_action_t;
-typedef struct nxt_http_routes_s        nxt_http_routes_t;
-typedef struct nxt_http_forward_s       nxt_http_forward_t;
-typedef struct nxt_upstream_s           nxt_upstream_t;
-typedef struct nxt_upstreams_s          nxt_upstreams_t;
-typedef struct nxt_router_access_log_s  nxt_router_access_log_t;
+typedef struct nxt_http_action_s               nxt_http_action_t;
+typedef struct nxt_http_routes_s               nxt_http_routes_t;
+typedef struct nxt_http_forward_s              nxt_http_forward_t;
+typedef struct nxt_upstream_s                  nxt_upstream_t;
+typedef struct nxt_upstreams_s                 nxt_upstreams_t;
+typedef struct nxt_router_access_log_s         nxt_router_access_log_t;
+typedef struct nxt_router_access_log_format_s  nxt_router_access_log_format_t;
 
 
 #define NXT_HTTP_ACTION_ERROR  ((nxt_http_action_t *) -1)
@@ -39,22 +40,22 @@ typedef struct {
 
 
 typedef struct {
-    uint32_t                 count;
-    uint32_t                 threads;
+    uint32_t                        count;
+    uint32_t                        threads;
 
-    nxt_mp_t                 *mem_pool;
-    nxt_tstr_state_t         *tstr_state;
+    nxt_mp_t                        *mem_pool;
+    nxt_tstr_state_t                *tstr_state;
 
-    nxt_router_t             *router;
-    nxt_http_routes_t        *routes;
-    nxt_upstreams_t          *upstreams;
+    nxt_router_t                    *router;
+    nxt_http_routes_t               *routes;
+    nxt_upstreams_t                 *upstreams;
 
-    nxt_lvlhsh_t             mtypes_hash;
-    nxt_lvlhsh_t             apps_hash;
+    nxt_lvlhsh_t                    mtypes_hash;
+    nxt_lvlhsh_t                    apps_hash;
 
-    nxt_router_access_log_t  *access_log;
-    nxt_tstr_t               *log_format;
-    nxt_tstr_cond_t          log_cond;
+    nxt_tstr_cond_t                 log_cond;
+    nxt_router_access_log_t         *access_log;
+    nxt_router_access_log_format_t  *log_format;
 } nxt_router_conf_t;
 
 
@@ -235,7 +236,7 @@ typedef struct {
 struct nxt_router_access_log_s {
     void                   (*handler)(nxt_task_t *task, nxt_http_request_t *r,
                                       nxt_router_access_log_t *access_log,
-                                      nxt_tstr_t *format);
+                                      nxt_router_access_log_format_t *format);
     nxt_fd_t               fd;
     nxt_str_t              path;
     uint32_t               count;

--- a/src/nxt_router_access_log.c
+++ b/src/nxt_router_access_log.c
@@ -11,20 +11,28 @@
 
 
 typedef struct {
-    nxt_str_t                 path;
-    nxt_conf_value_t          *format;
-    nxt_conf_value_t          *expr;
+    nxt_str_t                       path;
+    nxt_conf_value_t                *format;
+    nxt_conf_value_t                *expr;
 } nxt_router_access_log_conf_t;
 
 
 typedef struct {
-    nxt_str_t                 text;
-    nxt_router_access_log_t   *access_log;
+    nxt_str_t                       text;
+    nxt_router_access_log_t         *access_log;
 } nxt_router_access_log_ctx_t;
 
 
+typedef struct {
+    nxt_str_t                       name;
+    nxt_tstr_t                      *tstr;
+} nxt_router_access_log_member_t;
+
+
 struct nxt_router_access_log_format_s {
-    nxt_tstr_t                *tstr;
+    nxt_tstr_t                      *tstr;
+    nxt_uint_t                      nmembers;
+    nxt_router_access_log_member_t  *member;
 };
 
 
@@ -32,6 +40,11 @@ static nxt_router_access_log_format_t *nxt_router_access_log_format_create(
     nxt_task_t *task, nxt_router_conf_t *rtcf, nxt_conf_value_t *value);
 static void nxt_router_access_log_writer(nxt_task_t *task,
     nxt_http_request_t *r, nxt_router_access_log_t *access_log,
+    nxt_router_access_log_format_t *format);
+static nxt_int_t nxt_router_access_log_text(nxt_task_t *task,
+    nxt_http_request_t *r, nxt_router_access_log_ctx_t *ctx, nxt_tstr_t *tstr);
+static nxt_int_t nxt_router_access_log_json(nxt_task_t *task,
+    nxt_http_request_t *r, nxt_router_access_log_ctx_t *ctx,
     nxt_router_access_log_format_t *format);
 static void nxt_router_access_log_write(nxt_task_t *task, nxt_http_request_t *r,
     nxt_router_access_log_ctx_t *ctx);
@@ -145,7 +158,12 @@ static nxt_router_access_log_format_t *
 nxt_router_access_log_format_create(nxt_task_t *task, nxt_router_conf_t *rtcf,
     nxt_conf_value_t *value)
 {
-    nxt_str_t                       str;
+    size_t                          size;
+    uint32_t                        i, n, next;
+    nxt_str_t                       name, str, *dst;
+    nxt_bool_t                      has_js;
+    nxt_conf_value_t                *cv;
+    nxt_router_access_log_member_t  *member;
     nxt_router_access_log_format_t  *format;
 
     static const nxt_str_t  default_format = nxt_string("$remote_addr - - "
@@ -159,7 +177,74 @@ nxt_router_access_log_format_create(nxt_task_t *task, nxt_router_conf_t *rtcf,
     }
 
     if (value != NULL) {
-        nxt_conf_get_string(value, &str);
+
+        if (nxt_conf_type(value) == NXT_CONF_OBJECT) {
+            next = 0;
+            has_js = 0;
+
+            n = nxt_conf_object_members_count(value);
+
+            for ( ;; ) {
+                cv = nxt_conf_next_object_member(value, &name, &next);
+                if (cv == NULL) {
+                    break;
+                }
+
+                nxt_conf_get_string(cv, &str);
+
+                if (nxt_tstr_is_js(&str)) {
+                    has_js = 1;
+                }
+            }
+
+            if (has_js) {
+                member = nxt_mp_alloc(rtcf->mem_pool,
+                                    n * sizeof(nxt_router_access_log_member_t));
+                if (nxt_slow_path(member == NULL)) {
+                    return NULL;
+                }
+
+                next = 0;
+
+                for (i = 0; i < n; i++) {
+                    cv = nxt_conf_next_object_member(value, &name, &next);
+                    if (cv == NULL) {
+                        break;
+                    }
+
+                    dst = nxt_str_dup(rtcf->mem_pool, &member[i].name, &name);
+                    if (nxt_slow_path(dst == NULL)) {
+                        return NULL;
+                    }
+
+                    nxt_conf_get_string(cv, &str);
+
+                    member[i].tstr = nxt_tstr_compile(rtcf->tstr_state, &str,
+                                                      NXT_TSTR_LOGGING);
+                    if (nxt_slow_path(member[i].tstr == NULL)) {
+                        return NULL;
+                    }
+                }
+
+                format->nmembers = n;
+                format->member = member;
+
+                return format;
+            }
+
+            size = nxt_conf_json_length(value, NULL);
+
+            str.start = nxt_mp_nget(rtcf->mem_pool, size);
+            if (nxt_slow_path(str.start == NULL)) {
+                return NULL;
+            }
+
+            str.length = nxt_conf_json_print(str.start, value, NULL)
+                         - str.start;
+
+        } else {
+            nxt_conf_get_string(value, &str);
+        }
 
     } else {
         str = default_format;
@@ -180,7 +265,6 @@ nxt_router_access_log_writer(nxt_task_t *task, nxt_http_request_t *r,
     nxt_router_access_log_t *access_log, nxt_router_access_log_format_t *format)
 {
     nxt_int_t                    ret;
-    nxt_router_conf_t            *rtcf;
     nxt_router_access_log_ctx_t  *ctx;
 
     ctx = nxt_mp_get(r->mem_pool, sizeof(nxt_router_access_log_ctx_t));
@@ -190,8 +274,28 @@ nxt_router_access_log_writer(nxt_task_t *task, nxt_http_request_t *r,
 
     ctx->access_log = access_log;
 
-    if (nxt_tstr_is_const(format->tstr)) {
-        nxt_tstr_str(format->tstr, &ctx->text);
+    if (format->tstr != NULL) {
+        ret = nxt_router_access_log_text(task, r, ctx, format->tstr);
+
+    } else {
+        ret = nxt_router_access_log_json(task, r, ctx, format);
+    }
+
+    if (ret == NXT_OK) {
+        nxt_router_access_log_write(task, r, ctx);
+    }
+}
+
+
+static nxt_int_t
+nxt_router_access_log_text(nxt_task_t *task, nxt_http_request_t *r,
+    nxt_router_access_log_ctx_t *ctx, nxt_tstr_t *tstr)
+{
+    nxt_int_t          ret;
+    nxt_router_conf_t  *rtcf;
+
+    if (nxt_tstr_is_const(tstr)) {
+        nxt_tstr_str(tstr, &ctx->text);
 
     } else {
         rtcf = r->conf->socket_conf->router_conf;
@@ -199,16 +303,76 @@ nxt_router_access_log_writer(nxt_task_t *task, nxt_http_request_t *r,
         ret = nxt_tstr_query_init(&r->tstr_query, rtcf->tstr_state,
                                   &r->tstr_cache, r, r->mem_pool);
         if (nxt_slow_path(ret != NXT_OK)) {
-            return;
+            return NXT_ERROR;
         }
 
-        ret = nxt_tstr_query(task, r->tstr_query, format->tstr, &ctx->text);
+        ret = nxt_tstr_query(task, r->tstr_query, tstr, &ctx->text);
         if (nxt_slow_path(ret != NXT_OK)) {
-            return;
+            return NXT_ERROR;
         }
     }
 
-    nxt_router_access_log_write(task, r, ctx);
+    return NXT_OK;
+}
+
+
+static nxt_int_t
+nxt_router_access_log_json(nxt_task_t *task, nxt_http_request_t *r,
+    nxt_router_access_log_ctx_t *ctx, nxt_router_access_log_format_t *format)
+{
+    u_char                          *p;
+    size_t                          size;
+    nxt_int_t                       ret;
+    nxt_str_t                       str;
+    nxt_uint_t                      i;
+    nxt_conf_value_t                *value;
+    nxt_router_conf_t               *rtcf;
+    nxt_router_access_log_member_t  *member;
+
+    rtcf = r->conf->socket_conf->router_conf;
+
+    value = nxt_conf_create_object(r->mem_pool, format->nmembers);
+    if (nxt_slow_path(value == NULL)) {
+        return NXT_ERROR;
+    }
+
+    for (i = 0; i < format->nmembers; i++) {
+        member = &format->member[i];
+
+        if (nxt_tstr_is_const(member->tstr)) {
+            nxt_tstr_str(member->tstr, &str);
+
+        } else {
+            ret = nxt_tstr_query_init(&r->tstr_query, rtcf->tstr_state,
+                                      &r->tstr_cache, r, r->mem_pool);
+            if (nxt_slow_path(ret != NXT_OK)) {
+                return NXT_ERROR;
+            }
+
+            ret = nxt_tstr_query(task, r->tstr_query, member->tstr, &str);
+            if (nxt_slow_path(ret != NXT_OK)) {
+                return NXT_ERROR;
+            }
+        }
+
+        nxt_conf_set_member_string(value, &member->name, &str, i);
+    }
+
+    size = nxt_conf_json_length(value, NULL) + 1;
+
+    p = nxt_mp_nget(r->mem_pool, size);
+    if (nxt_slow_path(p == NULL)) {
+        return NXT_ERROR;
+    }
+
+    ctx->text.start = p;
+
+    p = nxt_conf_json_print(p, value, NULL);
+    *p++ = '\n';
+
+    ctx->text.length = p - ctx->text.start;
+
+    return NXT_OK;
 }
 
 

--- a/src/nxt_tstr.c
+++ b/src/nxt_tstr.c
@@ -41,10 +41,6 @@ struct nxt_tstr_query_s {
 };
 
 
-#define nxt_tstr_is_js(str)                                         \
-    nxt_strchr_start(str, '`')
-
-
 nxt_tstr_state_t *
 nxt_tstr_state_new(nxt_mp_t *mp, nxt_bool_t test)
 {

--- a/src/nxt_tstr.h
+++ b/src/nxt_tstr.h
@@ -64,6 +64,10 @@ nxt_int_t nxt_tstr_query(nxt_task_t *task, nxt_tstr_query_t *query,
 void nxt_tstr_query_release(nxt_tstr_query_t *query);
 
 
+#define nxt_tstr_is_js(str)                                         \
+    nxt_strchr_start(str, '`')
+
+
 nxt_inline nxt_bool_t
 nxt_is_tstr(nxt_str_t *str)
 {

--- a/test/test_access_log.py
+++ b/test/test_access_log.py
@@ -298,6 +298,12 @@ def test_access_log_format(wait_for_record):
     check_format(log_format, log_format)
     check_format('$uri $status $uri $status', '/ 200 / 200')
 
+    log_format = {
+        'status': '$status',
+        'uri': '$uri'
+    }
+    check_format(log_format, '{"status":"200","uri":"/"}')
+
 
 def test_access_log_variables(wait_for_record):
     load('mirror')
@@ -366,6 +372,24 @@ def test_access_log_if_njs(require, search_in_file, wait_for_record):
 
     assert wait_for_record(r'^/foo_1$', 'access.log') is not None
     assert search_in_file(r'^/foo_2$', 'access.log') is None
+
+
+def test_access_log_format_njs(require, search_in_file, wait_for_record):
+    require({'modules': {'njs': 'any'}})
+
+    load('empty')
+
+    def check_format(log_format, expect, url='/'):
+        set_format(log_format)
+
+        assert client.get(url=url)['status'] == 200
+        assert wait_for_record(expect, 'access.log') is not None, 'found'
+
+    log_format = {
+        'status': '$status',
+        'uri': '`${vars.uri}`'
+    }
+    check_format(log_format, '{"status":"200","uri":"/"}')
 
 
 def test_access_log_incorrect(temp_dir, skip_alert):


### PR DESCRIPTION
Allow format to be an object to generate JSON logs. The object keys
become JSON field names, and values support string, variable, and JS.

Note that when there is no JS in the format values, the object will
be pre-serialized to a JSON template string at configuration phase
for better performance.

Example config:
```
  {
    "access_log": {
      "path": "/tmp/access.log",
      "format": {
        "remote_addr": "$remote_addr",
        "time_local": "$time_local",
        "request_line": "$request_line",
        "status": "$status",
        "body_bytes_sent": "$body_bytes_sent",
        "header_referer": "$header_referer",
        "header_user_agent": "$header_user_agent"
      }
    }
  }
```