### PR TITLE
Docker: Mount rust from image at build time instead of downloading it

### DIFF
--- a/pkg/docker/Dockerfile.go1.22
+++ b/pkg/docker/Dockerfile.go1.22
@@ -1,3 +1,5 @@
+FROM rust:1.83.0-bookworm AS rust-build
+
 FROM golang:1.22-bookworm
 
 LABEL org.opencontainers.image.title="Unit (go1.22)"
@@ -8,30 +10,17 @@ LABEL org.opencontainers.image.documentation="https://unit.nginx.org/installatio
 LABEL org.opencontainers.image.vendor="NGINX Docker Maintainers <docker-maint@nginx.com>"
 LABEL org.opencontainers.image.version="1.34.0"
 
-RUN set -ex \
+COPY --from=unit:1.34.0-minimal /usr/sbin/unitd* /usr/sbin/
+RUN --mount=type=bind,target=/rust,from=rust-build,rw \
+    set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
     && apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests -y \
          ca-certificates git build-essential libssl-dev libpcre2-dev curl pkg-config libclang-dev cmake \
-    && export RUST_VERSION=1.83.0 \
-    && export RUSTUP_HOME=/usr/src/unit/rustup \
-    && export CARGO_HOME=/usr/src/unit/cargo \
-    && export PATH=/usr/src/unit/cargo/bin:$PATH \
+    && export RUSTUP_HOME=/rust/usr/local/rustup \
+    && export CARGO_HOME=/rust/usr/local/cargo \
+    && export PATH=/rust/usr/local/cargo/bin:$PATH \
     && dpkgArch="$(dpkg --print-architecture)" \
-    && case "${dpkgArch##*-}" in \
-         amd64) rustArch="x86_64-unknown-linux-gnu"; rustupSha256="6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d" ;; \
-         arm64) rustArch="aarch64-unknown-linux-gnu"; rustupSha256="1cffbf51e63e634c746f741de50649bbbcbd9dbe1de363c9ecef64e278dba2b2" ;; \
-         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
-       esac \
-    && url="https://static.rust-lang.org/rustup/archive/1.27.1/${rustArch}/rustup-init" \
-    && curl -L -O "$url" \
-    && echo "${rustupSha256} *rustup-init" | sha256sum -c - \
-    && chmod +x rustup-init \
-    && ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch} \
-    && rm rustup-init \
-    && rustup --version \
-    && cargo --version \
-    && rustc --version \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
@@ -56,16 +45,6 @@ RUN set -ex \
     && CONFIGURE_ARGS="$CONFIGURE_ARGS_MODULES \
                 --njs \
                 --otel" \
-    && make -j $NCPU -C pkg/contrib .njs \
-    && export PKG_CONFIG_PATH=$(pwd)/pkg/contrib/njs/build \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd-debug \
-    && make clean \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/modules \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd \
-    && make clean \
     && /bin/true \
     && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
     && ./configure go --go-path=$GOPATH \

--- a/pkg/docker/Dockerfile.go1.23
+++ b/pkg/docker/Dockerfile.go1.23
@@ -1,3 +1,5 @@
+FROM rust:1.83.0-bookworm AS rust-build
+
 FROM golang:1.23-bookworm
 
 LABEL org.opencontainers.image.title="Unit (go1.23)"
@@ -8,30 +10,17 @@ LABEL org.opencontainers.image.documentation="https://unit.nginx.org/installatio
 LABEL org.opencontainers.image.vendor="NGINX Docker Maintainers <docker-maint@nginx.com>"
 LABEL org.opencontainers.image.version="1.34.0"
 
-RUN set -ex \
+COPY --from=unit:1.34.0-minimal /usr/sbin/unitd* /usr/sbin/
+RUN --mount=type=bind,target=/rust,from=rust-build,rw \
+    set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
     && apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests -y \
          ca-certificates git build-essential libssl-dev libpcre2-dev curl pkg-config libclang-dev cmake \
-    && export RUST_VERSION=1.83.0 \
-    && export RUSTUP_HOME=/usr/src/unit/rustup \
-    && export CARGO_HOME=/usr/src/unit/cargo \
-    && export PATH=/usr/src/unit/cargo/bin:$PATH \
+    && export RUSTUP_HOME=/rust/usr/local/rustup \
+    && export CARGO_HOME=/rust/usr/local/cargo \
+    && export PATH=/rust/usr/local/cargo/bin:$PATH \
     && dpkgArch="$(dpkg --print-architecture)" \
-    && case "${dpkgArch##*-}" in \
-         amd64) rustArch="x86_64-unknown-linux-gnu"; rustupSha256="6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d" ;; \
-         arm64) rustArch="aarch64-unknown-linux-gnu"; rustupSha256="1cffbf51e63e634c746f741de50649bbbcbd9dbe1de363c9ecef64e278dba2b2" ;; \
-         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
-       esac \
-    && url="https://static.rust-lang.org/rustup/archive/1.27.1/${rustArch}/rustup-init" \
-    && curl -L -O "$url" \
-    && echo "${rustupSha256} *rustup-init" | sha256sum -c - \
-    && chmod +x rustup-init \
-    && ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch} \
-    && rm rustup-init \
-    && rustup --version \
-    && cargo --version \
-    && rustc --version \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
@@ -56,16 +45,6 @@ RUN set -ex \
     && CONFIGURE_ARGS="$CONFIGURE_ARGS_MODULES \
                 --njs \
                 --otel" \
-    && make -j $NCPU -C pkg/contrib .njs \
-    && export PKG_CONFIG_PATH=$(pwd)/pkg/contrib/njs/build \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd-debug \
-    && make clean \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/modules \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd \
-    && make clean \
     && /bin/true \
     && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
     && ./configure go --go-path=$GOPATH \

--- a/pkg/docker/Dockerfile.jsc11
+++ b/pkg/docker/Dockerfile.jsc11
@@ -1,3 +1,5 @@
+FROM rust:1.83.0-bookworm AS rust-build
+
 FROM eclipse-temurin:11-jdk-jammy
 
 LABEL org.opencontainers.image.title="Unit (jsc11)"
@@ -8,30 +10,17 @@ LABEL org.opencontainers.image.documentation="https://unit.nginx.org/installatio
 LABEL org.opencontainers.image.vendor="NGINX Docker Maintainers <docker-maint@nginx.com>"
 LABEL org.opencontainers.image.version="1.34.0"
 
-RUN set -ex \
+COPY --from=unit:1.34.0-minimal /usr/sbin/unitd* /usr/sbin/
+RUN --mount=type=bind,target=/rust,from=rust-build,rw \
+    set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
     && apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests -y \
          ca-certificates git build-essential libssl-dev libpcre2-dev curl pkg-config libclang-dev cmake \
-    && export RUST_VERSION=1.83.0 \
-    && export RUSTUP_HOME=/usr/src/unit/rustup \
-    && export CARGO_HOME=/usr/src/unit/cargo \
-    && export PATH=/usr/src/unit/cargo/bin:$PATH \
+    && export RUSTUP_HOME=/rust/usr/local/rustup \
+    && export CARGO_HOME=/rust/usr/local/cargo \
+    && export PATH=/rust/usr/local/cargo/bin:$PATH \
     && dpkgArch="$(dpkg --print-architecture)" \
