### PR TITLE
ci: Update to actions/upload-artifact@v4 in cifuzz.yml

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -27,7 +27,7 @@ jobs:
         fuzz-seconds: 300
         output-sarif: true
     - name: Upload Crash
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts


### PR DESCRIPTION
```
    ci: Update to actions/upload-artifact@v4 in cifuzz.yml
    
    We need to update to the latest version of actions/upload-artifact in
    cifuzz.yml due to the workflow failing because of
    
      Error: This request has been automatically failed because it uses a
      deprecated version of `actions/upload-artifact: v3`. Learn more:
      https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
    
    Signed-off-by: Andrew Clayton <a.clayton@nginx.com>
```
