### PR TITLE
do not exclude unit-openapi.yaml from releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@
 pkg/**	export-ignore
 docs/*.*	export-ignore
 docs/Makefile	export-ignore
+docs/unit-openapi.yaml	-export-ignore


### PR DESCRIPTION
### Proposed changes

The file is expluded from release tarbal so to build `unitctl` this file should be fetched additionally to sources

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)).
