### PR TITLE
Fix build with PHP 8.5.0 Beta2

### DIFF
--- a/src/nxt_php_sapi.c
+++ b/src/nxt_php_sapi.c
@@ -93,8 +93,10 @@ static nxt_int_t nxt_php_alter_option(nxt_str_t *name, nxt_str_t *value,
 #ifdef NXT_PHP8
 static void nxt_php_disable_functions(nxt_str_t *str);
 #endif
+#if (PHP_VERSION_ID < 80500)
 static void nxt_php_disable(nxt_task_t *task, const char *type,
     nxt_str_t *value, char **ptr, nxt_php_disable_t disable);
+#endif
 
 static nxt_int_t nxt_php_dirname(const nxt_str_t *file, nxt_str_t *dir);
 static void nxt_php_str_trim_trail(nxt_str_t *str, u_char t);
@@ -710,9 +712,11 @@ nxt_php_set_options(nxt_task_t *task, nxt_conf_value_t *options, int type)
             }
 
             if (nxt_str_eq(&name, "disable_classes", 15)) {
+#if (PHP_VERSION_ID < 80500)
                 nxt_php_disable(task, "class", &value,
                                 &PG(disable_classes),
                                 zend_disable_class);
+#endif
                 continue;
             }
         }
@@ -817,6 +821,8 @@ nxt_php_disable_functions(nxt_str_t *str)
 #endif
 
 
+#if (PHP_VERSION_ID < 80500)
+
 static void
 nxt_php_disable(nxt_task_t *task, const char *type, nxt_str_t *value,
     char **ptr, nxt_php_disable_t disable)
@@ -867,6 +873,8 @@ nxt_php_disable(nxt_task_t *task, const char *type, nxt_str_t *value,
 
     } while (c != '\0');
 }
+
+#endif
 
 
 static nxt_int_t


### PR DESCRIPTION
References:
- https://wiki.php.net/rfc/remove_disable_classes
- https://github.com/php/php-src/pull/12043

  CC     build/src/nxt_php_sapi-php85.o
cc -c -pipe -fPIC -fvisibility=hidden -fno-strict-overflow -funsigned-char -std=gnu11 -O -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -fno-strict-aliasing -Wstrict-overflow=5 -Wmissing-prototypes -Werror -g  -O2 -pipe  -fstack-protector-strong -fno-strict-aliasing    -I src -I build/include \
-I/usr/local/include/php -I/usr/local/include/php/main -I/usr/local/include/php/TSRM -I/usr/local/include/php/Zend -I/usr/local/include/php/ext -I/usr/local/include/php/ext/date/lib -DNXT_ZEND_SIGNAL_STARTUP=1 \
-MMD -MF build/src/nxt_php_sapi-php85.dep -MT build/src/nxt_php_sapi-php85.o \
-o build/src/nxt_php_sapi-php85.o src/nxt_php_sapi.c
src/nxt_php_sapi.c:714:37: error: no member named 'disable_classes' in 'struct _php_core_globals'
  714 |                                 &PG(disable_classes),
      |                                  ~~~^~~~~~~~~~~~~~~~
/usr/local/include/php/main/php_globals.h:31:30: note: expanded from macro 'PG'
   31 | # define PG(v) (core_globals.v)
      |                 ~~~~~~~~~~~~ ^
src/nxt_php_sapi.c:715:33: error: use of undeclared identifier 'zend_disable_class'
  715 |                                 zend_disable_class);
      |                                 ^
2 errors generated.
gmake[1]: *** [build/Makefile:2107: build/src/nxt_php_sapi-php85.o] Error 1

### Proposed changes

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in this PR's description or commit message.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [ ] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes.
- [ ] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)).
