### PR TITLE
auto/modules/wasm: Remove an unneeded compiler option

### DIFF
--- a/auto/modules/wasm
+++ b/auto/modules/wasm
@@ -63,8 +63,8 @@ NXT_WASM_LDFLAGS=
 if [ "$NXT_WASM_RUNTIME" = "wasmtime" ]; then
     NXT_WASM_LDFLAGS=-lwasmtime
 fi
-NXT_WASM_ADDITIONAL_FLAGS="-Wno-missing-field-initializers \
- -DNXT_HAVE_WASM_$(echo ${NXT_WASM_RUNTIME} | tr 'a-z' 'A-Z') \
+NXT_WASM_ADDITIONAL_FLAGS=" \
+-DNXT_HAVE_WASM_$(echo ${NXT_WASM_RUNTIME} | tr 'a-z' 'A-Z') \
 "
 
 # Set the RPATH/RUNPATH.


### PR DESCRIPTION
```
    auto/modules/wasm: Remove an unneeded compiler option
    
    -Wno-missing-field-initializers was needed for GCC 4.8 / RHEL 7 etc to
    avoid warnings with {} empty initialisers.
    
    We haven't needed to support that compiler for sometime.
    
    Signed-off-by: Andrew Clayton <a.clayton@nginx.com>
```