### PR TITLE
Properly initialise some structures

### DIFF
--- a/src/nxt_socket_msg.h
+++ b/src/nxt_socket_msg.h
@@ -89,6 +89,8 @@ nxt_socket_msg_oob_init(nxt_send_oob_t *oob, int *fds)
     int             nfds;
     struct cmsghdr  *cmsg;
 
+    *oob = (nxt_send_oob_t) {};
+
 #if (NXT_HAVE_MSGHDR_CMSGCRED)
     cmsg = (struct cmsghdr *) (oob->buf);
     /*

--- a/src/nxt_unit.c
+++ b/src/nxt_unit.c
@@ -943,7 +943,7 @@ nxt_unit_ready(nxt_unit_ctx_t *ctx, int ready_fd, uint32_t stream, int queue_fd)
 {
     ssize_t          res;
     nxt_send_oob_t   oob;
-    nxt_port_msg_t   msg;
+    nxt_port_msg_t   msg = {};
     nxt_unit_impl_t  *lib;
     int              fds[2] = {queue_fd, -1};
 
@@ -951,12 +951,8 @@ nxt_unit_ready(nxt_unit_ctx_t *ctx, int ready_fd, uint32_t stream, int queue_fd)
 
     msg.stream = stream;
     msg.pid = lib->pid;
-    msg.reply_port = 0;
     msg.type = _NXT_PORT_MSG_PROCESS_READY;
     msg.last = 1;
-    msg.mmap = 0;
-    msg.nf = 0;
-    msg.mf = 0;
 
     nxt_socket_msg_oob_init(&oob, fds);
 
@@ -3258,7 +3254,7 @@ void
 nxt_unit_request_done(nxt_unit_request_info_t *req, int rc)
 {
     uint32_t                      size;
-    nxt_port_msg_t                msg;
+    nxt_port_msg_t                msg = {};
     nxt_unit_impl_t               *lib;
     nxt_unit_request_info_impl_t  *req_impl;
 
@@ -3302,13 +3298,9 @@ skip_response_send:
 
     msg.stream = req_impl->stream;
     msg.pid = lib->pid;
-    msg.reply_port = 0;
     msg.type = (rc == NXT_UNIT_OK) ? _NXT_PORT_MSG_DATA
                                    : _NXT_PORT_MSG_RPC_ERROR;
     msg.last = 1;
-    msg.mmap = 0;
-    msg.nf = 0;
-    msg.mf = 0;
 
     (void) nxt_unit_port_send(req->ctx, req->response_port,
                               &msg, sizeof(msg), NULL);


### PR DESCRIPTION
While tracking down some memory leaks valgrind(1) was highlighting numerous issues. Including the following

```
==166470== Syscall param sendmsg(msg.msg_iov[0]) points to uninitialised byte(s)
==166470==    at 0x4AE6514: sendmsg (sendmsg.c:28)
==166470==    by 0x42D86C: nxt_sendmsg (nxt_socket_msg.c:32)
==166470==    by 0x4FE6695: nxt_unit_sendmsg (nxt_unit.c:6013)
==166470==    by 0x4FEB6E2: nxt_unit_ready (nxt_unit.c:963)
==166470==    by 0x4FEB6E2: nxt_unit_init (nxt_unit.c:557)
==166470==    by 0x4FEEC56: nxt_php_start (nxt_php_sapi.c:507)
==166470==    by 0x426BA0: nxt_app_setup (nxt_application.c:1029)
==166470==    by 0x403153: nxt_process_do_start (nxt_process.c:718)
==166470==    by 0x4042A3: nxt_process_whoami_ok (nxt_process.c:846)
==166470==    by 0x407A28: nxt_port_rpc_handler (nxt_port_rpc.c:347)
==166470==    by 0x407E42: nxt_port_handler (nxt_port.c:184)
==166470==    by 0x40501B: nxt_port_read_msg_process (nxt_port_socket.c:1271)
==166470==    by 0x4055B3: nxt_port_read_handler (nxt_port_socket.c:778)
==166470==  Address 0x1ffefffc7f is on thread 1's stack
==166470==  in frame #3, created by nxt_unit_init (nxt_unit.c:428)
==166470==  Uninitialised value was created by a stack allocation
==166470==    at 0x4FEABFE: nxt_unit_init (nxt_unit.c:436)

==166470== Syscall param sendmsg(msg.msg_control) points to uninitialised byte(s)
==166470==    at 0x4AE6514: sendmsg (sendmsg.c:28)
==166470==    by 0x42D86C: nxt_sendmsg (nxt_socket_msg.c:32)
==166470==    by 0x4FE6695: nxt_unit_sendmsg (nxt_unit.c:6013)
==166470==    by 0x4FEB6E2: nxt_unit_ready (nxt_unit.c:963)
==166470==    by 0x4FEB6E2: nxt_unit_init (nxt_unit.c:557)
==166470==    by 0x4FEEC56: nxt_php_start (nxt_php_sapi.c:507)
==166470==    by 0x426BA0: nxt_app_setup (nxt_application.c:1029)
==166470==    by 0x403153: nxt_process_do_start (nxt_process.c:718)
==166470==    by 0x4042A3: nxt_process_whoami_ok (nxt_process.c:846)
==166470==    by 0x407A28: nxt_port_rpc_handler (nxt_port_rpc.c:347)
==166470==    by 0x407E42: nxt_port_handler (nxt_port.c:184)
==166470==    by 0x40501B: nxt_port_read_msg_process (nxt_port_socket.c:1271)
==166470==    by 0x4055B3: nxt_port_read_handler (nxt_port_socket.c:778)
==166470==  Address 0x1ffefffc9c is on thread 1's stack
==166470==  in frame #3, created by nxt_unit_init (nxt_unit.c:428)
==166470==  Uninitialised value was created by a stack allocation
==166470==    at 0x4FEABFE: nxt_unit_init (nxt_unit.c:436)

==166690== Syscall param sendmsg(msg.msg_iov[0]) points to uninitialised byte(s)
==166690==    at 0x4AE6514: sendmsg (sendmsg.c:28)
==166690==    by 0x42D871: nxt_sendmsg (nxt_socket_msg.c:32)
==166690==    by 0x4FE6695: nxt_unit_sendmsg (nxt_unit.c:6009)
==166690==    by 0x4FE69C8: nxt_unit_port_send (nxt_unit.c:5939)
==166690==    by 0x4FE8C77: nxt_unit_request_done (nxt_unit.c:3309)
==166690==    by 0x4FEE13B: nxt_php_execute (nxt_php_sapi.c:1257)
==166690==    by 0x4FEE2F1: nxt_php_dynamic_request (nxt_php_sapi.c:1128)
==166690==    by 0x4FEE79E: nxt_php_request_handler (nxt_php_sapi.c:1023)
==166690==    by 0x4FE92AD: nxt_unit_process_ready_req (nxt_unit.c:4846)
==166690==    by 0x4FED1B4: nxt_unit_run_once_impl (nxt_unit.c:4605)
==166690==    by 0x4FED3AE: nxt_unit_run (nxt_unit.c:4548)
==166690==    by 0x4FEEC2A: nxt_php_start (nxt_php_sapi.c:514)
==166690==  Address 0x1ffeffea5f is on thread 1's stack
==166690==  in frame #3, created by nxt_unit_port_send (nxt_unit.c:5907)
==166690==  Uninitialised value was created by a stack allocation
==166690==    at 0x4FE8C05: nxt_unit_request_done (nxt_unit.c:3255)
```

These are down to structures being passed around with uninitialised members.

(Note: There are some more similar cases but these commits resolve the above while being obviously correct and good in their own right).

The first commit `Fully initialise nxt_port_msg_t msg structures` resolves the first and last of the above alerts, by fully [empty-initialising](https://en.cppreference.com/w/c/language/initialization#Empty_initialization) the msg structure, this then negates the need to further initialise some members to 0.  

The second commit `Fully initialise the oob struct in nxt_socket_msg_oob_init()` resolves the middle of the above alerts, by fully [empty-initialising](https://en.cppreference.com/w/c/language/initialization#Empty_initialization) the oob structure.

```
The following changes since commit 3b18ffe09370573f81220fda5e924124fcf8f0df:

  tests: Fix TLS tests with Python 3.13 (2025-03-27 23:39:32 +0000)

are available in the Git repository at:

  git@github.com:ac000/unit.git struct-init

for you to fetch changes up to 0c59a033b6fa5c02c98128cef9492264d489a32f:

  Fully initialise the oob struct in nxt_socket_msg_oob_init() (2025-04-09 17:46:14 +0100)

----------------------------------------------------------------
Andrew Clayton (2):
      Fully initialise nxt_port_msg_t msg structures
      Fully initialise the oob struct in nxt_socket_msg_oob_init()

 src/nxt_socket_msg.h |  2 ++
 src/nxt_unit.c       | 12 ++----------
 2 files changed, 4 insertions(+), 10 deletions(-)
```