-    && case "${dpkgArch##*-}" in \
-         amd64) rustArch="x86_64-unknown-linux-gnu"; rustupSha256="6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d" ;; \
-         arm64) rustArch="aarch64-unknown-linux-gnu"; rustupSha256="1cffbf51e63e634c746f741de50649bbbcbd9dbe1de363c9ecef64e278dba2b2" ;; \
-         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
-       esac \
-    && url="https://static.rust-lang.org/rustup/archive/1.27.1/${rustArch}/rustup-init" \
-    && curl -L -O "$url" \
-    && echo "${rustupSha256} *rustup-init" | sha256sum -c - \
-    && chmod +x rustup-init \
-    && ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch} \
-    && rm rustup-init \
-    && rustup --version \
-    && cargo --version \
-    && rustc --version \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
@@ -56,16 +45,6 @@ RUN set -ex \
     && CONFIGURE_ARGS="$CONFIGURE_ARGS_MODULES \
                 --njs \
                 --otel" \
-    && make -j $NCPU -C pkg/contrib .njs \
-    && export PKG_CONFIG_PATH=$(pwd)/pkg/contrib/njs/build \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd-debug \
-    && make clean \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/modules \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd \
-    && make clean \
     && /bin/true \
     && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
     && ./configure java --jars=/usr/share/unit-jsc-common/ \

--- a/pkg/docker/Dockerfile.minimal
+++ b/pkg/docker/Dockerfile.minimal
@@ -1,3 +1,5 @@
+FROM rust:1.83.0-bookworm AS rust-build
+
 FROM debian:bookworm-slim
 
 LABEL org.opencontainers.image.title="Unit (minimal)"
@@ -8,30 +10,17 @@ LABEL org.opencontainers.image.documentation="https://unit.nginx.org/installatio
 LABEL org.opencontainers.image.vendor="NGINX Docker Maintainers <docker-maint@nginx.com>"
 LABEL org.opencontainers.image.version="1.34.0"
 
-RUN set -ex \
+
+RUN --mount=type=bind,target=/rust,from=rust-build,rw \
+    set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
     && apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests -y \
          ca-certificates git build-essential libssl-dev libpcre2-dev curl pkg-config libclang-dev cmake \
-    && export RUST_VERSION=1.83.0 \
-    && export RUSTUP_HOME=/usr/src/unit/rustup \
-    && export CARGO_HOME=/usr/src/unit/cargo \
-    && export PATH=/usr/src/unit/cargo/bin:$PATH \
+    && export RUSTUP_HOME=/rust/usr/local/rustup \
+    && export CARGO_HOME=/rust/usr/local/cargo \
+    && export PATH=/rust/usr/local/cargo/bin:$PATH \
     && dpkgArch="$(dpkg --print-architecture)" \
-    && case "${dpkgArch##*-}" in \
-         amd64) rustArch="x86_64-unknown-linux-gnu"; rustupSha256="6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d" ;; \
-         arm64) rustArch="aarch64-unknown-linux-gnu"; rustupSha256="1cffbf51e63e634c746f741de50649bbbcbd9dbe1de363c9ecef64e278dba2b2" ;; \
-         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
-       esac \
-    && url="https://static.rust-lang.org/rustup/archive/1.27.1/${rustArch}/rustup-init" \
-    && curl -L -O "$url" \
-    && echo "${rustupSha256} *rustup-init" | sha256sum -c - \
-    && chmod +x rustup-init \
-    && ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch} \
-    && rm rustup-init \
-    && rustup --version \
-    && cargo --version \
-    && rustc --version \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
@@ -66,14 +55,6 @@ RUN set -ex \
     && make -j $NCPU unitd \
     && install -pm755 build/sbin/unitd /usr/sbin/unitd \
     && make clean \
-    && /bin/true \
-    && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
-    && ./configure  \
-    && make -j $NCPU version \
-    && make clean \
-    && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/modules \
-    && ./configure  \
-    && make -j $NCPU version \
     && cd \
     && rm -rf /usr/src/unit \
     && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \

--- a/pkg/docker/Dockerfile.node20
+++ b/pkg/docker/Dockerfile.node20
@@ -1,3 +1,5 @@
+FROM rust:1.83.0-bookworm AS rust-build
+
 FROM node:20-bookworm
 
 LABEL org.opencontainers.image.title="Unit (node20)"
@@ -8,30 +10,17 @@ LABEL org.opencontainers.image.documentation="https://unit.nginx.org/installatio
 LABEL org.opencontainers.image.vendor="NGINX Docker Maintainers <docker-maint@nginx.com>"
 LABEL org.opencontainers.image.version="1.34.0"
 
-RUN set -ex \
+COPY --from=unit:1.34.0-minimal /usr/sbin/unitd* /usr/sbin/
+RUN --mount=type=bind,target=/rust,from=rust-build,rw \
+    set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
     && apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests -y \
          ca-certificates git build-essential libssl-dev libpcre2-dev curl pkg-config libclang-dev cmake \
-    && export RUST_VERSION=1.83.0 \
-    && export RUSTUP_HOME=/usr/src/unit/rustup \
-    && export CARGO_HOME=/usr/src/unit/cargo \
-    && export PATH=/usr/src/unit/cargo/bin:$PATH \
+    && export RUSTUP_HOME=/rust/usr/local/rustup \
+    && export CARGO_HOME=/rust/usr/local/cargo \
+    && export PATH=/rust/usr/local/cargo/bin:$PATH \
     && dpkgArch="$(dpkg --print-architecture)" \
-    && case "${dpkgArch##*-}" in \
-         amd64) rustArch="x86_64-unknown-linux-gnu"; rustupSha256="6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d" ;; \
-         arm64) rustArch="aarch64-unknown-linux-gnu"; rustupSha256="1cffbf51e63e634c746f741de50649bbbcbd9dbe1de363c9ecef64e278dba2b2" ;; \
-         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
-       esac \
-    && url="https://static.rust-lang.org/rustup/archive/1.27.1/${rustArch}/rustup-init" \
-    && curl -L -O "$url" \
-    && echo "${rustupSha256} *rustup-init" | sha256sum -c - \
-    && chmod +x rustup-init \
-    && ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch} \
-    && rm rustup-init \
-    && rustup --version \
-    && cargo --version \
-    && rustc --version \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
@@ -56,16 +45,6 @@ RUN set -ex \
     && CONFIGURE_ARGS="$CONFIGURE_ARGS_MODULES \
                 --njs \
                 --otel" \
-    && make -j $NCPU -C pkg/contrib .njs \
-    && export PKG_CONFIG_PATH=$(pwd)/pkg/contrib/njs/build \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd-debug \
-    && make clean \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/modules \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd \
-    && make clean \
     && npm -g install node-gyp \
     && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
     && ./configure nodejs --node-gyp=/usr/local/bin/node-gyp \

--- a/pkg/docker/Dockerfile.node22
+++ b/pkg/docker/Dockerfile.node22
@@ -1,3 +1,5 @@
+FROM rust:1.83.0-bookworm AS rust-build
+
 FROM node:22-bookworm
 
 LABEL org.opencontainers.image.title="Unit (node22)"
@@ -8,30 +10,17 @@ LABEL org.opencontainers.image.documentation="https://unit.nginx.org/installatio
 LABEL org.opencontainers.image.vendor="NGINX Docker Maintainers <docker-maint@nginx.com>"
 LABEL org.opencontainers.image.version="1.34.0"
 
