### PR TITLE
http: Compress application responses

### DIFF
--- a/src/nxt_http_compression.h
+++ b/src/nxt_http_compression.h
@@ -90,6 +90,8 @@ extern const nxt_http_comp_operations_t  nxt_http_comp_brotli_ops;
 #endif
 
 
+extern nxt_int_t nxt_http_comp_compress_app_response(nxt_task_t *task,
+    nxt_http_request_t *r, nxt_buf_t **b);
 extern nxt_int_t nxt_http_comp_compress_static_response(nxt_task_t *task,
     nxt_file_t **f, nxt_file_info_t *fi, size_t static_buf_len,
     size_t *out_total);

--- a/src/nxt_router.c
+++ b/src/nxt_router.c
@@ -4191,8 +4191,13 @@ nxt_router_response_ready_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg,
 
     if (r->header_sent) {
         nxt_buf_chain_add(&r->out, b);
-        nxt_http_request_send_body(task, r, NULL);
 
+        ret = nxt_http_comp_compress_app_response(task, r, &r->out);
+        if (ret == NXT_ERROR) {
+            goto fail;
+        }
+
+        nxt_http_request_send_body(task, r, NULL);
     } else {
         b_size = nxt_buf_is_mem(b) ? nxt_buf_mem_used_size(&b->mem) : 0;
 
@@ -4270,6 +4275,11 @@ nxt_router_response_ready_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg,
 
         if (b != NULL) {
             nxt_buf_chain_add(&r->out, b);
+        }
+
+        ret = nxt_http_comp_check_compression(task, r);
+        if (ret != NXT_OK) {
+            goto fail;
         }
 
         nxt_http_request_header_send(task, r, nxt_http_request_send_body, NULL);


### PR DESCRIPTION
```
    http: Compress application responses
    
    This adds initial support for compressing application responses.
    
    A couple of things to note
    
    1) Compressed responses are sent 'chunked' as we don't know beforehand
       how large the compressed response will be.
    
    2) We only compress responses where we know the Content-Length as we
       need to check with the 'min_length' config parameter. It's also
       currently how we track when we need to close the compression stream
       off.
    
    Co-authored-by: Alejandro Colomar <alx@kernel.org>
    Signed-off-by: Alejandro Colomar <alx@kernel.org>
    Signed-off-by: Andrew Clayton <a.clayton@nginx.com>
```