### PR TITLE
Fix GCC 15 Wunterminated-string-initialization issues

### DIFF
--- a/src/nxt_http_parse.c
+++ b/src/nxt_http_parse.c
@@ -164,8 +164,10 @@ nxt_http_parse_request_line(nxt_http_request_parse_t *rp, u_char **pos,
     nxt_http_ver_t           ver;
     nxt_http_target_traps_e  trap;
 
-    static const nxt_http_ver_t  http11 = { "HTTP/1.1" };
-    static const nxt_http_ver_t  http10 = { "HTTP/1.0" };
+    static const nxt_http_ver_t  http11 =
+                            {{ 'H', 'T', 'T', 'P', '/', '1', '.', '1' }};
+    static const nxt_http_ver_t  http10 =
+                            {{ 'H', 'T', 'T', 'P', '/', '1', '.', '0' }};
 
     p = *pos;
 
@@ -516,7 +518,8 @@ nxt_http_parse_field_name(nxt_http_request_parse_t *rp, u_char **pos,
     size_t    len;
     uint32_t  hash;
 
-    static const u_char  normal[256]  nxt_aligned(64) =
+    /* The last '\0' is not needed because the string is NUL terminated */
+    static const u_char  normal[]  nxt_aligned(64) =
         "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
     /*   \s ! " # $ % & ' ( ) * + ,        . /                 : ; < = > ?   */
         "\0\1\0\1\1\1\1\1\0\0\1\1\0" "-" "\1\0" "0123456789" "\0\0\0\0\0\0"
@@ -529,7 +532,7 @@ nxt_http_parse_field_name(nxt_http_request_parse_t *rp, u_char **pos,
         "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
         "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
         "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
-        "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
+        "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
 
     p = *pos + rp->field_name.length;
     hash = rp->field_hash;

--- a/src/nxt_sprintf.c
+++ b/src/nxt_sprintf.c
@@ -112,8 +112,8 @@ nxt_vsprintf(u_char *buf, u_char *end, const char *fmt, va_list args)
     nxt_sprintf_t        spf;
     nxt_file_name_t      *fn;
 
-    static const u_char  hexadecimal[16] = "0123456789abcdef";
-    static const u_char  HEXADECIMAL[16] = "0123456789ABCDEF";
+    static const u_char  hexadecimal[] = "0123456789abcdef";
+    static const u_char  HEXADECIMAL[] = "0123456789ABCDEF";
     static const u_char  nan[] = "[nan]";
     static const u_char  null[] = "[null]";
     static const u_char  infinity[] = "[infinity]";

--- a/src/nxt_string.c
+++ b/src/nxt_string.c
@@ -592,13 +592,14 @@ nxt_decode_uri_plus(u_char *dst, u_char *src, size_t length)
 }
 
 
+static const u_char  nxt_hex[] = "0123456789ABCDEF";
+
+
 uintptr_t
 nxt_encode_uri(u_char *dst, u_char *src, size_t length)
 {
     u_char      *end;
     nxt_uint_t  n;
-
-    static const u_char  hex[16] = "0123456789ABCDEF";
 
     end = src + length;
 
@@ -624,8 +625,8 @@ nxt_encode_uri(u_char *dst, u_char *src, size_t length)
 
         if (nxt_uri_escape[*src >> 5] & (1U << (*src & 0x1f))) {
             *dst++ = '%';
-            *dst++ = hex[*src >> 4];
-            *dst++ = hex[*src & 0xf];
+            *dst++ = nxt_hex[*src >> 4];
+            *dst++ = nxt_hex[*src & 0xf];
 
         } else {
             *dst++ = *src;
@@ -643,8 +644,6 @@ nxt_encode_complex_uri(u_char *dst, u_char *src, size_t length)
 {
     u_char      *reserved, *end, ch;
     nxt_uint_t  n;
-
-    static const u_char  hex[16] = "0123456789ABCDEF";
 
     reserved = (u_char *) "?#\0";
 
@@ -689,8 +688,8 @@ nxt_encode_complex_uri(u_char *dst, u_char *src, size_t length)
 
             } else {
                 *dst++ = '%';
-                *dst++ = hex[ch >> 4];
-                *dst++ = hex[ch & 0xf];
+                *dst++ = nxt_hex[ch >> 4];
+                *dst++ = nxt_hex[ch & 0xf];
                 continue;
             }
         }


### PR DESCRIPTION
```
    Fix GCC 15 Wunterminated-string-initialization issues
    
    When building with the upcoming GCC 15, we are hit by the new
    Wunterminated-string-initialization compiler warning (however, due to
    -Werror, this is a build failure). E.g.
    
      src/nxt_string.c: In function ‘nxt_encode_uri’:
      src/nxt_string.c:601:36: error: initializer-string for array of ‘unsigned char’ is too long [-Werror=unterminated-string-initialization]
        601 |     static const u_char  hex[16] = "0123456789ABCDEF";
            |                                    ^~~~~~~~~~~~~~~~~~
    
    We have created a character array containing 16 elements, but is not NUL
    terminated. While this type of (lookup/translation table) use case is
    perfectly valid and we could simply disable the warning, it is probably
    still a useful warning to have enabled.
    
    There is a 'nonstring' attribute, but that doesn't influence this
    warning. Well not yet at least... but that looks to change!
    
    Lets just do what nginx does and create them NUL terminated. Except in
    src/nxt_http_parse.c where they *really* want to be non-NUL
    terminated and we use *arrays* of chars.
    
    Link: <https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Common-Variable-Attributes.html>
    Link: <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117178#c21>
    Signed-off-by: Andrew Clayton <a.clayton@nginx.com>
```