-RUN set -ex \
+COPY --from=unit:1.34.0-minimal /usr/sbin/unitd* /usr/sbin/
+RUN --mount=type=bind,target=/rust,from=rust-build,rw \
+    set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
     && apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests -y \
          ca-certificates git build-essential libssl-dev libpcre2-dev curl pkg-config libclang-dev cmake \
-    && export RUST_VERSION=1.83.0 \
-    && export RUSTUP_HOME=/usr/src/unit/rustup \
-    && export CARGO_HOME=/usr/src/unit/cargo \
-    && export PATH=/usr/src/unit/cargo/bin:$PATH \
+    && export RUSTUP_HOME=/rust/usr/local/rustup \
+    && export CARGO_HOME=/rust/usr/local/cargo \
+    && export PATH=/rust/usr/local/cargo/bin:$PATH \
     && dpkgArch="$(dpkg --print-architecture)" \
-    && case "${dpkgArch##*-}" in \
-         amd64) rustArch="x86_64-unknown-linux-gnu"; rustupSha256="6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d" ;; \
-         arm64) rustArch="aarch64-unknown-linux-gnu"; rustupSha256="1cffbf51e63e634c746f741de50649bbbcbd9dbe1de363c9ecef64e278dba2b2" ;; \
-         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
-       esac \
-    && url="https://static.rust-lang.org/rustup/archive/1.27.1/${rustArch}/rustup-init" \
-    && curl -L -O "$url" \
-    && echo "${rustupSha256} *rustup-init" | sha256sum -c - \
-    && chmod +x rustup-init \
-    && ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch} \
-    && rm rustup-init \
-    && rustup --version \
-    && cargo --version \
-    && rustc --version \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
@@ -56,16 +45,6 @@ RUN set -ex \
     && CONFIGURE_ARGS="$CONFIGURE_ARGS_MODULES \
                 --njs \
                 --otel" \
-    && make -j $NCPU -C pkg/contrib .njs \
-    && export PKG_CONFIG_PATH=$(pwd)/pkg/contrib/njs/build \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd-debug \
-    && make clean \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/modules \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd \
-    && make clean \
     && npm -g install node-gyp \
     && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
     && ./configure nodejs --node-gyp=/usr/local/bin/node-gyp \

--- a/pkg/docker/Dockerfile.perl5.38
+++ b/pkg/docker/Dockerfile.perl5.38
@@ -1,3 +1,5 @@
+FROM rust:1.83.0-bookworm AS rust-build
+
 FROM perl:5.38-bookworm
 
 LABEL org.opencontainers.image.title="Unit (perl5.38)"
@@ -8,30 +10,17 @@ LABEL org.opencontainers.image.documentation="https://unit.nginx.org/installatio
 LABEL org.opencontainers.image.vendor="NGINX Docker Maintainers <docker-maint@nginx.com>"
 LABEL org.opencontainers.image.version="1.34.0"
 
-RUN set -ex \
+COPY --from=unit:1.34.0-minimal /usr/sbin/unitd* /usr/sbin/
+RUN --mount=type=bind,target=/rust,from=rust-build,rw \
+    set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
     && apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests -y \
          ca-certificates git build-essential libssl-dev libpcre2-dev curl pkg-config libclang-dev cmake \
-    && export RUST_VERSION=1.83.0 \
-    && export RUSTUP_HOME=/usr/src/unit/rustup \
-    && export CARGO_HOME=/usr/src/unit/cargo \
-    && export PATH=/usr/src/unit/cargo/bin:$PATH \
+    && export RUSTUP_HOME=/rust/usr/local/rustup \
+    && export CARGO_HOME=/rust/usr/local/cargo \
+    && export PATH=/rust/usr/local/cargo/bin:$PATH \
     && dpkgArch="$(dpkg --print-architecture)" \
-    && case "${dpkgArch##*-}" in \
-         amd64) rustArch="x86_64-unknown-linux-gnu"; rustupSha256="6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d" ;; \
-         arm64) rustArch="aarch64-unknown-linux-gnu"; rustupSha256="1cffbf51e63e634c746f741de50649bbbcbd9dbe1de363c9ecef64e278dba2b2" ;; \
-         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
-       esac \
-    && url="https://static.rust-lang.org/rustup/archive/1.27.1/${rustArch}/rustup-init" \
-    && curl -L -O "$url" \
-    && echo "${rustupSha256} *rustup-init" | sha256sum -c - \
-    && chmod +x rustup-init \
-    && ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch} \
-    && rm rustup-init \
-    && rustup --version \
-    && cargo --version \
-    && rustc --version \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
@@ -56,16 +45,6 @@ RUN set -ex \
     && CONFIGURE_ARGS="$CONFIGURE_ARGS_MODULES \
                 --njs \
                 --otel" \
-    && make -j $NCPU -C pkg/contrib .njs \
-    && export PKG_CONFIG_PATH=$(pwd)/pkg/contrib/njs/build \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd-debug \
-    && make clean \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/modules \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd \
-    && make clean \
     && /bin/true \
     && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
     && ./configure perl \

--- a/pkg/docker/Dockerfile.perl5.40
+++ b/pkg/docker/Dockerfile.perl5.40
@@ -1,3 +1,5 @@
+FROM rust:1.83.0-bookworm AS rust-build
+
 FROM perl:5.40-bookworm
 
 LABEL org.opencontainers.image.title="Unit (perl5.40)"
@@ -8,30 +10,17 @@ LABEL org.opencontainers.image.documentation="https://unit.nginx.org/installatio
 LABEL org.opencontainers.image.vendor="NGINX Docker Maintainers <docker-maint@nginx.com>"
 LABEL org.opencontainers.image.version="1.34.0"
 
-RUN set -ex \
+COPY --from=unit:1.34.0-minimal /usr/sbin/unitd* /usr/sbin/
+RUN --mount=type=bind,target=/rust,from=rust-build,rw \
+    set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
     && apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests -y \
          ca-certificates git build-essential libssl-dev libpcre2-dev curl pkg-config libclang-dev cmake \
-    && export RUST_VERSION=1.83.0 \
-    && export RUSTUP_HOME=/usr/src/unit/rustup \
-    && export CARGO_HOME=/usr/src/unit/cargo \
-    && export PATH=/usr/src/unit/cargo/bin:$PATH \
+    && export RUSTUP_HOME=/rust/usr/local/rustup \
+    && export CARGO_HOME=/rust/usr/local/cargo \
+    && export PATH=/rust/usr/local/cargo/bin:$PATH \
     && dpkgArch="$(dpkg --print-architecture)" \
-    && case "${dpkgArch##*-}" in \
-         amd64) rustArch="x86_64-unknown-linux-gnu"; rustupSha256="6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d" ;; \
-         arm64) rustArch="aarch64-unknown-linux-gnu"; rustupSha256="1cffbf51e63e634c746f741de50649bbbcbd9dbe1de363c9ecef64e278dba2b2" ;; \
-         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
-       esac \
-    && url="https://static.rust-lang.org/rustup/archive/1.27.1/${rustArch}/rustup-init" \
-    && curl -L -O "$url" \
-    && echo "${rustupSha256} *rustup-init" | sha256sum -c - \
-    && chmod +x rustup-init \
-    && ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch} \
-    && rm rustup-init \
-    && rustup --version \
-    && cargo --version \
-    && rustc --version \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
@@ -56,16 +45,6 @@ RUN set -ex \
     && CONFIGURE_ARGS="$CONFIGURE_ARGS_MODULES \
                 --njs \
                 --otel" \
