### PR TITLE
Packaging: update docker golang version. Remove unsupported 1.22, add newer 1.24

### DIFF
--- a/pkg/docker/Dockerfile.go1.24
+++ b/pkg/docker/Dockerfile.go1.24
@@ -1,6 +1,6 @@
-FROM golang:1.22-bookworm
+FROM golang:1.24-bookworm
 
-LABEL org.opencontainers.image.title="Unit (go1.22)"
+LABEL org.opencontainers.image.title="Unit (go1.24)"
 LABEL org.opencontainers.image.description="Official build of Unit for Docker."
 LABEL org.opencontainers.image.url="https://unit.nginx.org"
 LABEL org.opencontainers.image.source="https://github.com/nginx/unit"

--- a/pkg/docker/Makefile
+++ b/pkg/docker/Makefile
@@ -119,7 +119,7 @@ build-%: Dockerfile.%
 	touch $@
 
 library:
-	@echo "# this file is generated via https://github.com/nginx/unit/blob/$(shell git describe --always --abbrev=0 HEAD)/pkg/docker/Makefile"
+	@echo "# this file is generated via https://github.com/nginx/unit/blob/$(shell git rev-parse HEAD)/pkg/docker/Makefile"
 	@echo ""
 	@echo "Maintainers: Unit Docker Maintainers <docker-maint@nginx.com> (@nginx)"
 	@echo "GitRepo: https://github.com/nginx/unit.git"
@@ -144,7 +144,7 @@ library:
 		fi; \
 		echo "Architectures: amd64, arm64v8"; \
 		echo "GitFetch: refs/heads/packaging"; \
-		echo "GitCommit: $(shell git describe --always --abbrev=0 HEAD)"; \
+		echo "GitCommit: $(shell git rev-parse HEAD)"; \
 		echo "Directory: pkg/docker"; \
 		echo "File: Dockerfile.$$mod"; \
 		previous="$$previous $$modname"; \

--- a/pkg/docker/Makefile
+++ b/pkg/docker/Makefile
@@ -20,7 +20,7 @@ INSTALL_minimal ?=	version
 RUN_minimal ?=		/bin/true
 MODULE_PREBUILD_minimal ?= /bin/true
 
-VERSIONS_go ?=		1.22 1.23
+VERSIONS_go ?=		1.23 1.24
 VARIANT_go ?=		$(VARIANT)
 $(foreach goversion, $(VERSIONS_go), $(eval CONTAINER_go$(goversion) = golang:$(goversion)-$(VARIANT_go)))
 CONFIGURE_go ?=		go --go-path=$$GOPATH


### PR DESCRIPTION
Official images check for outdated references in images so we have to update golang image we use.
https://github.com/docker-library/official-images/pull/18559

While at it: git desc doesn't work well with lightweight tags. So replaced it with rev-parse which gives proper results.
IIRC we did similar substitution for other docker projects somewhere.