### PR TITLE
auto/otel: Fix breakage on non-Linux platforms

### DIFF
--- a/auto/otel
+++ b/auto/otel
@@ -22,6 +22,7 @@ if [ $NXT_OTEL = YES ]; then
     $echo -n "  - "
 
     nxt_feature="OpenSSL library"
+    nxt_feature_name=NXT_HAVE_OTEL
     nxt_feature_run=yes
     nxt_feature_incs=
     nxt_feature_libs="-lssl -lcrypto"
@@ -42,11 +43,4 @@ if [ $NXT_OTEL = YES ]; then
 
     NXT_OTEL_LIBS="-lssl -lcrypto"
 
-    cat << END >> $NXT_AUTO_CONFIG_H
-
-#ifndef NXT_HAVE_OTEL
-#define NXT_HAVE_OTEL 1
-#endif
-
-END
 fi


### PR DESCRIPTION
    auto/otel: Fix breakage on non-Linux platforms
    
    When building with --otel on macOS for example I was seeing compile
    failures with the cpu_set_t stuff which should only be used under Linux.
    
    It turned out that despite
    
      checking for Linux sched_getaffinity() ... not found
    
    we were getting
    
      #ifndef NXT_HAVE_LINUX_SCHED_GETAFFINITY
      #define NXT_HAVE_LINUX_SCHED_GETAFFINITY  1
      #endif
    
    in build/include/nxt_auto_config.h
    
    It seems this was due to the
    
        . auto/feature
    
    in auto/otel, this check happens right after the above. Without having
    
        nxt_feature_name=NXT_HAVE_OTEL
    
    set.
    
    Instead we were adding the define for that manually.
    
    Doing auto/feature without having a nxt_feature_name must have used the
    last set one and enabled it.
    
    Set nxt_feature_name and remove the manual editing of nxt_auto_config.h
    
    Signed-off-by: Andrew Clayton <a.clayton@nginx.com>