-    && make -j $NCPU -C pkg/contrib .njs \
-    && export PKG_CONFIG_PATH=$(pwd)/pkg/contrib/njs/build \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd-debug \
-    && make clean \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/modules \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd \
-    && make clean \
     && /bin/true \
     && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
     && ./configure perl \

--- a/pkg/docker/Dockerfile.php8.3
+++ b/pkg/docker/Dockerfile.php8.3
@@ -1,3 +1,5 @@
+FROM rust:1.83.0-bookworm AS rust-build
+
 FROM php:8.3-cli-bookworm
 
 LABEL org.opencontainers.image.title="Unit (php8.3)"
@@ -8,30 +10,17 @@ LABEL org.opencontainers.image.documentation="https://unit.nginx.org/installatio
 LABEL org.opencontainers.image.vendor="NGINX Docker Maintainers <docker-maint@nginx.com>"
 LABEL org.opencontainers.image.version="1.34.0"
 
-RUN set -ex \
+COPY --from=unit:1.34.0-minimal /usr/sbin/unitd* /usr/sbin/
+RUN --mount=type=bind,target=/rust,from=rust-build,rw \
+    set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
     && apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests -y \
          ca-certificates git build-essential libssl-dev libpcre2-dev curl pkg-config libclang-dev cmake \
-    && export RUST_VERSION=1.83.0 \
-    && export RUSTUP_HOME=/usr/src/unit/rustup \
-    && export CARGO_HOME=/usr/src/unit/cargo \
-    && export PATH=/usr/src/unit/cargo/bin:$PATH \
+    && export RUSTUP_HOME=/rust/usr/local/rustup \
+    && export CARGO_HOME=/rust/usr/local/cargo \
+    && export PATH=/rust/usr/local/cargo/bin:$PATH \
     && dpkgArch="$(dpkg --print-architecture)" \
-    && case "${dpkgArch##*-}" in \
-         amd64) rustArch="x86_64-unknown-linux-gnu"; rustupSha256="6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d" ;; \
-         arm64) rustArch="aarch64-unknown-linux-gnu"; rustupSha256="1cffbf51e63e634c746f741de50649bbbcbd9dbe1de363c9ecef64e278dba2b2" ;; \
-         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
-       esac \
-    && url="https://static.rust-lang.org/rustup/archive/1.27.1/${rustArch}/rustup-init" \
-    && curl -L -O "$url" \
-    && echo "${rustupSha256} *rustup-init" | sha256sum -c - \
-    && chmod +x rustup-init \
-    && ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch} \
-    && rm rustup-init \
-    && rustup --version \
-    && cargo --version \
-    && rustc --version \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
@@ -56,16 +45,6 @@ RUN set -ex \
     && CONFIGURE_ARGS="$CONFIGURE_ARGS_MODULES \
                 --njs \
                 --otel" \
-    && make -j $NCPU -C pkg/contrib .njs \
-    && export PKG_CONFIG_PATH=$(pwd)/pkg/contrib/njs/build \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd-debug \
-    && make clean \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/modules \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd \
-    && make clean \
     && /bin/true \
     && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
     && ./configure php \

--- a/pkg/docker/Dockerfile.php8.4
+++ b/pkg/docker/Dockerfile.php8.4
@@ -1,3 +1,5 @@
+FROM rust:1.83.0-bookworm AS rust-build
+
 FROM php:8.4-cli-bookworm
 
 LABEL org.opencontainers.image.title="Unit (php8.4)"
@@ -8,30 +10,17 @@ LABEL org.opencontainers.image.documentation="https://unit.nginx.org/installatio
 LABEL org.opencontainers.image.vendor="NGINX Docker Maintainers <docker-maint@nginx.com>"
 LABEL org.opencontainers.image.version="1.34.0"
 
-RUN set -ex \
+COPY --from=unit:1.34.0-minimal /usr/sbin/unitd* /usr/sbin/
+RUN --mount=type=bind,target=/rust,from=rust-build,rw \
+    set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
     && apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests -y \
          ca-certificates git build-essential libssl-dev libpcre2-dev curl pkg-config libclang-dev cmake \
-    && export RUST_VERSION=1.83.0 \
-    && export RUSTUP_HOME=/usr/src/unit/rustup \
-    && export CARGO_HOME=/usr/src/unit/cargo \
-    && export PATH=/usr/src/unit/cargo/bin:$PATH \
+    && export RUSTUP_HOME=/rust/usr/local/rustup \
+    && export CARGO_HOME=/rust/usr/local/cargo \
+    && export PATH=/rust/usr/local/cargo/bin:$PATH \
     && dpkgArch="$(dpkg --print-architecture)" \
-    && case "${dpkgArch##*-}" in \
-         amd64) rustArch="x86_64-unknown-linux-gnu"; rustupSha256="6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d" ;; \
-         arm64) rustArch="aarch64-unknown-linux-gnu"; rustupSha256="1cffbf51e63e634c746f741de50649bbbcbd9dbe1de363c9ecef64e278dba2b2" ;; \
-         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
-       esac \
-    && url="https://static.rust-lang.org/rustup/archive/1.27.1/${rustArch}/rustup-init" \
-    && curl -L -O "$url" \
-    && echo "${rustupSha256} *rustup-init" | sha256sum -c - \
-    && chmod +x rustup-init \
-    && ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch} \
-    && rm rustup-init \
-    && rustup --version \
-    && cargo --version \
-    && rustc --version \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
@@ -56,16 +45,6 @@ RUN set -ex \
     && CONFIGURE_ARGS="$CONFIGURE_ARGS_MODULES \
                 --njs \
                 --otel" \
-    && make -j $NCPU -C pkg/contrib .njs \
-    && export PKG_CONFIG_PATH=$(pwd)/pkg/contrib/njs/build \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd-debug \
-    && make clean \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/modules \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd \
-    && make clean \
     && /bin/true \
     && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
     && ./configure php \

--- a/pkg/docker/Dockerfile.python3.12
+++ b/pkg/docker/Dockerfile.python3.12
@@ -1,3 +1,5 @@
+FROM rust:1.83.0-bookworm AS rust-build
+
 FROM python:3.12-bookworm
 
 LABEL org.opencontainers.image.title="Unit (python3.12)"
@@ -8,30 +10,17 @@ LABEL org.opencontainers.image.documentation="https://unit.nginx.org/installatio
 LABEL org.opencontainers.image.vendor="NGINX Docker Maintainers <docker-maint@nginx.com>"
 LABEL org.opencontainers.image.version="1.34.0"
 
-RUN set -ex \
+COPY --from=unit:1.34.0-minimal /usr/sbin/unitd* /usr/sbin/
+RUN --mount=type=bind,target=/rust,from=rust-build,rw \
+    set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
     && apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests -y \
          ca-certificates git build-essential libssl-dev libpcre2-dev curl pkg-config libclang-dev cmake \
-    && export RUST_VERSION=1.83.0 \
-    && export RUSTUP_HOME=/usr/src/unit/rustup \
-    && export CARGO_HOME=/usr/src/unit/cargo \
-    && export PATH=/usr/src/unit/cargo/bin:$PATH \
+    && export RUSTUP_HOME=/rust/usr/local/rustup \
+    && export CARGO_HOME=/rust/usr/local/cargo \
+    && export PATH=/rust/usr/local/cargo/bin:$PATH \
     && dpkgArch="$(dpkg --print-architecture)" \
