### PR TITLE
add libotel for tests

### DIFF
--- a/auto/make
+++ b/auto/make
@@ -269,7 +269,7 @@ $NXT_BUILD_DIR/tests: \$(NXT_TEST_OBJS) \\
 	\$(v)\$(NXT_EXEC_LINK) -o $NXT_BUILD_DIR/tests \\
 		\$(CFLAGS) \$(NXT_TEST_OBJS) \\
 		$NXT_BUILD_DIR/lib/$NXT_LIB_STATIC \\
-		$NXT_LD_OPT $NXT_LIBM $NXT_LIBS $NXT_LIB_AUX_LIBS
+		$NXT_LD_OPT $NXT_LIBM $NXT_LIBS $NXT_LIB_AUX_LIBS \$(NXT_OTEL_LIB_LOC)
 
 $NXT_BUILD_DIR/utf8_file_name_test: $NXT_LIB_UTF8_FILE_NAME_TEST_SRCS \\
 			$NXT_BUILD_DIR/lib/$NXT_LIB_STATIC
@@ -278,7 +278,7 @@ $NXT_BUILD_DIR/utf8_file_name_test: $NXT_LIB_UTF8_FILE_NAME_TEST_SRCS \\
 		-o $NXT_BUILD_DIR/utf8_file_name_test \\
 		$NXT_LIB_UTF8_FILE_NAME_TEST_SRCS \\
 		$NXT_BUILD_DIR/lib/$NXT_LIB_STATIC \\
-		$NXT_LD_OPT $NXT_LIBM $NXT_LIBS $NXT_LIB_AUX_LIBS
+		$NXT_LD_OPT $NXT_LIBM $NXT_LIBS $NXT_LIB_AUX_LIBS \$(NXT_OTEL_LIB_LOC)
 
 $NXT_BUILD_DIR/ncq_test: $NXT_BUILD_DIR/src/test/nxt_ncq_test.o \\
 			$NXT_BUILD_DIR/lib/$NXT_LIB_STATIC
@@ -286,7 +286,7 @@ $NXT_BUILD_DIR/ncq_test: $NXT_BUILD_DIR/src/test/nxt_ncq_test.o \\
 	\$(v)\$(NXT_EXEC_LINK) -o $NXT_BUILD_DIR/ncq_test \\
 		\$(CFLAGS) $NXT_BUILD_DIR/src/test/nxt_ncq_test.o \\
 		$NXT_BUILD_DIR/lib/$NXT_LIB_STATIC \\
-		$NXT_LD_OPT $NXT_LIBM $NXT_LIBS $NXT_LIB_AUX_LIBS
+		$NXT_LD_OPT $NXT_LIBM $NXT_LIBS $NXT_LIB_AUX_LIBS \$(NXT_OTEL_LIB_LOC)
 
 $NXT_BUILD_DIR/vbcq_test: $NXT_BUILD_DIR/src/test/nxt_vbcq_test.o \\
 			$NXT_BUILD_DIR/lib/$NXT_LIB_STATIC
@@ -294,7 +294,7 @@ $NXT_BUILD_DIR/vbcq_test: $NXT_BUILD_DIR/src/test/nxt_vbcq_test.o \\
 	\$(v)\$(NXT_EXEC_LINK) -o $NXT_BUILD_DIR/vbcq_test \\
 		\$(CFLAGS) $NXT_BUILD_DIR/src/test/nxt_vbcq_test.o \\
 		$NXT_BUILD_DIR/lib/$NXT_LIB_STATIC \\
-		$NXT_LD_OPT $NXT_LIBM $NXT_LIBS $NXT_LIB_AUX_LIBS
+		$NXT_LD_OPT $NXT_LIBM $NXT_LIBS $NXT_LIB_AUX_LIBS \$(NXT_OTEL_LIB_LOC)
 
 $NXT_BUILD_DIR/unit_app_test: $NXT_BUILD_DIR/src/test/nxt_unit_app_test.o \\
 		$NXT_BUILD_DIR/lib/$NXT_LIB_UNIT_STATIC


### PR DESCRIPTION
When otel support is enable, libnxt.a needs libotel.a

