### PR TITLE
python: Fix Litestar WebSockets compatibility

### DIFF
--- a/src/python/nxt_python_asgi.c
+++ b/src/python/nxt_python_asgi.c
@@ -693,15 +693,17 @@ nxt_py_asgi_create_http_scope(nxt_unit_request_info_t *req,
                                               : nxt_py_1_0_str)
     SET_ITEM(scope, scheme, scheme)
 
-    v = PyString_FromStringAndSize(nxt_unit_sptr_get(&r->method),
-                                   r->method_length);
-    if (nxt_slow_path(v == NULL)) {
-        nxt_unit_req_alert(req, "Python failed to create 'method' string");
-        goto fail;
-    }
+    if (!r->websocket_handshake) {
+        v = PyString_FromStringAndSize(nxt_unit_sptr_get(&r->method),
+                                       r->method_length);
+        if (nxt_slow_path(v == NULL)) {
+            nxt_unit_req_alert(req, "Python failed to create 'method' string");
+            goto fail;
+        }
 
-    SET_ITEM(scope, method, v)
-    Py_DECREF(v);
+        SET_ITEM(scope, method, v)
+        Py_DECREF(v);
+    }
 
     v = PyUnicode_DecodeUTF8(nxt_unit_sptr_get(&r->path), r->path_length,
                              "replace");


### PR DESCRIPTION
```
    python: Fix Litestar WebSockets compatibility
    
    It was reported on GitHub that Unit was unable to work with WebSockets
    under Litestar Python applications.
    
    This was due to Unit sending a 'method' variable in the WebSocket's
    connection scope, which Litestar was interpreting as being a normal HTTP
    connection.
    
    The ASGI WebSocket specification makes no mention about setting a
    'method', so let's not send it on WebSockets.
    
    Also tested this change with basic ASGI WebSockets and FastAPI
    WebSockets and obviously pytests still pass.

    Closes: https://github.com/nginx/unit/issues/1507
    Link: <https://asgi.readthedocs.io/en/latest/specs/www.html#websocket-connection-scope>
    Signed-off-by: Andrew Clayton <a.clayton@nginx.com>
```