-    && case "${dpkgArch##*-}" in \
-         amd64) rustArch="x86_64-unknown-linux-gnu"; rustupSha256="6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d" ;; \
-         arm64) rustArch="aarch64-unknown-linux-gnu"; rustupSha256="1cffbf51e63e634c746f741de50649bbbcbd9dbe1de363c9ecef64e278dba2b2" ;; \
-         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
-       esac \
-    && url="https://static.rust-lang.org/rustup/archive/1.27.1/${rustArch}/rustup-init" \
-    && curl -L -O "$url" \
-    && echo "${rustupSha256} *rustup-init" | sha256sum -c - \
-    && chmod +x rustup-init \
-    && ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch} \
-    && rm rustup-init \
-    && rustup --version \
-    && cargo --version \
-    && rustc --version \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
@@ -56,16 +45,6 @@ RUN set -ex \
     && CONFIGURE_ARGS="$CONFIGURE_ARGS_MODULES \
                 --njs \
                 --otel" \
-    && make -j $NCPU -C pkg/contrib .njs \
-    && export PKG_CONFIG_PATH=$(pwd)/pkg/contrib/njs/build \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd-debug \
-    && make clean \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/modules \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd \
-    && make clean \
     && /bin/true \
     && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
     && ./configure python --config=/usr/local/bin/python3-config \

--- a/pkg/docker/Dockerfile.python3.12-slim
+++ b/pkg/docker/Dockerfile.python3.12-slim
@@ -1,3 +1,5 @@
+FROM rust:1.83.0-bookworm AS rust-build
+
 FROM python:3.12-slim-bookworm
 
 LABEL org.opencontainers.image.title="Unit (python3.12-slim)"
@@ -8,30 +10,17 @@ LABEL org.opencontainers.image.documentation="https://unit.nginx.org/installatio
 LABEL org.opencontainers.image.vendor="NGINX Docker Maintainers <docker-maint@nginx.com>"
 LABEL org.opencontainers.image.version="1.34.0"
 
-RUN set -ex \
+COPY --from=unit:1.34.0-minimal /usr/sbin/unitd* /usr/sbin/
+RUN --mount=type=bind,target=/rust,from=rust-build,rw \
+    set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
     && apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests -y \
          ca-certificates git build-essential libssl-dev libpcre2-dev curl pkg-config libclang-dev cmake \
-    && export RUST_VERSION=1.83.0 \
-    && export RUSTUP_HOME=/usr/src/unit/rustup \
-    && export CARGO_HOME=/usr/src/unit/cargo \
-    && export PATH=/usr/src/unit/cargo/bin:$PATH \
+    && export RUSTUP_HOME=/rust/usr/local/rustup \
+    && export CARGO_HOME=/rust/usr/local/cargo \
+    && export PATH=/rust/usr/local/cargo/bin:$PATH \
     && dpkgArch="$(dpkg --print-architecture)" \
-    && case "${dpkgArch##*-}" in \
-         amd64) rustArch="x86_64-unknown-linux-gnu"; rustupSha256="6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d" ;; \
-         arm64) rustArch="aarch64-unknown-linux-gnu"; rustupSha256="1cffbf51e63e634c746f741de50649bbbcbd9dbe1de363c9ecef64e278dba2b2" ;; \
-         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
-       esac \
-    && url="https://static.rust-lang.org/rustup/archive/1.27.1/${rustArch}/rustup-init" \
-    && curl -L -O "$url" \
-    && echo "${rustupSha256} *rustup-init" | sha256sum -c - \
-    && chmod +x rustup-init \
-    && ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch} \
-    && rm rustup-init \
-    && rustup --version \
-    && cargo --version \
-    && rustc --version \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
@@ -56,16 +45,6 @@ RUN set -ex \
     && CONFIGURE_ARGS="$CONFIGURE_ARGS_MODULES \
                 --njs \
                 --otel" \
-    && make -j $NCPU -C pkg/contrib .njs \
-    && export PKG_CONFIG_PATH=$(pwd)/pkg/contrib/njs/build \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd-debug \
-    && make clean \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/modules \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd \
-    && make clean \
     && /bin/true \
     && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
     && ./configure python --config=/usr/local/bin/python3-config \

--- a/pkg/docker/Dockerfile.python3.13
+++ b/pkg/docker/Dockerfile.python3.13
@@ -1,3 +1,5 @@
+FROM rust:1.83.0-bookworm AS rust-build
+
 FROM python:3.13-bookworm
 
 LABEL org.opencontainers.image.title="Unit (python3.13)"
@@ -8,30 +10,17 @@ LABEL org.opencontainers.image.documentation="https://unit.nginx.org/installatio
 LABEL org.opencontainers.image.vendor="NGINX Docker Maintainers <docker-maint@nginx.com>"
 LABEL org.opencontainers.image.version="1.34.0"
 
-RUN set -ex \
+COPY --from=unit:1.34.0-minimal /usr/sbin/unitd* /usr/sbin/
+RUN --mount=type=bind,target=/rust,from=rust-build,rw \
+    set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
     && apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests -y \
          ca-certificates git build-essential libssl-dev libpcre2-dev curl pkg-config libclang-dev cmake \
-    && export RUST_VERSION=1.83.0 \
-    && export RUSTUP_HOME=/usr/src/unit/rustup \
-    && export CARGO_HOME=/usr/src/unit/cargo \
-    && export PATH=/usr/src/unit/cargo/bin:$PATH \
+    && export RUSTUP_HOME=/rust/usr/local/rustup \
+    && export CARGO_HOME=/rust/usr/local/cargo \
+    && export PATH=/rust/usr/local/cargo/bin:$PATH \
     && dpkgArch="$(dpkg --print-architecture)" \
-    && case "${dpkgArch##*-}" in \
-         amd64) rustArch="x86_64-unknown-linux-gnu"; rustupSha256="6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d" ;; \
-         arm64) rustArch="aarch64-unknown-linux-gnu"; rustupSha256="1cffbf51e63e634c746f741de50649bbbcbd9dbe1de363c9ecef64e278dba2b2" ;; \
-         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
-       esac \
-    && url="https://static.rust-lang.org/rustup/archive/1.27.1/${rustArch}/rustup-init" \
-    && curl -L -O "$url" \
-    && echo "${rustupSha256} *rustup-init" | sha256sum -c - \
-    && chmod +x rustup-init \
-    && ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch} \
-    && rm rustup-init \
-    && rustup --version \
-    && cargo --version \
-    && rustc --version \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
@@ -56,16 +45,6 @@ RUN set -ex \
     && CONFIGURE_ARGS="$CONFIGURE_ARGS_MODULES \
                 --njs \
                 --otel" \
-    && make -j $NCPU -C pkg/contrib .njs \
-    && export PKG_CONFIG_PATH=$(pwd)/pkg/contrib/njs/build \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd-debug \
-    && make clean \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/modules \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd \
-    && make clean \
     && /bin/true \
     && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
     && ./configure python --config=/usr/local/bin/python3-config \

