### PR TITLE
auto/otel: Remove pkg-config check

### DIFF
--- a/auto/otel
+++ b/auto/otel
@@ -41,9 +41,7 @@ if [ $NXT_OTEL = YES ]; then
     fi
 
     NXT_OTEL_LIBS="-lssl -lcrypto"
-    if [ $(which pkg-config) ]; then
-        NXT_OTEL_LIBS="$(pkg-config openssl --cflags --libs)"
-    fi
+
     cat << END >> $NXT_AUTO_CONFIG_H
 
 #ifndef NXT_HAVE_OTEL


### PR DESCRIPTION
```
    auto/otel: Remove pkg-config check

    @thresheek reported an issue trying to configure OTEL support on Amazon
    Linux 2
    
      checking for OTEL requirements:
        - checking for rust compiler ... found
        - checking for cargo ... found
        - checking for OpenSSL library ... found
      Package openssl was not found in the pkg-config search path.
      Perhaps you should add the directory containing `openssl.pc'
      to the PKG_CONFIG_PATH environment variable
      No package 'openssl' found
    
    We successfully built the test program with '-lssl -lcrypto', but then
    tried to use 'pkg-config openssl --cflags --libs' to override
    NXT_OTEL_LIBS.
    
    On Amazon Linux2 there is no openssl.pc, they have a openssl11.pc.
    
    Let's just remove the pkg-config check, if we get here, we have
    successfully built with '-lssl -lcrypto', so just go with that (it also
    matches what we do in auto/ssltls).
    
    Closes: https://github.com/nginx/unit/issues/1510
    Signed-off-by: Andrew Clayton <a.clayton@nginx.com>
```