### PR TITLE
ci: clang-ast: Update to openjdk-21-jdk

### DIFF
--- a/.github/workflows/clang-ast.yaml
+++ b/.github/workflows/clang-ast.yaml
@@ -32,7 +32,7 @@ jobs:
           apt-get -y install git wget curl llvm-dev libclang-dev clang make \
                              libssl-dev libpcre2-dev libperl-dev \
                              libphp-embed php-dev python3-dev libpython3-dev \
-                             ruby-dev openjdk-17-jdk npm
+                             ruby-dev openjdk-21-jdk npm
           npm install -g node-gyp
 
       - uses: actions/checkout@v4


### PR DESCRIPTION
    ci: clang-ast: Update to openjdk-21-jdk
    
    Seems OpenJDK 17 is no longer available in Debian testing.
    
    Signed-off-by: Andrew Clayton <a.clayton@nginx.com>

