### PR TITLE
Fixed `alt_names` at `test_tls_sni_same_alt`

### DIFF
--- a/test/test_tls_sni.py
+++ b/test/test_tls_sni.py
@@ -255,8 +255,8 @@ def test_tls_sni_duplicated_bundle():
 
 def test_tls_sni_same_alt():
     bundles = {
-        "localhost": {"subj": "subj1", "alt_names": "same.altname.com"},
-        "example": {"subj": "subj2", "alt_names": "same.altname.com"},
+        "localhost": {"subj": "subj1", "alt_names": ["same.altname.com"]},
+        "example": {"subj": "subj2", "alt_names": ["same.altname.com"]},
     }
     ctx = config_bundles(bundles)
     add_tls(["localhost", "example"])


### PR DESCRIPTION
### Proposed changes

`alt_names` should be an array of strings, and when it is a string it ends with `openssl.conf` which contains:
```
[alt_names]
DNS.1 = s
DNS.2 = a
DNS.3 = m
DNS.4 = e
DNS.5 = .
DNS.6 = a
DNS.7 = l
DNS.8 = t
DNS.9 = n
DNS.10 = a
DNS.11 = m
DNS.12 = e
DNS.13 = .
DNS.14 = c
DNS.15 = o
DNS.16 = m
```
what may work or fail, which depends on OpenSSL library because `.` can be trated as empty string.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [ ] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md).
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes.
- [ ] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)).
