### PR TITLE
otel: Disable static_mut_refs warning for nxt_otel_rs_span_tx()

### DIFF
--- a/src/otel/src/lib.rs
+++ b/src/otel/src/lib.rs
@@ -36,6 +36,7 @@ pub type nxt_uint_t = usize;
 
 // Stored sender channel to send spans or a shutdown message to within the
 // Tokio runtime.
+#[allow(static_mut_refs)]
 unsafe fn nxt_otel_rs_span_tx(destruct: bool) -> *const OnceLock<Sender<SpanMessage>> {
     static mut SPAN_TX: OnceLock<Sender<SpanMessage>> = OnceLock::new();
     if destruct {


### PR DESCRIPTION

    otel: Disable static_mut_refs warning for nxt_otel_rs_span_tx()
    
    When compiling OTEL support with rustc 1.83.0 we started getting the
    following warning
    
         Compiling otel v0.1.0 (/home/andrew/src/unit/src/otel)
      warning: creating a mutable reference to mutable static is discouraged
        --> src/lib.rs:42:9
         |
      42 |         SPAN_TX.take();
         |         ^^^^^^^^^^^^^^ mutable reference to mutable static
         |
         = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
         = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
         = note: `#[warn(static_mut_refs)]` on by default
    
      warning: `otel` (lib) generated 1 warning
          Finished `release` profile [optimized] target(s) in 1m 07s
    
    However it *seems* our usage is OK, so we can disable this warning
    (which it seems will soon turn into a hard error), fortunately we only
    need to disable it for the nxt_otel_rs_span_tx() function.
    
    Signed-off-by: Andrew Clayton <a.clayton@nginx.com>
