### PR TITLE
Tag some char arrays with __attribute__ ((__nonstring__))

### DIFF
--- a/auto/cc/test
+++ b/auto/cc/test
@@ -93,10 +93,6 @@ case $NXT_CC_NAME in
 
         NXT_CFLAGS="$NXT_CFLAGS -Wmissing-prototypes"
 
-        # Disable Wunterminated-string-initialization temporarily.
-        # See <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117178#c21>
-        NXT_CFLAGS="$NXT_CFLAGS -Wno-unterminated-string-initialization"
-
         # Stop on warning.
         NXT_CFLAGS="$NXT_CFLAGS -Werror"
 

--- a/auto/clang
+++ b/auto/clang
@@ -194,3 +194,17 @@ nxt_feature_test="static void f(void) __attribute__ ((__unused__));
                       return 0;
                   }"
 . auto/feature
+
+
+nxt_feature="GCC __attribute__ nonstring"
+nxt_feature_name=NXT_HAVE_GCC_ATTRIBUTE_NONSTRING
+nxt_feature_run=
+nxt_feature_incs=
+nxt_feature_libs=
+nxt_feature_test="int main(void) {
+                      static const char str[3] __attribute__ ((__nonstring__)) =
+                          \"ABC\";
+
+                      return !!str[0];
+                  }"
+. auto/feature

--- a/src/nxt_clang.h
+++ b/src/nxt_clang.h
@@ -131,6 +131,17 @@
 #endif
 
 
+#if (NXT_HAVE_GCC_ATTRIBUTE_NONSTRING)
+
+#define NXT_NONSTRING      __attribute__((__nonstring__))
+
+#else
+
+#define NXT_NONSTRING
+
+#endif
+
+
 #if (NXT_HAVE_BUILTIN_POPCOUNT)
 
 #define nxt_popcount       __builtin_popcount

--- a/src/nxt_http_parse.c
+++ b/src/nxt_http_parse.c
@@ -516,7 +516,7 @@ nxt_http_parse_field_name(nxt_http_request_parse_t *rp, u_char **pos,
     size_t    len;
     uint32_t  hash;
 
-    static const u_char  normal[256]  nxt_aligned(64) =
+    static const u_char  normal[256]  NXT_NONSTRING nxt_aligned(64) =
         "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
     /*   \s ! " # $ % & ' ( ) * + ,        . /                 : ; < = > ?   */
         "\0\1\0\1\1\1\1\1\0\0\1\1\0" "-" "\1\0" "0123456789" "\0\0\0\0\0\0"

--- a/src/nxt_http_parse.h
+++ b/src/nxt_http_parse.h
@@ -21,7 +21,7 @@ typedef struct nxt_http_fields_hash_s    nxt_http_fields_hash_t;
 
 
 typedef union {
-    u_char                    str[8];
+    u_char                    str[8] NXT_NONSTRING;
     uint64_t                  ui64;
 
     struct {

--- a/src/nxt_sprintf.c
+++ b/src/nxt_sprintf.c
@@ -112,8 +112,8 @@ nxt_vsprintf(u_char *buf, u_char *end, const char *fmt, va_list args)
     nxt_sprintf_t        spf;
     nxt_file_name_t      *fn;
 
-    static const u_char  hexadecimal[16] = "0123456789abcdef";
-    static const u_char  HEXADECIMAL[16] = "0123456789ABCDEF";
+    static const u_char  hexadecimal[16] NXT_NONSTRING = "0123456789abcdef";
+    static const u_char  HEXADECIMAL[16] NXT_NONSTRING = "0123456789ABCDEF";
     static const u_char  nan[] = "[nan]";
     static const u_char  null[] = "[null]";
     static const u_char  infinity[] = "[infinity]";

--- a/src/nxt_string.c
+++ b/src/nxt_string.c
@@ -598,7 +598,7 @@ nxt_encode_uri(u_char *dst, u_char *src, size_t length)
     u_char      *end;
     nxt_uint_t  n;
 
-    static const u_char  hex[16] = "0123456789ABCDEF";
+    static const u_char  hex[16] NXT_NONSTRING = "0123456789ABCDEF";
 
     end = src + length;
 
@@ -644,7 +644,7 @@ nxt_encode_complex_uri(u_char *dst, u_char *src, size_t length)
     u_char      *reserved, *end, ch;
     nxt_uint_t  n;
 
-    static const u_char  hex[16] = "0123456789ABCDEF";
+    static const u_char  hex[16] NXT_NONSTRING = "0123456789ABCDEF";
 
     reserved = (u_char *) "?#\0";
 


### PR DESCRIPTION
As previously promised, this PR comprises three commits that allow us to re-enable the new GCC 15 warning `Wunterminated-string-initialization`.

* The first commit adds a wrapper around `__attribute__ ((__nonstring__))`

As a reminder, this attribute is used to mark character arrays that are intentionally not NUL terminated.

* The second commit tags various character arrays with this attribute.

* The third commit removes the disabling of this new warning.

```
The following changes since commit d7afeb2b94f1cd72ed02403609e5484f9514e5eb:

  java: websocket: Additional payload length validation (2025-02-21 22:49:15 +0000)

are available in the Git repository at:

  git@github.com:ac000/unit.git wusi

for you to fetch changes up to ca60536172916b7c3e4ff62e20be1ae2f3de039d:

  auto/cc: gcc: Don't disable -Wunterminated-string-initialization (2025-03-19 17:58:37 +0000)

----------------------------------------------------------------
Andrew Clayton (3):
      auto/clang: Add a NXT_NONSTRING macro
      Tag various character arrays with NXT_NONSTRING
      auto/cc: gcc: Don't disable -Wunterminated-string-initialization

 auto/cc/test         |  4 ----
 auto/clang           | 14 ++++++++++++++
 src/nxt_clang.h      | 11 +++++++++++
 src/nxt_http_parse.c |  2 +-
 src/nxt_http_parse.h |  2 +-
 src/nxt_sprintf.c    |  4 ++--
 src/nxt_string.c     |  4 ++--
 7 files changed, 31 insertions(+), 10 deletions(-)
```