### PR TITLE
ci: Build Unit with --zlib --zstd --brotli

### DIFF
--- a/.github/workflows/ci-dev-distro-compiler.yaml
+++ b/.github/workflows/ci-dev-distro-compiler.yaml
@@ -37,6 +37,7 @@ jobs:
           dnf -y update
           dnf -y install --setopt=install_weak_deps=False \
               which wget git gcc make pcre2-devel openssl-devel \
+              zlib-ng-compat-devel libzstd-devel brotli-devel \
               python-unversioned-command python3 python3-devel \
               php-devel php-embedded perl-devel perl-ExtUtils-Embed \
               ruby-devel java-devel nodejs-devel nodejs-npm golang \
@@ -51,9 +52,9 @@ jobs:
       - name: configure unit CC=${{ matrix.compiler }}
         run: |
           if [ "${{ matrix.compiler }}" = "clang" ]; then
-            ./configure --openssl --otel --cc=clang
+            ./configure --openssl --otel --zlib --zstd --brotli --cc=clang
           else
-            ./configure --openssl --otel
+            ./configure --openssl --otel --zlib --zstd --brotli
           fi
 
       - name: make unit
@@ -129,6 +130,7 @@ jobs:
         run: |
           apk update && apk upgrade
           apk add gcc make musl-dev openssl-dev pcre2-dev curl \
+              zlib-dev zstd-dev brotli-dev \
               php83-dev php83-embed python3-dev perl-dev ruby-dev \
               openjdk21-jdk cargo rust
           if [ "${{ matrix.compiler }}" = "clang" ]; then
@@ -140,9 +142,9 @@ jobs:
       - name: configure unit CC=${{ matrix.compiler }}
         run: |
           if [ "${{ matrix.compiler }}" = "clang" ]; then
-            ./configure --openssl --otel --cc=clang
+            ./configure --openssl --otel --zlib --zstd --brotli --cc=clang
           else
-            ./configure --openssl --otel
+            ./configure --openssl --otel --zlib --zstd --brotli
           fi
 
       - name: make unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,9 @@ jobs:
             sudo kill -9 $PID
           fi
 
+      - name: Install packages
+        run: sudo apt-get -y install libbrotli-dev
+
       ##
       ## njs
       ##
@@ -139,6 +142,9 @@ jobs:
             --tests \
             --openssl \
             --njs \
+            --zlib \
+            --zstd \
+            --brotli \
             --cc-opt="-I njs/src/ -I njs/build"  \
             --ld-opt="-L njs/build"
 


### PR DESCRIPTION
    ci: Build Unit with --zlib --zstd --brotli
    
    This just does a build test of building Unit with support for zlib
    (deflate & gzip), zstd and brotli HTTP compression.
    
    Signed-off-by: Andrew Clayton <a.clayton@nginx.com>