--- a/pkg/docker/Dockerfile.python3.13-slim
+++ b/pkg/docker/Dockerfile.python3.13-slim
@@ -1,3 +1,5 @@
+FROM rust:1.83.0-bookworm AS rust-build
+
 FROM python:3.13-slim-bookworm
 
 LABEL org.opencontainers.image.title="Unit (python3.13-slim)"
@@ -8,30 +10,17 @@ LABEL org.opencontainers.image.documentation="https://unit.nginx.org/installatio
 LABEL org.opencontainers.image.vendor="NGINX Docker Maintainers <docker-maint@nginx.com>"
 LABEL org.opencontainers.image.version="1.34.0"
 
-RUN set -ex \
+COPY --from=unit:1.34.0-minimal /usr/sbin/unitd* /usr/sbin/
+RUN --mount=type=bind,target=/rust,from=rust-build,rw \
+    set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
     && apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests -y \
          ca-certificates git build-essential libssl-dev libpcre2-dev curl pkg-config libclang-dev cmake \
-    && export RUST_VERSION=1.83.0 \
-    && export RUSTUP_HOME=/usr/src/unit/rustup \
-    && export CARGO_HOME=/usr/src/unit/cargo \
-    && export PATH=/usr/src/unit/cargo/bin:$PATH \
+    && export RUSTUP_HOME=/rust/usr/local/rustup \
+    && export CARGO_HOME=/rust/usr/local/cargo \
+    && export PATH=/rust/usr/local/cargo/bin:$PATH \
     && dpkgArch="$(dpkg --print-architecture)" \
-    && case "${dpkgArch##*-}" in \
-         amd64) rustArch="x86_64-unknown-linux-gnu"; rustupSha256="6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d" ;; \
-         arm64) rustArch="aarch64-unknown-linux-gnu"; rustupSha256="1cffbf51e63e634c746f741de50649bbbcbd9dbe1de363c9ecef64e278dba2b2" ;; \
-         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
-       esac \
-    && url="https://static.rust-lang.org/rustup/archive/1.27.1/${rustArch}/rustup-init" \
-    && curl -L -O "$url" \
-    && echo "${rustupSha256} *rustup-init" | sha256sum -c - \
-    && chmod +x rustup-init \
-    && ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch} \
-    && rm rustup-init \
-    && rustup --version \
-    && cargo --version \
-    && rustc --version \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
@@ -56,16 +45,6 @@ RUN set -ex \
     && CONFIGURE_ARGS="$CONFIGURE_ARGS_MODULES \
                 --njs \
                 --otel" \
-    && make -j $NCPU -C pkg/contrib .njs \
-    && export PKG_CONFIG_PATH=$(pwd)/pkg/contrib/njs/build \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd-debug \
-    && make clean \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/modules \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd \
-    && make clean \
     && /bin/true \
     && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
     && ./configure python --config=/usr/local/bin/python3-config \

--- a/pkg/docker/Dockerfile.ruby3.2
+++ b/pkg/docker/Dockerfile.ruby3.2
@@ -1,3 +1,5 @@
+FROM rust:1.83.0-bookworm AS rust-build
+
 FROM ruby:3.2-bookworm
 
 LABEL org.opencontainers.image.title="Unit (ruby3.2)"
@@ -8,30 +10,17 @@ LABEL org.opencontainers.image.documentation="https://unit.nginx.org/installatio
 LABEL org.opencontainers.image.vendor="NGINX Docker Maintainers <docker-maint@nginx.com>"
 LABEL org.opencontainers.image.version="1.34.0"
 
-RUN set -ex \
+COPY --from=unit:1.34.0-minimal /usr/sbin/unitd* /usr/sbin/
+RUN --mount=type=bind,target=/rust,from=rust-build,rw \
+    set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
     && apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests -y \
          ca-certificates git build-essential libssl-dev libpcre2-dev curl pkg-config libclang-dev cmake \
-    && export RUST_VERSION=1.83.0 \
-    && export RUSTUP_HOME=/usr/src/unit/rustup \
-    && export CARGO_HOME=/usr/src/unit/cargo \
-    && export PATH=/usr/src/unit/cargo/bin:$PATH \
+    && export RUSTUP_HOME=/rust/usr/local/rustup \
+    && export CARGO_HOME=/rust/usr/local/cargo \
+    && export PATH=/rust/usr/local/cargo/bin:$PATH \
     && dpkgArch="$(dpkg --print-architecture)" \
-    && case "${dpkgArch##*-}" in \
-         amd64) rustArch="x86_64-unknown-linux-gnu"; rustupSha256="6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d" ;; \
-         arm64) rustArch="aarch64-unknown-linux-gnu"; rustupSha256="1cffbf51e63e634c746f741de50649bbbcbd9dbe1de363c9ecef64e278dba2b2" ;; \
-         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
-       esac \
-    && url="https://static.rust-lang.org/rustup/archive/1.27.1/${rustArch}/rustup-init" \
-    && curl -L -O "$url" \
-    && echo "${rustupSha256} *rustup-init" | sha256sum -c - \
-    && chmod +x rustup-init \
-    && ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch} \
-    && rm rustup-init \
-    && rustup --version \
-    && cargo --version \
-    && rustc --version \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
@@ -56,16 +45,6 @@ RUN set -ex \
     && CONFIGURE_ARGS="$CONFIGURE_ARGS_MODULES \
                 --njs \
                 --otel" \
-    && make -j $NCPU -C pkg/contrib .njs \
-    && export PKG_CONFIG_PATH=$(pwd)/pkg/contrib/njs/build \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd-debug \
-    && make clean \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/modules \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd \
-    && make clean \
     && /bin/true \
     && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
     && ./configure ruby \

--- a/pkg/docker/Dockerfile.ruby3.3
+++ b/pkg/docker/Dockerfile.ruby3.3
@@ -1,3 +1,5 @@
+FROM rust:1.83.0-bookworm AS rust-build
+
 FROM ruby:3.3-bookworm
 
 LABEL org.opencontainers.image.title="Unit (ruby3.3)"
@@ -8,30 +10,17 @@ LABEL org.opencontainers.image.documentation="https://unit.nginx.org/installatio
 LABEL org.opencontainers.image.vendor="NGINX Docker Maintainers <docker-maint@nginx.com>"
 LABEL org.opencontainers.image.version="1.34.0"
 
-RUN set -ex \
+COPY --from=unit:1.34.0-minimal /usr/sbin/unitd* /usr/sbin/
+RUN --mount=type=bind,target=/rust,from=rust-build,rw \
+    set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
     && apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests -y \
          ca-certificates git build-essential libssl-dev libpcre2-dev curl pkg-config libclang-dev cmake \
-    && export RUST_VERSION=1.83.0 \
-    && export RUSTUP_HOME=/usr/src/unit/rustup \
-    && export CARGO_HOME=/usr/src/unit/cargo \
-    && export PATH=/usr/src/unit/cargo/bin:$PATH \
+    && export RUSTUP_HOME=/rust/usr/local/rustup \
+    && export CARGO_HOME=/rust/usr/local/cargo \
+    && export PATH=/rust/usr/local/cargo/bin:$PATH \
     && dpkgArch="$(dpkg --print-architecture)" \
