### PR TITLE
auto: Remove unused pthread spinlock checks

### DIFF
--- a/auto/threads
+++ b/auto/threads
@@ -73,56 +73,6 @@ if [ $nxt_found = no ]; then
 fi
 
 
-# FreeBSD, Solaris, AIX.
-
-nxt_feature="pthread spinlock"
-nxt_feature_name=NXT_HAVE_PTHREAD_SPINLOCK
-nxt_feature_run=yes
-nxt_feature_incs=
-nxt_feature_libs=$NXT_PTHREAD
-nxt_feature_test="#include <pthread.h>
-
-              int main(void) {
-                  pthread_spinlock_t  lock;
-
-                  if (pthread_spin_init(&lock, PTHREAD_PROCESS_PRIVATE) != 0)
-                      return 1;
-                  if (pthread_spin_lock(&lock) != 0)
-                      return 1;
-                  if (pthread_spin_unlock(&lock) != 0)
-                      return 1;
-                  if (pthread_spin_destroy(&lock) != 0)
-                      return 1;
-                  return 0;
-              }"
-. auto/feature
-
-
-if [ $nxt_found = yes ]; then
-
-    # Linux glibc uses 0 as pthread_spinlock_t initial value on the most
-    # platforms.  However, on i386 and x86_64 the initial value is 1.
-
-    nxt_feature="pthread spinlock zero initial value"
-    nxt_feature_name=NXT_HAVE_PTHREAD_SPINLOCK_ZERO
-    nxt_feature_run=yes
-    nxt_feature_incs=
-    nxt_feature_libs=$NXT_PTHREAD
-    nxt_feature_test="#include <pthread.h>
-
-                      pthread_spinlock_t  lock = 0;
-
-                      int main(void) {
-                          if (pthread_spin_trylock(&lock) != 0)
-                              return 1;
-                          if (pthread_spin_unlock(&lock) != 0)
-                              return 1;
-                          return 0;
-                      }"
-    . auto/feature
-fi
-
-
 nxt_feature="sem_timedwait()"
 nxt_feature_name=NXT_HAVE_SEM_TIMEDWAIT
 nxt_feature_run=yes


### PR DESCRIPTION
```
    When configuring under Linux we always got the following
    
      checking for pthread spinlock zero initial value ... found but is not working
    
    Having *actually* taken a look at this, this check seems somewhat bogus,
    the first thing it does is
    
      pthread_spinlock_t  lock = 0;
    
    which you shouldn't do anyway, you should use pthread_spin_init(3) to
    initialise the pthread_spinlock_t variable.
    
    But in any case, this thing, NXT_HAVE_PTHREAD_SPINLOCK_ZERO, isn't even
    checked for in the code.
    
    Neither is NXT_HAVE_PTHREAD_SPINLOCK, we don't use the pthread_spin_*
    API, but rather roll our own spinlock implementation.
    
    So let's just remove these checks, at the very least it'll speed
    ./configure up!
```