Without this patch, when building tests

```
 LD     build/unit_websocket_chat
/usr/bin/ld: build/lib/libnxt.a(nxt_router.o): in function `nxt_router_conf_create':
/builddir/build/BUILD/unit-1.34.0-build/unit-27bde184dedcbf687db2f314c60c037623318a8d/src/nxt_router.c:2217:(.text+0x73c8): undefined reference to `nxt_otel_rs_init'
/usr/bin/ld: /builddir/build/BUILD/unit-1.34.0-build/unit-27bde184dedcbf687db2f314c60c037623318a8d/src/nxt_router.c:2221:(.text+0x755f): undefined reference to `nxt_otel_rs_uninit'
/usr/bin/ld: build/lib/libnxt.a(nxt_http_request.o): in function `nxt_http_request_create':
/builddir/build/BUILD/unit-1.34.0-build/unit-27bde184dedcbf687db2f314c60c037623318a8d/src/nxt_http_request.c:289:(.text+0x9dc): undefined reference to `nxt_otel_rs_is_init'
/usr/bin/ld: build/lib/libnxt.a(nxt_otel.o): in function `nxt_otel_propagate_header':
/builddir/build/BUILD/unit-1.34.0-build/unit-27bde184dedcbf687db2f314c60c037623318a8d/src/nxt_otel.c:72:(.text+0xe8): undefined reference to `nxt_otel_rs_copy_traceparent'
/usr/bin/ld: /builddir/build/BUILD/unit-1.34.0-build/unit-27bde184dedcbf687db2f314c60c037623318a8d/src/nxt_otel.c:93:(.text+0x14d): undefined reference to `nxt_otel_rs_add_event_to_trace'
/usr/bin/ld: build/lib/libnxt.a(nxt_otel.o): in function `nxt_otel_trace_and_span_init':
/builddir/build/BUILD/unit-1.34.0-build/unit-27bde184dedcbf687db2f314c60c037623318a8d/src/nxt_otel.c:270:(.text+0x280): undefined reference to `nxt_otel_rs_get_or_create_trace'
/usr/bin/ld: build/lib/libnxt.a(nxt_otel.o): in function `nxt_otel_span_add_headers':
/builddir/build/BUILD/unit-1.34.0-build/unit-27bde184dedcbf687db2f314c60c037623318a8d/src/nxt_otel.c:146:(.text+0x340): undefined reference to `nxt_otel_rs_add_event_to_trace'
/usr/bin/ld: /builddir/build/BUILD/unit-1.34.0-build/unit-27bde184dedcbf687db2f314c60c037623318a8d/src/nxt_otel.c:150:(.text+0x382): undefined reference to `nxt_otel_rs_add_event_to_trace'
/usr/bin/ld: /builddir/build/BUILD/unit-1.34.0-build/unit-27bde184dedcbf687db2f314c60c037623318a8d/src/nxt_otel.c:152:(.text+0x3af): undefined reference to `nxt_otel_rs_add_event_to_trace'
/usr/bin/ld: build/lib/libnxt.a(nxt_otel.o): in function `nxt_otel_span_add_body':
/builddir/build/BUILD/unit-1.34.0-build/unit-27bde184dedcbf687db2f314c60c037623318a8d/src/nxt_otel.c:204:(.text+0x48f): undefined reference to `nxt_otel_rs_add_event_to_trace'
/usr/bin/ld: build/lib/libnxt.a(nxt_otel.o): in function `nxt_otel_span_collect':
/builddir/build/BUILD/unit-1.34.0-build/unit-27bde184dedcbf687db2f314c60c037623318a8d/src/nxt_otel.c:245:(.text+0x4dc): undefined reference to `nxt_otel_rs_send_trace'
/usr/bin/ld: build/lib/libnxt.a(nxt_otel.o): in function `nxt_otel_span_add_status':
/builddir/build/BUILD/unit-1.34.0-build/unit-27bde184dedcbf687db2f314c60c037623318a8d/src/nxt_otel.c:230:(.text+0x553): undefined reference to `nxt_otel_rs_add_event_to_trace'

```