-    && case "${dpkgArch##*-}" in \
-         amd64) rustArch="x86_64-unknown-linux-gnu"; rustupSha256="6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d" ;; \
-         arm64) rustArch="aarch64-unknown-linux-gnu"; rustupSha256="1cffbf51e63e634c746f741de50649bbbcbd9dbe1de363c9ecef64e278dba2b2" ;; \
-         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
-       esac \
-    && url="https://static.rust-lang.org/rustup/archive/1.27.1/${rustArch}/rustup-init" \
-    && curl -L -O "$url" \
-    && echo "${rustupSha256} *rustup-init" | sha256sum -c - \
-    && chmod +x rustup-init \
-    && ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch} \
-    && rm rustup-init \
-    && rustup --version \
-    && cargo --version \
-    && rustc --version \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
@@ -56,16 +45,6 @@ RUN set -ex \
     && CONFIGURE_ARGS="$CONFIGURE_ARGS_MODULES \
                 --njs \
                 --otel" \
-    && make -j $NCPU -C pkg/contrib .njs \
-    && export PKG_CONFIG_PATH=$(pwd)/pkg/contrib/njs/build \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd-debug \
-    && make clean \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/modules \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd \
-    && make clean \
     && /bin/true \
     && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
     && ./configure ruby \

--- a/pkg/docker/Dockerfile.wasm
+++ b/pkg/docker/Dockerfile.wasm
@@ -1,3 +1,5 @@
+FROM rust:1.83.0-bookworm AS rust-build
+
 FROM debian:bookworm-slim
 
 LABEL org.opencontainers.image.title="Unit (wasm)"
@@ -8,30 +10,17 @@ LABEL org.opencontainers.image.documentation="https://unit.nginx.org/installatio
 LABEL org.opencontainers.image.vendor="NGINX Docker Maintainers <docker-maint@nginx.com>"
 LABEL org.opencontainers.image.version="1.34.0"
 
-RUN set -ex \
+COPY --from=unit:1.34.0-minimal /usr/sbin/unitd* /usr/sbin/
+RUN --mount=type=bind,target=/rust,from=rust-build,rw \
+    set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
     && apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests -y \
          ca-certificates git build-essential libssl-dev libpcre2-dev curl pkg-config libclang-dev cmake \
-    && export RUST_VERSION=1.83.0 \
-    && export RUSTUP_HOME=/usr/src/unit/rustup \
-    && export CARGO_HOME=/usr/src/unit/cargo \
-    && export PATH=/usr/src/unit/cargo/bin:$PATH \
+    && export RUSTUP_HOME=/rust/usr/local/rustup \
+    && export CARGO_HOME=/rust/usr/local/cargo \
+    && export PATH=/rust/usr/local/cargo/bin:$PATH \
     && dpkgArch="$(dpkg --print-architecture)" \
-    && case "${dpkgArch##*-}" in \
-         amd64) rustArch="x86_64-unknown-linux-gnu"; rustupSha256="6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d" ;; \
-         arm64) rustArch="aarch64-unknown-linux-gnu"; rustupSha256="1cffbf51e63e634c746f741de50649bbbcbd9dbe1de363c9ecef64e278dba2b2" ;; \
-         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
-       esac \
-    && url="https://static.rust-lang.org/rustup/archive/1.27.1/${rustArch}/rustup-init" \
-    && curl -L -O "$url" \
-    && echo "${rustupSha256} *rustup-init" | sha256sum -c - \
-    && chmod +x rustup-init \
-    && ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch} \
-    && rm rustup-init \
-    && rustup --version \
-    && cargo --version \
-    && rustc --version \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \
@@ -56,16 +45,6 @@ RUN set -ex \
     && CONFIGURE_ARGS="$CONFIGURE_ARGS_MODULES \
                 --njs \
                 --otel" \
-    && make -j $NCPU -C pkg/contrib .njs \
-    && export PKG_CONFIG_PATH=$(pwd)/pkg/contrib/njs/build \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd-debug \
-    && make clean \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/modules \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd \
-    && make clean \
     && make -C pkg/contrib .wasmtime \
     && install -pm 755 pkg/contrib/wasmtime/artifacts/lib/libwasmtime.so /usr/lib/$(dpkg-architecture -q DEB_HOST_MULTIARCH)/ \
     && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \

--- a/pkg/docker/Makefile
+++ b/pkg/docker/Makefile
@@ -154,7 +154,7 @@ Dockerfile.%: ../../version template.Dockerfile
 
 build-%: build-minimal Dockerfile.%
 	docker pull $(CONTAINER_$*)
-	docker build --no-cache -t unit:$(VERSION)-$* -f Dockerfile.$* .
+	docker build --progress=plain --no-cache -t unit:$(VERSION)-$* -f Dockerfile.$* .
 	touch $@
 
 library:

--- a/pkg/docker/Makefile
+++ b/pkg/docker/Makefile
@@ -13,6 +13,9 @@ MODULES_SLIM ?= python
 
 VARIANT ?= bookworm
 
+VERSION_RUST ?= 1.83.0
+CONTAINER_RUST ?= rust:$(VERSION_RUST)-$(VARIANT)
+
 VERSIONS_minimal ?=
 CONTAINER_minimal ?= debian:$(VARIANT)-slim
 CONFIGURE_minimal ?=
@@ -141,6 +144,7 @@ Dockerfile.%: ../../version template.Dockerfile
 			-e 's,@@COPY_STEP@@,$(COPY_STEP_$(call modname, $*)),g' \
 			-e 's,@@PATCHLEVEL@@,$(PATCHLEVEL),g' \
 			-e 's,@@CONTAINER@@,$(CONTAINER_$*),g' \
+			-e 's,@@CONTAINER_RUST@@,$(CONTAINER_RUST),g' \
 			-e 's,@@CONFIGURE@@,$(CONFIGURE_$(call modname, $*)),g' \
 			-e 's,@@INSTALL@@,$(INSTALL_$(call modname, $*)),g' \
 			-e 's,@@RUN@@,$(RUN_$(call modname, $*)),g' \

--- a/pkg/docker/Makefile
+++ b/pkg/docker/Makefile
@@ -148,7 +148,7 @@ Dockerfile.%: ../../version template.Dockerfile
 			-e 's,@@MODULE@@,$*,g' \
 			> $@
 
-build-%: Dockerfile.%
+build-%: build-minimal Dockerfile.%
 	docker pull $(CONTAINER_$*)
 	docker build --no-cache -t unit:$(VERSION)-$* -f Dockerfile.$* .
 	touch $@

--- a/pkg/docker/Makefile
+++ b/pkg/docker/Makefile
@@ -19,6 +19,8 @@ CONFIGURE_minimal ?=
 INSTALL_minimal ?=	version
 RUN_minimal ?=		/bin/true
 MODULE_PREBUILD_minimal ?= /bin/true
+COPY_STEP_minimal =
+BUILD_STEP_minimal = $(BUILD_UNITD)
 
 VERSIONS_go ?=		1.22 1.23
 VARIANT_go ?=		$(VARIANT)
@@ -88,6 +90,37 @@ make -C pkg/contrib .wasmtime \\\n \
 \ \ \ \&\& install -pm 755 pkg/contrib/wasmtime/artifacts/lib/libwasmtime.so /usr/lib/\$$\(dpkg-architecture -q DEB_HOST_MULTIARCH\)/
 endef
 
