### PR TITLE
Fix build with GCC 15

### DIFF
--- a/auto/cc/test
+++ b/auto/cc/test
@@ -93,6 +93,10 @@ case $NXT_CC_NAME in
 
         NXT_CFLAGS="$NXT_CFLAGS -Wmissing-prototypes"
 
+        # Disable Wunterminated-string-initialization temporarily.
+        # See <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117178#c21>
+        NXT_CFLAGS="$NXT_CFLAGS -Wno-unterminated-string-initialization"
+
         # Stop on warning.
         NXT_CFLAGS="$NXT_CFLAGS -Werror"
 


### PR DESCRIPTION
```
    Fix build with GCC 15
    
    The upcoming GCC 15 release introduces a new compiler warning,
    Wunterminated-string-initialization.
    
    This is intended to catch things like
    
      static const u_char  hex[16] = "0123456789ABCDEF";
    
    Where we are creating a character array from a string literal, but the
    specified size is not enough for the terminating NUL byte.
    
    In the above example that is intended as it is used as a lookup table
    and only the individual indices are accessed.
    
    As it happens, Unit uses the above idiom in a few places, triggering
    this warning (which we treat as an error by default).
    
    While I don't like disabling compiler warnings, lets just disable this
    one temporarily, as there is a patch in the works to make the
    "nonstring" variable attribute quell this warning.
    
    We just disable this on GCC as this isn't in Clang and we don't need to
    worry about older compilers as GCC silently ignores unknown -Wno-*
    options.
    
    Link: <https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=44c9403ed1833ae71a59e84f9e37af3182be0df5>
    Link: <https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Common-Variable-Attributes.html>
    Link: <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117178#c21>
    Cc: Alejandro Colomar <alx@kernel.org>
    Reviewed-by: Alejandro Colomar <alx@kernel.org>
    Signed-off-by: Andrew Clayton <a.clayton@nginx.com>
```