### PR TITLE
rust, wasm-wc, otel: Update the slab crate

### DIFF
--- a/src/otel/Cargo.lock
+++ b/src/otel/Cargo.lock
@@ -1760,9 +1760,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"

--- a/src/wasm-wasi-component/Cargo.lock
+++ b/src/wasm-wasi-component/Cargo.lock
@@ -1441,9 +1441,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"


### PR DESCRIPTION

```
rust, wasm-wc, otel: Update the slab crate                              

This updates the slab crate to 0.4.11. This is the same as commit
d413a255 ("tools/unitctl: Bump the slab crate from 0.4.10 to 0.4.11")
which updated the slab crate in unitctl.

That was done by dependabot. It turns out this update is also needed for
OTEL and wasm-wasi-component.

Unfortunately it seems dependabot is b0rked and hasn't created
pull-requests to update those.

Signed-off-by: Andrew Clayton <a.clayton@nginx.com>
```