+define BUILD_UNITD
+make -j $$NCPU -C pkg/contrib .njs \\\n \
+\ \ \ \&\& export PKG_CONFIG_PATH=\$$\(pwd\)/pkg/contrib/njs/build \\\n \
+\ \ \ \&\& ./configure $$CONFIGURE_ARGS --cc-opt="$$CC_OPT" --ld-opt="$$LD_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \\\n \
+\ \ \ \&\& make -j $$NCPU unitd \\\n \
+\ \ \ \&\& install -pm755 build/sbin/unitd /usr/sbin/unitd-debug \\\n \
+\ \ \ \&\& make clean \\\n \
+\ \ \ \&\& ./configure $$CONFIGURE_ARGS --cc-opt="$$CC_OPT" --ld-opt="$$LD_OPT" --modulesdir=/usr/lib/unit/modules \\\n \
+\ \ \ \&\& make -j $$NCPU unitd \\\n \
+\ \ \ \&\& install -pm755 build/sbin/unitd /usr/sbin/unitd \\\n \
+\ \ \ \&\& make clean
+endef
+
+define COPY_UNITD
+COPY --from=unit:$(VERSION)-minimal /usr/sbin/unitd* /usr/sbin/
+endef
+
+define BUILD_MODULE
+@@MODULE_PREBUILD@@ \\\n \
+\ \ \ \&\& ./configure $$$$CONFIGURE_ARGS_MODULES --cc-opt="$$$$CC_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \\\n \
+\ \ \ \&\& ./configure @@CONFIGURE@@ \\\n \
+\ \ \ \&\& make -j $$$$NCPU @@INSTALL@@ \\\n \
+\ \ \ \&\& make clean \\\n \
+\ \ \ \&\& ./configure $$$$CONFIGURE_ARGS_MODULES --cc-opt="$$$$CC_OPT" --modulesdir=/usr/lib/unit/modules \\\n \
+\ \ \ \&\& ./configure @@CONFIGURE@@ \\\n \
+\ \ \ \&\& make -j $$$$NCPU @@INSTALL@@
+endef
+
+$(foreach module, $(MODULES), $(eval BUILD_STEP_$(module) = $(BUILD_MODULE)))
+$(foreach module, $(MODULES), $(eval COPY_STEP_$(module) = $(COPY_UNITD)))
+
 default:
 	@echo "valid targets: all build dockerfiles library clean"
 
@@ -104,6 +137,8 @@ Dockerfile.%: ../../version template.Dockerfile
 	@echo "===> Building $@"
 	cat template.Dockerfile | sed \
 			-e 's,@@VERSION@@,$(VERSION),g' \
+			-e 's,@@BUILD_STEP@@,$(BUILD_STEP_$(call modname, $*)),g' \
+			-e 's,@@COPY_STEP@@,$(COPY_STEP_$(call modname, $*)),g' \
 			-e 's,@@PATCHLEVEL@@,$(PATCHLEVEL),g' \
 			-e 's,@@CONTAINER@@,$(CONTAINER_$*),g' \
 			-e 's,@@CONFIGURE@@,$(CONFIGURE_$(call modname, $*)),g' \

--- a/pkg/docker/template.Dockerfile
+++ b/pkg/docker/template.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.83.0-bookworm as rust-build
+FROM @@CONTAINER_RUST@@ as rust-build
 
 FROM @@CONTAINER@@
 

--- a/pkg/docker/template.Dockerfile
+++ b/pkg/docker/template.Dockerfile
@@ -10,6 +10,7 @@ LABEL org.opencontainers.image.documentation="https://unit.nginx.org/installatio
 LABEL org.opencontainers.image.vendor="NGINX Docker Maintainers <docker-maint@nginx.com>"
 LABEL org.opencontainers.image.version="@@VERSION@@"
 
+@@COPY_STEP@@
 RUN --mount=type=bind,target=/rust,from=rust-build,rw \
     set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
@@ -44,24 +45,7 @@ RUN --mount=type=bind,target=/rust,from=rust-build,rw \
     && CONFIGURE_ARGS="$CONFIGURE_ARGS_MODULES \
                 --njs \
                 --otel" \
-    && make -j $NCPU -C pkg/contrib .njs \
-    && export PKG_CONFIG_PATH=$(pwd)/pkg/contrib/njs/build \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd-debug \
-    && make clean \
-    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/modules \
-    && make -j $NCPU unitd \
-    && install -pm755 build/sbin/unitd /usr/sbin/unitd \
-    && make clean \
-    && @@MODULE_PREBUILD@@ \
-    && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
-    && ./configure @@CONFIGURE@@ \
-    && make -j $NCPU @@INSTALL@@ \
-    && make clean \
-    && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/modules \
-    && ./configure @@CONFIGURE@@ \
-    && make -j $NCPU @@INSTALL@@ \
+    && @@BUILD_STEP@@ \
     && cd \
     && rm -rf /usr/src/unit \
     && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \

--- a/pkg/docker/template.Dockerfile
+++ b/pkg/docker/template.Dockerfile
@@ -1,4 +1,4 @@
-FROM @@CONTAINER_RUST@@ as rust-build
+FROM @@CONTAINER_RUST@@ AS rust-build
 
 FROM @@CONTAINER@@
 

--- a/pkg/docker/template.Dockerfile
+++ b/pkg/docker/template.Dockerfile
@@ -1,3 +1,5 @@
+FROM rust:1.83.0-bookworm as rust-build
+
 FROM @@CONTAINER@@
 
 LABEL org.opencontainers.image.title="Unit (@@MODULE@@)"
@@ -8,30 +10,16 @@ LABEL org.opencontainers.image.documentation="https://unit.nginx.org/installatio
 LABEL org.opencontainers.image.vendor="NGINX Docker Maintainers <docker-maint@nginx.com>"
 LABEL org.opencontainers.image.version="@@VERSION@@"
 
-RUN set -ex \
+RUN --mount=type=bind,target=/rust,from=rust-build,rw \
+    set -ex \
     && savedAptMark="$(apt-mark showmanual)" \
     && apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests -y \
          ca-certificates git build-essential libssl-dev libpcre2-dev curl pkg-config libclang-dev cmake \
-    && export RUST_VERSION=1.83.0 \
-    && export RUSTUP_HOME=/usr/src/unit/rustup \
-    && export CARGO_HOME=/usr/src/unit/cargo \
-    && export PATH=/usr/src/unit/cargo/bin:$PATH \
+    && export RUSTUP_HOME=/rust/usr/local/rustup \
+    && export CARGO_HOME=/rust/usr/local/cargo \
+    && export PATH=/rust/usr/local/cargo/bin:$PATH \
     && dpkgArch="$(dpkg --print-architecture)" \
-    && case "${dpkgArch##*-}" in \
-         amd64) rustArch="x86_64-unknown-linux-gnu"; rustupSha256="6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d" ;; \
-         arm64) rustArch="aarch64-unknown-linux-gnu"; rustupSha256="1cffbf51e63e634c746f741de50649bbbcbd9dbe1de363c9ecef64e278dba2b2" ;; \
-         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
-       esac \
-    && url="https://static.rust-lang.org/rustup/archive/1.27.1/${rustArch}/rustup-init" \
-    && curl -L -O "$url" \
-    && echo "${rustupSha256} *rustup-init" | sha256sum -c - \
-    && chmod +x rustup-init \
-    && ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch} \
-    && rm rustup-init \
-    && rustup --version \
-    && cargo --version \
-    && rustc --version \
     && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
     && mkdir -p /usr/src/unit \
     && cd /usr/src/unit \


### PR DESCRIPTION
This ensures that rust is not left behind in the image