### PR TITLE
A couple of java websocket fixes

### DIFF
--- a/src/java/nginx/unit/websocket/WsFrameBase.java
+++ b/src/java/nginx/unit/websocket/WsFrameBase.java
@@ -260,6 +260,13 @@ public abstract class WsFrameBase {
         } else if (payloadLength == 127) {
             payloadLength = byteArrayToLong(inputBuffer.array(),
                     inputBuffer.arrayOffset() + inputBuffer.position(), 8);
+            // The most significant bit of those 8 bytes is required to be zero
+            // (see RFC 6455, section 5.2). If the most significant bit is set,
+            // the resulting payload length will be negative so test for that.
+            if (payloadLength < 0) {
+                throw new WsIOException(
+                        new CloseReason(CloseCodes.PROTOCOL_ERROR, sm.getString("wsFrame.payloadMsbInvalid")));
+            }
             inputBuffer.position(inputBuffer.position() + 8);
         }
         if (Util.isControl(opCode)) {

--- a/src/java/nginx/unit/websocket/WsFrameBase.java
+++ b/src/java/nginx/unit/websocket/WsFrameBase.java
@@ -670,7 +670,7 @@ public abstract class WsFrameBase {
         int shift = 0;
         long result = 0;
         for (int i = start + len - 1; i >= start; i--) {
-            result = result + ((b[i] & 0xFF) << shift);
+            result = result + ((b[i] & 0xFFL) << shift);
             shift += 8;
         }
         return result;


### PR DESCRIPTION
This pull-request comprises two patches.

* java: websocket: Fix calculation of payload length for > 32bit values

This fixes a calculation that was done as an `int` when it should have been treated as a `long`.

* java: websocket: Additional payload length validation

This adds a check for negative payload lengths.

Both these patches were applied to the Apache Tomcat sources a number of years ago. Original patch links are in the commit messages.

```
The following changes since commit 3fea47eaa3edd916ecf0b339626dd5f963838295:

  python: Add Django 5.x compatibility (2025-02-21 01:20:31 +0000)

are available in the Git repository at:

  git@github.com:ac000/unit.git java

for you to fetch changes up to d7afeb2b94f1cd72ed02403609e5484f9514e5eb:

  java: websocket: Additional payload length validation (2025-02-21 22:49:15 +0000)

----------------------------------------------------------------
Mark Thomas (2):
      java: websocket: Fix calculation of payload length for > 32bit values
      java: websocket: Additional payload length validation

 src/java/nginx/unit/websocket/WsFrameBase.java | 9 ++++++++-
 1 file changed, 8 insertions(+), 1 deletion(-)
```