### PR TITLE
Decast nxt_cpymem()

### DIFF
--- a/src/nxt_string.h
+++ b/src/nxt_string.h
@@ -58,7 +58,7 @@ NXT_EXPORT void nxt_memcpy_upcase(u_char *dst, const u_char *src,
 nxt_inline void *
 nxt_cpymem(void *dst, const void *src, size_t length)
 {
-    return ((u_char *) memcpy(dst, src, length)) + length;
+    return memcpy(dst, src, length) + length;
 }
 
 


### PR DESCRIPTION
```
    Decast nxt_cpymem()
    
    nxt_cpymem() is basically mempcpy(3)
    
    Like mempcpy() nxt_cpymem() returns a void *.
    
    nxt_cpymem() is implemented as a wrapper around memcpy(3), however
    before returning the new pointer value we cast the return of memcpy(3)
    to a u_char *, then add the length parameter to it.
    
    I guess this was done to support compilers that do not support
    arithmetic on void pointers as the C standard forbids it.
    
    However since we removed support for compilers other than GCC and Clang
    (ending in commit 9cd11133 ("Remove support for Sun's Sun Studio/SunPro
    C compiler")) this is no longer an issue as both GCC and Clang support
    arithmetic on void pointers (without the -pedantic option).
    
    While removing the unnecessary casting in this case doesn't necessarily
    improve type-safety (as we're dealing with void *'s in and out), it does
    just make the code that little more readable.
    
    Oh and for interest we have actually already been relying on this
    extension
    
      src/nxt_array.c:143:40: warning: arithmetic on a pointer to void is a GNU extension [-Wgnu-pointer-arith]
        143 |             nxt_memcpy(data, src->elts + (i * size), size);
            |                              ~~~~~~~~~ ^
      src/nxt_string.h:45:24: note: expanded from macro 'nxt_memcpy'
         45 |     (void) memcpy(dst, src, length)
            |                        ^~~
    
    which was introduced in e2b53e16 ("Added "rootfs" feature.") back in
    2020.
    
    Link: <https://gcc.gnu.org/onlinedocs/gcc/Pointer-Arith.html>
    Link: <https://clang.llvm.org/docs/LanguageExtensions.html#introduction>
    Signed-off-by: Andrew Clayton <a.clayton@nginx.com>
```