### PR TITLE
[nxt_http_static] add `.mjs` extension to default_types

### DIFF
--- a/src/nxt_http_static.c
+++ b/src/nxt_http_static.c
@@ -957,6 +957,7 @@ nxt_http_static_mtypes_init(nxt_mp_t *mp, nxt_lvlhsh_t *hash)
         { nxt_string("text/x-rst"),     ".rst"   },
 
         { nxt_string("application/javascript"),  ".js"   },
+        { nxt_string("application/javascript"),  ".mjs"  },
         { nxt_string("application/json"),        ".json" },
         { nxt_string("application/xml"),         ".xml"  },
         { nxt_string("application/rss+xml"),     ".rss"  },


### PR DESCRIPTION
Associate file extension `.mjs` with `application/javascript`.

Context: common output of static site generators. There's little risk of ambiguity for this extension, so might as well support it out of the box.