### PR TITLE
A couple of HTTP compression fixes

### DIFF
--- a/src/nxt_http_compression.c
+++ b/src/nxt_http_compression.c
@@ -305,6 +305,12 @@ nxt_http_comp_compress_static_response(nxt_task_t *task, nxt_http_request_t *r,
 
         cbytes = nxt_http_comp_compress(out + *out_total, out_size - *out_total,
                                         in + in_size - rest, n, last);
+        if (cbytes == -1) {
+            nxt_file_close(task, &tfile);
+            nxt_mem_munmap(in, in_size);
+            nxt_mem_munmap(out, out_size);
+            return NXT_ERROR;
+        }
 
         *out_total += cbytes;
         rest -= n;

--- a/src/nxt_http_compression.h
+++ b/src/nxt_http_compression.h
@@ -93,8 +93,8 @@ extern const nxt_http_comp_operations_t  nxt_http_comp_brotli_ops;
 extern nxt_int_t nxt_http_comp_compress_app_response(nxt_task_t *task,
     nxt_http_request_t *r, nxt_buf_t **b);
 extern nxt_int_t nxt_http_comp_compress_static_response(nxt_task_t *task,
-    nxt_file_t **f, nxt_file_info_t *fi, size_t static_buf_len,
-    size_t *out_total);
+    nxt_http_request_t *r, nxt_file_t **f, nxt_file_info_t *fi,
+    size_t static_buf_len, size_t *out_total);
 extern bool nxt_http_comp_wants_compression(void);
 extern bool nxt_http_comp_compressor_is_valid(const nxt_str_t *token);
 extern nxt_int_t nxt_http_comp_check_compression(nxt_task_t *task,

--- a/src/nxt_http_static.c
+++ b/src/nxt_http_static.c
@@ -593,7 +593,7 @@ nxt_http_static_send(nxt_task_t *task, nxt_http_request_t *r,
                 nxt_int_t  ret;
 
                 ret = nxt_http_comp_compress_static_response(
-                                                    task, &f, &fi,
+                                                    task, r, &f, &fi,
                                                     NXT_HTTP_STATIC_BUF_SIZE,
                                                     &out_total);
                 if (ret == NXT_ERROR) {


### PR DESCRIPTION
```
This pull-request comprises two commits

1) http: compression: Set the temporary file name in n_h_c_c_s_r()

The sets the temporary compressed file name in the nxt_file_t structure.

While we don't actually need it ourselves, it's used in the case that
nxt_file_close() fails.

2) http: compression: Add a missed nxt_http_comp_compress() return check

This adds a missing check for compression errors when compressing static
responses.

----------------------------------------------------------------
Andrew Clayton (2):
      http: compression: Set the temporary file name in n_h_c_c_s_r()
      http: compression: Add a missed nxt_http_comp_compress() return check

 src/nxt_http_compression.c | 26 ++++++++++++++++----------
 src/nxt_http_compression.h |  4 ++--
 src/nxt_http_static.c      |  2 +-
 3 files changed, 19 insertions(+), 13 deletions(-)
```
