### PR TITLE
tests: Fix TLS tests with Python 3.13

### DIFF
--- a/test/test_tls.py
+++ b/test/test_tls.py
@@ -49,6 +49,7 @@ def context_cert_req(cert='root'):
     context = ssl.create_default_context()
     context.check_hostname = False
     context.verify_mode = ssl.CERT_REQUIRED
+    context.verify_flags &= ~ssl.VERIFY_X509_STRICT
     context.load_verify_locations(f'{option.temp_dir}/{cert}.crt')
 
     return context

--- a/test/test_tls_sni.py
+++ b/test/test_tls_sni.py
@@ -99,6 +99,7 @@ def config_bundles(bundles):
     context = ssl.create_default_context()
     context.check_hostname = False
     context.verify_mode = ssl.CERT_REQUIRED
+    context.verify_flags &= ~ssl.VERIFY_X509_STRICT
     context.load_verify_locations(f'{option.temp_dir}/root.crt')
 
     return context


### PR DESCRIPTION
```
    tests: Fix TLS tests with Python 3.13
    
    Python 3.13 sets the VERIFY_X509_STRICT flag by default in
    create_default_context().
    
    This breaks our TLS tests with dummy certificates. Remove this flag.
    
    Thanks to @zfouts for the hint about the flag.
    
    As an aside there is another Python 3.13 change which breaks the tests,
    in that the cgi module has been removed. However there is a legacy-cgi
    module you can install to get things going again (note this module is
    unmaintained). E.g. In Fedora 'dnf install python3-legacy-cgi'.
    
    Reported-by: Konstantin Pavlov <thresh@nginx.com>
    Closes: https://github.com/nginx/unit/issues/1545
    Link: <https://docs.python.org/3/whatsnew/3.13.html#ssl>
    Link: <https://docs.python.org/3.13/library/cgi.html>
    Signed-off-by: Andrew Clayton <a.clayton@nginx.com>
```