### PR TITLE
Don't leak file descriptor in nxt_main_port_access_log_handler()

### DIFF
--- a/src/nxt_main_process.c
+++ b/src/nxt_main_process.c
@@ -1730,5 +1730,8 @@ nxt_main_port_access_log_handler(nxt_task_t *task, nxt_port_recv_msg_t *msg)
     if (nxt_fast_path(port != NULL)) {
         (void) nxt_port_socket_write(task, port, type, file.fd,
                                      msg->port_msg.stream, 0, NULL);
+
+    } else {
+        nxt_file_close(task, &file);
     }
 }


### PR DESCRIPTION

```
Don't leak file descriptor in nxt_main_port_access_log_handler()

After opening a file and setting file.fd we _may_ call
nxt_port_socket_write(). If so then the file is eventually closed via
something like

  nxt_port_socket_write()
    nxt_port_socket_write2()
      nxt_port_write_handler()
        nxt_port_msg_close_fd()
          nxt_port_close_fds()

Alternatively we may just return from the function and never close(2)
file.fd.

In which case we should call nxt_file_close().

This was reported by coverity.

Signed-off-by: Andrew Clayton <a.clayton@nginx.com>
```
