### PR TITLE
Fix building with PHP 8.5

### DIFF
--- a/src/nxt_php_sapi.c
+++ b/src/nxt_php_sapi.c
@@ -93,8 +93,10 @@ static nxt_int_t nxt_php_alter_option(nxt_str_t *name, nxt_str_t *value,
 #ifdef NXT_PHP8
 static void nxt_php_disable_functions(nxt_str_t *str);
 #endif
+#if (PHP_VERSION_ID < 80500)
 static void nxt_php_disable(nxt_task_t *task, const char *type,
     nxt_str_t *value, char **ptr, nxt_php_disable_t disable);
+#endif
 
 static nxt_int_t nxt_php_dirname(const nxt_str_t *file, nxt_str_t *dir);
 static void nxt_php_str_trim_trail(nxt_str_t *str, u_char t);
@@ -710,9 +712,11 @@ nxt_php_set_options(nxt_task_t *task, nxt_conf_value_t *options, int type)
             }
 
             if (nxt_str_eq(&name, "disable_classes", 15)) {
+#if (PHP_VERSION_ID < 80500)
                 nxt_php_disable(task, "class", &value,
                                 &PG(disable_classes),
                                 zend_disable_class);
+#endif
                 continue;
             }
         }
@@ -817,6 +821,7 @@ nxt_php_disable_functions(nxt_str_t *str)
 #endif
 
 
+#if (PHP_VERSION_ID < 80500)
 static void
 nxt_php_disable(nxt_task_t *task, const char *type, nxt_str_t *value,
     char **ptr, nxt_php_disable_t disable)
@@ -867,6 +872,7 @@ nxt_php_disable(nxt_task_t *task, const char *type, nxt_str_t *value,
 
     } while (c != '\0');
 }
+#endif
 
 
 static nxt_int_t


### PR DESCRIPTION
### Proposed changes

The `diable_classes` is deprecated since PHP 8.5, see https://github.com/php/php-src/commit/f4e2e91d4b6d28448104500819b68edf58bd263c

Making this build conditional also require to change tests

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)).
