### PR TITLE
Treat a “broken pipe” on SSL_shutdown() as a normal close

### DIFF
--- a/src/nxt_openssl.c
+++ b/src/nxt_openssl.c
@@ -1586,7 +1586,8 @@ nxt_openssl_conn_test_error(nxt_task_t *task, nxt_conn_t *c, int ret,
 
         nxt_debug(task, "ERR_peek_error(): %l", lib_err);
 
-        if (sys_err != 0 || lib_err != 0) {
+        /* Treat a broken pipe on shutdown as a normal close */
+        if (sys_err != NXT_EPIPE && (sys_err != 0 || lib_err != 0)) {
             c->socket.error = sys_err;
             return NXT_ERROR;
         }


### PR DESCRIPTION
Fixes #1600

### Proposed changes

The `test_tls_certificate_change` test likely uses Python's `ssl.get_server_certificate` function to retrieve the server's TLS certificate before and after changing it. This function establishes an SSL connection, retrieves the certificate, and then closes the connection without performing a proper SSL shutdown (i.e., sending a `close_notify` alert). On the server side, when `SSL_shutdown` is called during cleanup, it attempts to send its own `close_notify` alert but fails because the client has already closed the socket, resulting in the "Broken pipe" error (`EPIPE`). These errors are logged as alerts, and since they aren't skipped, the test fails during teardown when `Log.check_alerts asserts` that no unskipped alerts remain.


### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [ ] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md).
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes.
- [ ] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)).
