### PR TITLE
Set SERVER_PORT appropriately

### DIFF
--- a/src/nxt_php_sapi.c
+++ b/src/nxt_php_sapi.c
@@ -1500,7 +1500,8 @@ nxt_php_register_variables(zval *track_vars_array TSRMLS_DC)
 
     nxt_php_set_sptr(req, "SERVER_NAME", &r->server_name, r->server_name_length,
                      track_vars_array TSRMLS_CC);
-    nxt_php_set_cstr(req, "SERVER_PORT", "80", 2, track_vars_array TSRMLS_CC);
+    nxt_php_set_sptr(req, "SERVER_PORT", &r->local_port, r->local_port_length,
+                     track_vars_array TSRMLS_CC);
 
     if (r->tls) {
         nxt_php_set_cstr(req, "HTTPS", "on", 2, track_vars_array TSRMLS_CC);

--- a/src/perl/nxt_perl_psgi.c
+++ b/src/perl/nxt_perl_psgi.c
@@ -673,7 +673,8 @@ nxt_perl_psgi_env_create(PerlInterpreter *my_perl,
 
     RC(nxt_perl_psgi_add_sptr(my_perl, hash_env, NL("SERVER_NAME"),
                               &r->server_name, r->server_name_length));
-    RC(nxt_perl_psgi_add_str(my_perl, hash_env, NL("SERVER_PORT"), "80", 2));
+    RC(nxt_perl_psgi_add_sptr(my_perl, hash_env, NL("SERVER_PORT"),
+                              &r->local_port, r->local_port_length));
 
     for (i = 0; i < r->fields_count; i++) {
         f = r->fields + i;

--- a/src/python/nxt_python_wsgi.c
+++ b/src/python/nxt_python_wsgi.c
@@ -131,7 +131,6 @@ static PyTypeObject nxt_py_input_type = {
 
 static PyObject  *nxt_py_environ_ptyp;
 
-static PyObject  *nxt_py_80_str;
 static PyObject  *nxt_py_close_str;
 static PyObject  *nxt_py_content_length_str;
 static PyObject  *nxt_py_content_type_str;
@@ -151,7 +150,6 @@ static PyObject  *nxt_py_wsgi_input_str;
 static PyObject  *nxt_py_wsgi_uri_scheme_str;
 
 static nxt_python_string_t nxt_python_strings[] = {
-    { nxt_string("80"), &nxt_py_80_str },
     { nxt_string("close"), &nxt_py_close_str },
     { nxt_string("CONTENT_LENGTH"), &nxt_py_content_length_str },
     { nxt_string("CONTENT_TYPE"), &nxt_py_content_type_str },
@@ -638,6 +636,8 @@ nxt_python_get_environ(nxt_python_ctx_t *pctx,
                            r->remote_length));
     RC(nxt_python_add_sptr(pctx, nxt_py_server_addr_str, &r->local_addr,
                            r->local_addr_length));
+    RC(nxt_python_add_sptr(pctx, nxt_py_server_port_str, &r->local_port,
+                           r->local_port_length));
 
     if (r->tls) {
         RC(nxt_python_add_obj(pctx, nxt_py_wsgi_uri_scheme_str,
@@ -652,7 +652,6 @@ nxt_python_get_environ(nxt_python_ctx_t *pctx,
 
     RC(nxt_python_add_sptr(pctx, nxt_py_server_name_str, &r->server_name,
                            r->server_name_length));
-    RC(nxt_python_add_obj(pctx, nxt_py_server_port_str, nxt_py_80_str));
 
     nxt_unit_request_group_dup_fields(pctx->req);
 

--- a/src/ruby/nxt_ruby.c
+++ b/src/ruby/nxt_ruby.c
@@ -106,7 +106,6 @@ typedef struct {
     VALUE      *v;
 } nxt_ruby_string_t;
 
-static VALUE  nxt_rb_80_str;
 static VALUE  nxt_rb_content_length_str;
 static VALUE  nxt_rb_content_type_str;
 static VALUE  nxt_rb_http_str;
@@ -127,7 +126,6 @@ static VALUE  nxt_rb_on_thread_boot;
 static VALUE  nxt_rb_on_thread_shutdown;
 
 static nxt_ruby_string_t nxt_rb_strings[] = {
-    { nxt_string("80"), &nxt_rb_80_str },
     { nxt_string("CONTENT_LENGTH"), &nxt_rb_content_length_str },
     { nxt_string("CONTENT_TYPE"), &nxt_rb_content_type_str },
     { nxt_string("http"), &nxt_rb_http_str },
@@ -754,10 +752,10 @@ nxt_ruby_read_request(nxt_unit_request_info_t *req, VALUE hash_env)
                       r->remote_length);
     nxt_ruby_add_sptr(hash_env, nxt_rb_server_addr_str, &r->local_addr,
                       r->local_addr_length);
+    nxt_ruby_add_sptr(hash_env, nxt_rb_server_port_str, &r->local_port,
+                      r->local_port_length);
     nxt_ruby_add_sptr(hash_env, nxt_rb_server_name_str, &r->server_name,
                       r->server_name_length);
-
-    rb_hash_aset(hash_env, nxt_rb_server_port_str, nxt_rb_80_str);
 
     rb_hash_aset(hash_env, nxt_rb_rack_url_scheme_str,
                  r->tls ? nxt_rb_https_str : nxt_rb_http_str);


### PR DESCRIPTION
```
The Perl, PHP, Python and Ruby language modules all hard code
SERVER_PORT to "80".

Adjust them to bring them in line with the wasm language module which
uses r->local_port (I.e. the port unit accepted the connection on).

Closes: https://github.com/nginx/unit/issues/761
Signed-off-by: Andrew Clayton <a.clayton@nginx.com>
```